### PR TITLE
fix: Retain h2 for channelnewsasia.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mercury Parser Changelog
 
+### 2.3.3 (Jan 31, 2025)
+
+- [d5cd516d52] - fix: Retain h2 for channelnewsasia.com (Josiah Campbell) [#47](https://github.com/jocmp/mercury-parser/pull/47)
+
 ### 2.3.2 (Jan 27, 2025)
 
 - [684eab9194] - fix: Don't follow class names for androidauthority (Josiah Campbell) [#46](https://github.com/jocmp/mercury-parser/pull/46)

--- a/src/extractors/custom/www.channelnewsasia.com/index.js
+++ b/src/extractors/custom/www.channelnewsasia.com/index.js
@@ -29,7 +29,9 @@ export const WwwChannelnewsasiaComExtractor = {
   content: {
     selectors: ['section[data-title="Content"]'],
 
-    transforms: {},
+    transforms: {
+      h2: node => node.attr('class', 'mercury-parser-keep'),
+    },
 
     clean: [],
   },


### PR DESCRIPTION
- https://github.com/jocmp/capyreader/issues/790