### PR TITLE
fix: Update versants.com to parse figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mercury Parser Changelog
 
+### 2.3.0
+
+- [a45b329e0a] - fix: Update versants.com to parse figures (Josiah Campbell) [#42](https://github.com/jocmp/mercury-parser/pull/42)
+
 ### v2.2.10 (Jan 11, 2025)
 
 - [b8b4df7037] - feat: Add custom parser for mobilesyrup.com (Josiah Campbell) [#39](https://github.com/jocmp/mercury-parser/pull/39)

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ Note that the URL argument is still supplied, in order to identify the web site 
 
 Mercury Parser also ships with a CLI, meaning you can use it from your command line like so:
 
-![Mercury Parser CLI Basic Usage](./assets/parser-basic-usage.gif)
-
 ```bash
 # Install Mercury Parser globally
 yarn global add @jocmp/mercury-parser

--- a/src/extractors/custom/www.versants.com/index.js
+++ b/src/extractors/custom/www.versants.com/index.js
@@ -17,7 +17,20 @@ export const WwwVersantsComExtractor = {
   },
 
   content: {
-    selectors: ['.entry-content'],
-    clean: ['.adv-link', '.versa-target'],
+    transforms: {
+      '.featured-image': $node => {
+        $node.addClass('mercury-parser-keep');
+        const figcaption = $node.find('span');
+        $node.find('figure').append(figcaption);
+      },
+    },
+    selectors: ['.article-content'],
+    clean: [
+      '.adv-link',
+      '.versa-target',
+      'header', // Clean title
+      '.author', // Clean author
+      '.thumbnail-slider', // Remove, the main images will be within the .main-slider div.
+    ],
   },
 };

--- a/src/extractors/custom/www.versants.com/index.test.js
+++ b/src/extractors/custom/www.versants.com/index.test.js
@@ -70,7 +70,7 @@ describe('WwwVersantsComExtractor', () => {
 
       assert.equal(
         first13,
-        'La 32e campagne d’Opération Nez rouge de la Vallée-du-Richelieu sera en vigueur durant'
+        "C'est à Sainte-Julie que les bénévoles de l'ONR VDR se retrouveront dès le"
       );
     });
   });

--- a/src/utils/dom/clean-tags.js
+++ b/src/utils/dom/clean-tags.js
@@ -105,7 +105,7 @@ export default function cleanTags($article, $) {
     if (weight < 0) {
       $node.remove();
     } else {
-      // deteremine if node seems like content
+      // determine if node seems like content
       removeUnlessContent($node, $, weight);
     }
   });


### PR DESCRIPTION
- Strip image carousels of thumbnail images
- Keep first figure and append its caption

Ref

- https://github.com/jocmp/capyreader/issues/723