### PR TITLE
feat: Add frandroid.com custom parser

### DIFF
--- a/fixtures/www.frandroid.com/1777688498862.html
+++ b/fixtures/www.frandroid.com/1777688498862.html
@@ -1,0 +1,3189 @@
+<!DOCTYPE html><html lang="fr-FR"><head>
+    <link rel="preload" as="script" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js">
+    <link rel="dns-prefetch" href="https://scripts.opti-digital.com/">
+    <link rel="dns-prefetch" href="https://c0.lestechnophiles.com/">
+    <link rel="dns-prefetch" href="https://c1.lestechnophiles.com/">
+    <link rel="dns-prefetch" href="https://c2.lestechnophiles.com/">
+    <link rel="dns-prefetch" href="https://ddm.frandroid.com/">
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com/">
+
+    <link rel="manifest" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/pwa-manifest.json">
+
+    <meta charset="UTF-8">
+    <meta name="viewport" id="viewport" value="width=device-width, initial-scale=1, user-scalable=yes">
+
+    
+    <link rel="pingback" href="https://www.frandroid.com/wp/xmlrpc.php">
+
+    <meta name="apple-mobile-web-app-title" value="Frandroid">
+    <meta name="apple-mobile-web-app-capable" value="yes">
+
+            
+        
+        <link rel="preload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/fonts/frandroid/fonts/Frandroid_Font_2022-vBhkOLpzMpKchbC4dhlWs.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/fonts/montserrat-latin-wght-normal-vl_AIctKyqW00j2QsJjqU.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<meta name="robots" value="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+<meta http-equiv="X-UA-Compatible" value="IE=Edge">        
+        
+
+        <meta name="nli:image" value="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=1200,675&amp;key=de7094a4">
+<meta name="nli:tw" value="Fini les vélos cargos encombrants : on a testé l’alternative compacte à petit prix d’Intersport">
+<meta name="nli:fb" value="Fini les vélos cargos encombrants : on a testé l’alternative compacte à petit prix d’Intersport">        
+    
+
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/wordpress-dom-ready-va-j_DcZ-xxc3hbE_tB8c.js" id="theme-_wordpress-dom-ready-va-j_DcZ-xxc3hbE_tB8c-ab8a1fb35d4cc604-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/preload-helper-vUZRgTS1nDr6ZVhi1Lsec.js" id="theme-_preload-helper-vUZRgTS1nDr6ZVhi1Lsec-b7b64faababd60c5-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/humanoidfr-scripts-vChGlDGfYXqg_0OG1R6N5.js" id="theme-index-e231c981faba040d-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/humanoidfr-scripts2-vBN19ewMCu5iXs-lLY9KC.js" id="theme-_humanoidfr-scripts2-vBN19ewMCu5iXs-lLY9KC-d108defa9e526106-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/dompurify-v43caLOFFPwcA74AdPCKm.js" id="theme-_dompurify-v43caLOFFPwcA74AdPCKm-3bb029373a1c90f0-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/Frandroid-vBEwwzNaRDFG9Lxkt3Puy.js" id="theme-_Frandroid-vBEwwzNaRDFG9Lxkt3Puy-18d0465231e7a882-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/DomCreator-vDyTugzkSKrmql4YgSvGC.js" id="theme-_DomCreator-vDyTugzkSKrmql4YgSvGC-16efc5b14057992c-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/Ajax-v3nfmCkbaFPmfkyKG-JGd.js" id="theme-_Ajax-v3nfmCkbaFPmfkyKG-JGd-321023915e32342b-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/_commonjsHelpers-vDWwsNxpa_Hr3BskUF5qe.js" id="theme-__commonjsHelpers-vDWwsNxpa_Hr3BskUF5qe-9d3617ad68e4d5c5-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/javascripts/chunks/IndexMenu-vB5ZmyKqAeSla1znsTTHy.js" id="theme-_IndexMenu-vB5ZmyKqAeSla1znsTTHy-407b28e0a652a1b3-modulepreload">
+
+	<title>Test Intersport Nakamura Crosscity Plus : notre avis complet - Vélos électriques - Frandroid</title>
+	<meta name="description" value="Vélo cargo électrique compact et relativement léger, le Nakamura Crosscity+ n’a certes pas les capacités d’un longtail mais propose un bon équipement et un moteur central performant.">
+	<link rel="canonical" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique">
+	<meta value="fr_FR" name="og:locale">
+	<meta value="article" name="og:type">
+	<meta value="La nouvelle pépite d’Intersport : on a roulé avec ce vélo cargo compact à moins de 2200 €" name="og:title">
+	<meta value="Vélo cargo électrique compact et relativement léger, le Nakamura Crosscity+ n’a certes pas les capacités d’un longtail mais propose un bon équipement et un moteur central performant." name="og:description">
+	<meta value="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" name="og:url">
+	<meta value="Frandroid" name="og:site_name">
+	<meta value="https://www.facebook.com/frandroidcom/" name="article:publisher">
+	<meta value="2026-05-01T16:02:11+00:00" name="article:published_time">
+	<meta value="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg?resize=1600,900&amp;key=393ce73a&amp;watermark" name="og:image">
+	<meta value="1600" name="og:image:width">
+	<meta value="900" name="og:image:height">
+	<meta value="image/jpeg" name="og:image:type">
+	<meta name="author" value="Matthieu Lauraux">
+	<meta name="twitter:card" value="summary_large_image">
+	<meta name="twitter:creator" value="@Frandroid">
+	<meta name="twitter:site" value="@Frandroid">
+	<meta name="twitter:label1" value="Written by">
+	<meta name="twitter:data1" value="Matthieu Lauraux">
+	<meta name="twitter:label2" value="Est. reading time">
+	<meta name="twitter:data2" value="13 minutes">
+	
+
+
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/js/chunks/react-Czz5EkeT.js" id="optimus-_react-Czz5EkeT-50446e30faa6793d-modulepreload">
+<link rel="modulepreload" href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/js/chunks/bookmarkStore-C83viUJI.js" id="optimus-_bookmarkStore-C83viUJI-32bf27d7208adb5c-modulepreload">
+<link rel="alternate" type="application/rss+xml" title="Frandroid » Flux" href="https://www.frandroid.com/feed">
+
+        <meta name="parsely-title" value="Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?">
+        <meta name="parsely-link" value="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique">
+        <meta name="parsely-type" value="post">
+
+        
+            <meta name="parsely-image-url" value="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg">
+            <meta name="parsely-pub-date" value="2026-05-01T18:01:00Z">
+            <meta name="parsely-section" value="marques">
+                                        <meta name="parsely-author" value="Matthieu Lauraux">
+                                        <meta name="parsely-tags" value="marques,nakamura,survoltes,test,velo-electrique,intersport-nakamura-crosscity-plus,nakamura-crosscity,velo-cargo,be_velo-electrique,ct_article-test,at_froid,pt_post">
+            <meta name="parsely-post-id" value="3084049">
+
+            
+
+
+<link rel="stylesheet" id="theme-optimus-3797e1265a333c4b-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/optimus-v4Lu-mGXtdFvsGQS9zvi0.css" type="text/css" media="all">
+<link rel="stylesheet" id="theme-theme-f2c059d23cf72cef-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/theme-vDdw370R3zAW8ihPOztW5.css" type="text/css" media="all">
+<link rel="stylesheet" id="theme-frandroid-f2c198bfeee25b2d-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/frandroid-vDWsLTggYmdJSdP0usVdY.css" type="text/css" media="all">
+<link rel="stylesheet" id="theme-single-1c3926fe15bb08f6-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/single-vDETxrHSgKba4qRTrYtbo.css" type="text/css" media="all">
+<link rel="stylesheet" id="theme-survoltes-4f4344b20416d617-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/survoltes-vDKExfDFVZOI3YaXbDxzf.css" type="text/css" media="all">
+<link rel="stylesheet" id="theme-tiled-gallery-ffd3051aee509b66-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/tiled-gallery-vCuJw4n3uhKMRCkCroVak.css" type="text/css" media="all">
+<link rel="stylesheet" id="optimus-optimus-react-vo-ghjth-css" href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/css/optimus-react-vo-ghjth.css" type="text/css" media="all">
+
+
+
+        
+    
+
+        
+        
+        
+        
+                
+        
+        
+        
+        <link rel="icon" href="https://images.frandroid.com/wp-content/uploads/2019/12/cropped-flarge-32x32.png" sizes="32x32">
+<link rel="icon" href="https://images.frandroid.com/wp-content/uploads/2019/12/cropped-flarge-192x192.png" sizes="192x192">
+<link rel="apple-touch-icon" href="https://images.frandroid.com/wp-content/uploads/2019/12/cropped-flarge-180x180.png">
+<meta name="msapplication-TileImage" value="https://images.frandroid.com/wp-content/uploads/2019/12/cropped-flarge-270x270.png">
+
+                    <meta name="author" value="Matthieu Lauraux">
+    
+    <link rel="apple-touch-icon" sizes="180x180" href="https://images.frandroid.com/wp-content/uploads/2019/12/cropped-flarge-180x180.png" media="(prefers-color-scheme: dark)">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://images.frandroid.com/wp-content/uploads/2019/12/cropped-flarge-180x180.png" media="(prefers-color-scheme: light)">
+    
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2048-2732.jpg" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2732-2048.jpg" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1668-2388.jpg" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2388-1668.jpg" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1536-2048.jpg" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2048-1536.jpg" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1488-2266.jpg" media="(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2266-1488.jpg" media="(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1640-2360.jpg" media="(device-width: 820px) and (device-height: 1180px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2360-1640.jpg" media="(device-width: 820px) and (device-height: 1180px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1668-2224.jpg" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2224-1668.jpg" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1620-2160.jpg" media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2160-1620.jpg" media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1320-2868.jpg" media="(device-width: 440px) and (device-height: 956px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2868-1320.jpg" media="(device-width: 440px) and (device-height: 956px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1206-2622.jpg" media="(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2622-1206.jpg" media="(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1290-2796.jpg" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2796-1290.jpg" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1179-2556.jpg" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2556-1179.jpg" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1284-2778.jpg" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2778-1284.jpg" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1170-2532.jpg" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2532-1170.jpg" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1125-2436.jpg" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2436-1125.jpg" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1242-2688.jpg" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2688-1242.jpg" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-828-1792.jpg" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1792-828.jpg" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1242-2208.jpg" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-2208-1242.jpg" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-750-1334.jpg" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1334-750.jpg" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-640-1136.jpg" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+    <link rel="apple-touch-startup-image" href="https://www.frandroid.com/wp-content/uploads/2024/12/frandroid-apple-splash-1136-640.jpg" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">
+
+    <link rel="mask-icon" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/images/2019-redesign/logos/favicons/safari-pinned-tab.svg" color="#425fff">
+    <link rel="shortcut icon" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/images/2019-redesign/logos/favicons/favicon.svg">
+        <meta name="google-site-verification" value="ZkREix0SHs9VEzH1DgLyOQ84GkG5VbCYAy1AeAV16PU">
+    <meta name="color-scheme" value="light dark">
+    <meta name="theme-color" value="#1e2334">
+    
+</head>
+
+<body class="wp-singular post-template-default single single-post postid-3084049 single-format-standard wp-embed-responsive wp-theme-humanoid-redesign nojs is-survoltes has-survoltes-theme" data-site="frandroid">
+            
+        <div class="Mobile_Sticky_Bottom" style="display:none"></div>        <header id="header" class="header has-bg-body-background-secondary-color">
+    <div class="header__border-gradient"></div>
+    <div class="header__top-bar">
+        <div class="header__container">
+            <div class="columns is-multiline is-vcentered">
+                <div class="column">
+                    <div class="columns is-vcentered is-mobile top-bar__left">
+                        <div class="column is-narrow">
+                            <button class="gtm-menu header__burger-button js-burger-menu-trigger" aria-label="Ouvrir le menu">
+                                <span class="rounded has-bg-secondary"></span>
+                                <span class="rounded has-bg-secondary"></span>
+                                <span class="rounded"></span>
+                                <span class="rounded has-bg-ternary"></span>
+                                <span class="rounded"></span>
+                                <span class="rounded has-bg-primary"></span>
+                                <span class="rounded has-bg-good-deals"></span>
+                                <span class="rounded has-bg-primary"></span>
+                                <span class="rounded has-bg-primary"></span>
+                                <span class="header__burger-label">MENU</span>
+                            </button>
+                        </div>
+                        <div class="column has-text-centered-mobile">
+                            <a href="https://www.frandroid.com/" class="top-bar__title-container">
+                                                                    
+<svg class="top-bar__logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 574 59">
+            <title>Frandroid - La référence tech pour s’informer, comparer et bien acheter</title>
+            <defs>
+        <radialGradient id="frandroid-logo-a" cx="6.6%" cy="50%" r="277.8%" fx="6.6%" fy="50%" gradientTransform="matrix(.299 0 0 1.5208 0 -.3)">
+            <stop offset="0%" stop-color="#272847"></stop>
+            <stop offset="100%" stop-color="#272847"></stop>
+            <stop offset="100%" stop-color="#272847"></stop>
+        </radialGradient>
+        <radialGradient id="frandroid-logo-b" cx="7.5%" cy="50%" r="244.8%" fx="7.5%" fy="50%" gradientTransform="matrix(.42592 .02738 -.03765 3.22537 0 -1.1)">
+            <stop offset="0%" stop-color="#272847"></stop>
+            <stop offset="24.8%" stop-color="#272847"></stop>
+            <stop offset="100%" stop-color="#272847"></stop>
+            <stop offset="100%" stop-color="#272847"></stop>
+        </radialGradient>
+        <radialGradient id="frandroid-logo-c" cx="6.6%" cy="50%" r="128%" fx="6.6%" fy="50%" gradientTransform="matrix(1 0 0 .86281 0 0)">
+            <stop offset="0%" stop-color="#272847"></stop>
+            <stop offset="56.1%" stop-color="#272847"></stop>
+            <stop offset="100%" stop-color="#272847"></stop>
+            <stop offset="100%" stop-color="#272847"></stop>
+        </radialGradient>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <g transform="translate(0 .7)">
+            <rect width="55.1" height="16.5" fill="url(#frandroid-logo-a)" rx="8.2"></rect>
+            <rect width="38.7" height="16.5" y="20.4" fill="url(#frandroid-logo-b)" rx="8.2"></rect>
+            <circle cx="8.2" cy="49" r="8.2" fill="url(#frandroid-logo-c)"></circle>
+        </g>
+        <path fill="#272847" fill-rule="nonzero" d="M93.6 42.7H85V58h-16V.7h25.9c5.1 0 9.6.9 13.3 2.6 3.8 1.7 6.7 4.2 8.8 7.3 2 3.2 3 7 3 11.3 0 4.1-.9 7.7-2.8 10.8-2 3-4.7 5.5-8.2 7.2L121 58h-17.2L93.6 42.7zm8.4-21.6c0-2.6-.8-4.6-2.4-6-1.6-1.4-4-2.1-7.1-2.1H84V29h8.5c3.1 0 5.5-.7 7.1-2a7.5 7.5 0 002.4-6zm70.2 25.7h-23.7L144.1 58H128L152.7.7h15.6L193.1 58h-16.5l-4.4-11zm-5-12.6l-7-18-7 18h14zM258.4.7V58H245l-25-30.5V58h-15.8V.7h13.2l25.1 30.5V.7h15.8zm14.9 0h26.6c6.1 0 11.6 1.2 16.4 3.5a26.2 26.2 0 0115 25.1c0 5.8-1.3 10.8-4 15.1a26.2 26.2 0 01-11 10 36.7 36.7 0 01-16.4 3.5h-26.6V.7zM516 .7h26.6c6.2 0 11.6 1.2 16.4 3.5a26.2 26.2 0 0115 25.1c0 5.8-1.3 10.8-4 15.1a26.2 26.2 0 01-11 10 36.7 36.7 0 01-16.4 3.5H516V.7zM298.6 45c4.8 0 8.7-1.4 11.7-4.3 3-2.8 4.4-6.7 4.4-11.7 0-5-1.5-9-4.4-11.8-3-2.8-6.9-4.2-11.7-4.2h-10.2v32h10.2zm242.7 0c4.8 0 8.8-1.4 11.7-4.3 3-2.8 4.4-6.7 4.4-11.7 0-5-1.4-9-4.4-11.8-3-2.8-6.9-4.2-11.7-4.2H531v32h10.2zM370 42.7h-8.7V58h-16V.7h25.9c5 0 9.5.9 13.3 2.6 3.8 1.7 6.7 4.2 8.8 7.3 2 3.2 3 7 3 11.3 0 4.1-1 7.7-2.8 10.8-2 3-4.7 5.5-8.2 7.2l12.2 18h-17.2l-10.3-15.2zm9.5-21.6c0-2.6-.8-4.6-2.4-6-1.6-1.4-4-2.1-7.1-2.1h-8.5V29h8.5c3.1 0 5.5-.7 7-2a7.5 7.5 0 002.5-6zm60 37.9c-5.9 0-11.2-1.3-16-3.8a28.4 28.4 0 01-15.1-25.7 28.8 28.8 0 0115.2-25.7c4.7-2.5 10-3.8 16-3.8 5.9 0 11.2 1.3 16 3.8a28.4 28.4 0 0115.1 25.7 28.8 28.8 0 01-15.2 25.7c-4.7 2.5-10 3.8-16 3.8zm.1-13.3a14.6 14.6 0 0013.2-8c1.3-2.4 2-5.3 2-8.6 0-3.2-.7-6.1-2-8.6a14.7 14.7 0 00-13.2-8 14.6 14.6 0 00-13.1 8c-1.3 2.5-2 5.4-2 8.6 0 3.3.7 6.2 2 8.7a14.7 14.7 0 0013.1 7.9zM485 .7H501V58h-16.2V.7z"></path>
+    </g>
+</svg>
+                                                                </a>
+                        </div>
+                        <div class="column is-narrow is-flex is-vcentered">
+                            <a class="is-hidden-touch js-main-modal-open mr-3" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#reglages">
+                                <i class="icon icon-settings has-text-primary top-bar__search" aria-label="Thème"></i>
+                            </a>
+                            <a class="js-toggle-search">
+                                <i class="icon icon-search has-text-ternary top-bar__search" aria-label="Recherche"></i>
+                            </a>
+                                                                                            <a class="top-bar__profile-link " href="https://www.frandroid.com/connexion" aria-label="Mon compte">
+                                    <svg class="top-bar__profile-icon" width="20" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path class="top-bar__profile-path" d="M8.93 9.75c2.48 0 4.5-2.01 4.5-4.5s-2.02-4.5-4.5-4.5-4.5 2.01-4.5 4.5 2.01 4.5 4.5 4.5z" stroke="currentColor" stroke-width="1.5" stroke-miterlimit="10"></path>
+                                        <path class="top-bar__profile-path" d="M17.1 18.75s-2.7-4.67-8.14-4.67h-.07c-5.44 0-8.14 4.67-8.14 4.67h16.34z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                                    </svg>
+                                </a>
+                                                    </div>
+                    </div>
+                </div>
+                <div class="column">
+                    <ul class="top-bar__links columns is-mobile is-vcentered is-pulled-right-desktop is-justify-content-space-around">
+                        <li class="column is-narrow has-text-right-desktop">
+                            <a href="https://www.frandroid.com/actualites" class="gtm-verb has-link-border has-text-primary has-text-weight-medium top-bar__link
+                               ">
+                                Actus
+                            </a>
+                        </li>
+                        <li class="column is-narrow has-text-right-desktop">
+                            <a href="https://www.frandroid.com/test" class="gtm-verb has-link-border has-text-tests has-text-weight-medium top-bar__link
+                               ">
+                                Tests</a>
+                        </li>
+                        <li class="column is-narrow has-text-right-desktop">
+                            <a href="https://www.frandroid.com/guide-dachat" class="gtm-verb has-link-border has-text-ternary has-text-weight-medium top-bar__link
+                               ">
+                                Guides
+                            </a>
+                        </li>
+                        <li class="column is-narrow has-text-right-desktop">
+                            <a href="https://www.frandroid.com/bons-plans" class="gtm-verb has-link-border has-text-good-deals has-text-weight-medium top-bar__link
+                               ">
+                                Bons plans
+                            </a>
+                        </li>
+                        <li class="column is-narrow has-text-right-desktop">
+                            <a href="https://www.frandroid.com/comparateur-forfaits" class="gtm-verb has-link-border has-text-secondary has-text-weight-medium top-bar__link
+                               ">
+                                Forfait mobile
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="header__bottom-bar">
+        <div class="is-shadow-left is-hidden-desktop has-text-centered is-centered" id="header-categories-container-left">
+            <div class="category-icon-centered">
+                <i class="icon icon-arrow-left"></i>
+            </div>
+        </div>
+        <div class="is-shadow-right is-hidden-desktop has-text-centered is-centered is-active" id="header-categories-container-right">
+            <div class="category-icon-centered">
+                <i class="icon icon-arrow-right"></i>
+            </div>
+        </div>
+        <div class="header__bottom-bar__inner">
+                                                <a href="https://www.frandroid.com/survoltes">
+                        <div class="survoltes-logo">
+    <div class="bolt">
+        <div class="svg-wrapper ">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 38 48"><path fill="url(#bolt-a)" fill-rule="evenodd" d="M35 27 7 46c-.7.4-1.7.3-2.2-.3-.6-.7-.6-1.7 0-2.3 9.7-9.7 14.5-14.6 14.5-14.8-.1-.2-5.7-.5-16.8-1l17.8-1a1.7 1.7 0 0 1 1.8 2C21.8 30 8.4 42.2 8.9 42.2c.3 0 9-5 26.1-15.3Z" clip-rule="evenodd"></path><path fill="url(#bolt-b)" fill-rule="evenodd" d="m2.5 22.3 28-19c.7-.5 1.7-.4 2.2.3.6.6.6 1.6 0 2.2a304.4 304.4 0 0 0-14.5 14.8c0 .2 5.7.5 16.8 1l-17.8 1a1.7 1.7 0 0 1-1.8-2C15.7 19.3 29.1 7 28.6 7c-.3 0-9 5.1-26.1 15.3Z" clip-rule="evenodd"></path><defs><linearGradient id="bolt-a" x1="6.7" x2="27.5" y1="37.2" y2="33" gradientUnits="userSpaceOnUse"><stop stop-opacity=".9"></stop><stop offset=".5"></stop><stop offset="1" stop-opacity="0"></stop></linearGradient><linearGradient id="bolt-b" x1="19.7" x2="27.7" y1="15.2" y2="23.3" gradientUnits="userSpaceOnUse"><stop stop-opacity=".9"></stop><stop offset=".3"></stop><stop offset="1" stop-opacity="0"></stop></linearGradient></defs></svg></div>
+    </div>
+    <div class="survoltes-logo__text">
+        <div class="svg-wrapper ">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 60"><title>Survoltes</title><path d="M1.8 54.5v-7C6 49.1 10.8 50 16 50c6.4 0 9.6-2.2 9.6-6.5 0-3.1-2-4.7-5.9-4.7h-6.5C4.6 38.7.3 34.8.3 27c0-8.6 6.1-12.9 18.3-12.9 4.7 0 9.1.7 13.3 2v7.1a38 38 0 0 0-13.3-2.3c-7 0-10.5 2-10.5 6.1 0 3.1 1.7 4.7 5 4.7h6.6c9.1 0 13.7 3.9 13.7 11.7 0 8.8-5.8 13.2-17.4 13.2-5.3 0-10-.7-14.2-2ZM40.6 39.8V14.4h7.8v25.4c0 6.7 3.4 10 10.2 10 6.9 0 10.3-3.3 10.3-10V14.4h7.7v25.4c0 11.2-6 16.8-18 16.8s-18-5.6-18-16.8ZM86 56.2V14.4h19c8.6 0 12.9 3.7 12.9 11.2 0 5-3.3 9.3-10 12.6l13.3 18.1h-9.8L98.6 38v-3.5c7.5-1.3 11.2-4.1 11.2-8.6 0-3.1-1.8-4.7-5.2-4.7H93.9v35H86ZM167.2 14.4l-18.4 41.9h-8.3l-17.6-41.9h9.2l13 32 13-32h9ZM176.4 35.2c0 9.8 4.3 14.7 13 14.7 8.4 0 12.6-5 12.6-14.7 0-9.6-4.2-14.3-12.7-14.3-8.6 0-13 4.7-13 14.3Zm-8.1.2c0-14.2 7-21.3 21-21.3 13.8 0 20.8 7.1 20.8 21.3 0 14.1-7 21.2-20.8 21.2-13.4 0-20.4-7-21-21.2ZM226.4 14.4v35.2H243v6.7h-24.4V14.4h7.8ZM276 14.4v6.7h-12v35.2h-7.8V21.1h-12v-6.7H276ZM312 14.4v6.7h-21v10.5h20v7h-20v11h21.5v6.7h-29.1V14.4H312ZM297 .3h9.4l-7 7.6h-6.6L297 .3ZM320.7 54.5v-7c4.2 1.6 9 2.4 14.3 2.4 6.4 0 9.6-2.2 9.6-6.5 0-3.1-2-4.7-6-4.7h-6.5c-8.6 0-12.9-3.9-12.9-11.7 0-8.6 6.2-12.9 18.4-12.9 4.6 0 9 .7 13.3 2v7.1a38 38 0 0 0-13.3-2.3c-7 0-10.6 2-10.6 6.1 0 3.1 1.7 4.7 5.1 4.7h6.6c9 0 13.7 3.9 13.7 11.7 0 8.8-5.8 13.2-17.4 13.2-5.3 0-10-.7-14.3-2Z" class="main-shape"></path></svg></div>
+        <span class="is-hidden-mobile">Le média 100% Électrique</span>
+    </div>
+</div>
+                    </a>
+                                        <ul class="columns header__container is-mobile is-flex-grow-1" id="header-categories-container">
+                                    <li class="column has-text-centered">
+                        <a href="https://www.frandroid.com/survoltes/voitures-electriques" class="gtm-category header__category-link js-category-link header__category-link--survoltes">
+                                                            <div class="header__category-icon category--voitures-electriques">
+                                    <div class="svg-wrapper has-gradient-primary">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 69 40"><path d="m57.23 24.28-5.7.02a31.8 31.8 0 0 0-5.6-4.14 30.2 30.2 0 0 0-22.6-3.29 54.3 54.3 0 0 0-8.94 2.94l-.07.02-.02.02a31.21 31.21 0 0 0-7.7 4.66l-2.44.02A3.16 3.16 0 0 0 1 27.69v5.74c0 2.95 2.4 5.34 5.34 5.34l4.56-.02a6.2 6.2 0 0 0 12.1-.06l23.52-.1a6.2 6.2 0 0 0 12.16-.03l9.19-.04c.63 0 1.13-.51 1.13-1.14v-1.37c0-6.47-5.28-11.73-11.77-11.73Zm-12.46-2.16a31.6 31.6 0 0 1 3.26 2.2l-15.45.07-2.1-6.11a27.52 27.52 0 0 1 14.29 3.84Zm-20.92-3.04c1.43-.33 2.85-.56 4.27-.69l2.06 6-12.08.06-1.64-3.04c2.8-1.13 5.5-1.88 7.39-2.33Zm-6.9 22.22a3.93 3.93 0 1 1 0-7.85 3.93 3.93 0 0 1 0 7.85Zm35.65 0a3.92 3.92 0 0 1-3.92-3.84v-.08a3.93 3.93 0 1 1 3.92 3.92Zm14.13-5.05-8.04.04a6.2 6.2 0 0 0-12.2.03l-23.43.1a6.2 6.2 0 0 0-12.24.06l-4.48.02a3.07 3.07 0 0 1-3.07-3.07V27.7c0-.49.4-.89.9-.89l2.86-.02.13-.03c.1-.01.19-.02.28-.06l.19-.11c.04-.03.1-.05.14-.1a27.32 27.32 0 0 1 6.6-4.17l2.05 3.82c.2.37.58.6 1 .6l39.82-.18A9.49 9.49 0 0 1 66.73 36v.24Z" class="main-shape"></path><path fill="url(#voiture-a)" fill-rule="evenodd" d="M7 12.51a1.75 1.75 0 0 1 2.47 0l5.13 5.1h-.01c-1.2.45-2.33.97-3.4 1.53L7 14.98a1.75 1.75 0 0 1 0-2.47Zm2.1 7.83-6.12-6.1A1.75 1.75 0 0 0 .5 16.72l5.74 5.71c.87-.73 1.82-1.43 2.85-2.09Z" clip-rule="evenodd"></path><defs><linearGradient id="voiture-a" x1="0" x2="14.6" y1="17.22" y2="17.22" gradientUnits="userSpaceOnUse"><stop></stop><stop offset=".93"></stop></linearGradient></defs></svg></div>
+                                </div>
+                                <span class="header__category-name">Voitures</span>
+                                                    </a>
+                    </li>
+                                    <li class="column has-text-centered">
+                        <a href="https://www.frandroid.com/survoltes/velo-electrique" class="gtm-category header__category-link js-category-link active header__category-link--survoltes active">
+                                                            <div class="header__category-icon category--velo-electrique">
+                                    <div class="svg-wrapper has-gradient-primary">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 62 52"><path d="M49.3 29.32c-1.72 0-3.27.4-4.75 1.04l-5.35-8.5 2.56-1.22c.41-.23.59-.7.41-1.16a.96.96 0 0 0-1.19-.41l-3.32 1.69c-.42.17-.6.7-.42 1.1 0 .12.06.18.12.24l.65 1.04-10.64 2.27h-.06l-2.5-2.73h.9c.48 0 .9-.41.9-.88a.9.9 0 0 0-.9-.87h-4.93a.9.9 0 0 0-.9.87c0 .47.42.88.9.88h1.72s0 .06.06.06l3.15 3.49c-.18.17-.3.4-.42.64l-2.2 3.32c-1.3-.58-2.79-.87-4.33-.87A10.65 10.65 0 0 0 8 39.86c0 5.82 4.81 10.54 10.76 10.54 5.94 0 10.75-4.72 10.75-10.54 0-.3 0-.64-.06-.94l5.95-1.04a2.36 2.36 0 0 0 2.14-1.58l2.85-9.26 2.61 4.2a10.5 10.5 0 0 0-4.51 8.56c0 5.82 4.81 10.54 10.75 10.54C55.2 50.34 60 45.62 60 39.8c0-5.82-4.75-10.48-10.7-10.48ZM27.8 39.86c0 4.89-4.04 8.85-9.03 8.85-5 0-8.98-3.96-8.98-8.85 0-4.9 4.04-8.8 8.98-8.8 1.19 0 2.31.24 3.38.64l-3.68 5.65-.06.12c-.24.7-.12 1.46.36 2.04.41.58 1.13.93 1.9.93h.06l7.07-1.22v.64Zm-4.1-7.4a8.79 8.79 0 0 1 3.74 5.07l-6.89 1.16c-.18 0-.3-.11-.42-.23-.12-.12-.12-.3-.12-.4l3.69-5.6Zm.95-1.4 2.14-3.32.12-.23 7.96 8.74-5.64.99a10.78 10.78 0 0 0-4.58-6.18Zm14.44-5.53-2.97 9.61-7.49-8.21 9.99-2.16c.18 0 .3.12.41.24.06.17.12.35.06.52ZM49.3 48.71c-4.99 0-9.03-3.96-9.03-8.85a8.8 8.8 0 0 1 3.68-7.1l4.7 7.5c.18.3.48.41.77.41.18 0 .3-.06.48-.12a.84.84 0 0 0 .3-1.16l-4.7-7.45a9.07 9.07 0 0 1 3.8-.82c5 0 9.04 3.96 9.04 8.85 0 4.9-4.1 8.74-9.04 8.74Z" class="main-shape"></path><path fill="url(#velo-a)" fill-rule="evenodd" d="M8 24.51a1.75 1.75 0 0 1 2.47 0l3.97 3.94c-1.2.37-2.3.94-3.27 1.68L8 26.98a1.75 1.75 0 0 1 0-2.47Zm1.48 7.21-5.5-5.48a1.75 1.75 0 0 0-2.47 2.48l6.15 6.12a10.5 10.5 0 0 1 1.82-3.12Z" clip-rule="evenodd"></path><defs><linearGradient id="velo-a" x1="1" x2="14.44" y1="29.42" y2="29.42" gradientUnits="userSpaceOnUse"><stop></stop><stop offset=".93"></stop></linearGradient></defs></svg></div>
+                                </div>
+                                <span class="header__category-name">Vélos</span>
+                                                    </a>
+                    </li>
+                                    <li class="column has-text-centered">
+                        <a href="https://www.frandroid.com/survoltes/trottinette-electrique" class="gtm-category header__category-link js-category-link header__category-link--survoltes">
+                                                            <div class="header__category-icon category--trottinette-electrique">
+                                    <div class="svg-wrapper has-gradient-primary">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-8 0 60 30"><path fill="url(#trottinette-a)" fill-rule="evenodd" d="M9.74 36.84a7.02 7.02 0 0 1 0-11.69 6.09 6.09 0 1 0 0 11.69Z" clip-rule="evenodd"></path><path fill-rule="evenodd" d="M28.99 4.3a.82.82 0 0 0 0 1.64h3.96l2.14 12.17-7.72 12.5h-7.3a5.8 5.8 0 1 0-.1 1.63h7.67c.4 0 .77-.2.99-.55l6.89-11.16.88 5.01a5.8 5.8 0 1 0 1.61-.3l-1.25-7.1-2.27-12.87c-.1-.56-.58-.96-1.15-.96H29Zm7.7 22.88.78 4.39a.82.82 0 1 0 1.6-.29l-.77-4.4a4.17 4.17 0 1 1-1.6.3Zm-18.25 3.43H13.9a.82.82 0 0 0 0 1.63h4.37a4.17 4.17 0 1 1 .16-1.63Z" class="main-shape" clip-rule="evenodd"></path><defs><linearGradient id="trottinette-a" x1="1.94" x2="9.74" y1="31" y2="31" gradientUnits="userSpaceOnUse"><stop></stop><stop offset=".93"></stop></linearGradient></defs></svg></div>
+                                </div>
+                                <span class="header__category-name">Trottinettes</span>
+                                                    </a>
+                    </li>
+                                    <li class="column has-text-centered">
+                        <a href="https://www.frandroid.com/survoltes/scooters-electriques" class="gtm-category header__category-link js-category-link header__category-link--survoltes">
+                                                            <div class="header__category-icon category--scooters-electriques">
+                                    <div class="svg-wrapper has-gradient-primary">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 28"><path d="M53.05 21.8v-2.34c0-.43-.1-.86-.27-1.2l-2.91-7.02h1.78c.36 0 .65-.3.65-.65v-4.9c0-.35-.29-.64-.65-.64h-4.92c-.69 0-1.33.26-1.83.7-.88-.08-1.64.22-2.23.8a2.76 2.76 0 0 0 2.74 4.57l1.22 6.78c.05.23.05.46-.02.69l-2.22 7.74c-.17.6-.73 1.01-1.35 1.01h-5.27a1.4 1.4 0 0 1-1-.4l-4.39-4.37c.61-.49 1-1.22 1-2.06v-.3c0-1.46-1.18-2.64-2.65-2.64h-1.57c.44-.59.72-1.3.72-2.1V10.6a3.5 3.5 0 0 0-3.51-3.5h-8.43a3.5 3.5 0 0 0-3.51 3.5v4.88c0 1.02.45 1.93 1.15 2.57a2.63 2.63 0 0 0-1.15 2.17v.3c0 1.24.86 2.27 2 2.56a5.56 5.56 0 0 0-2 4.27v4.9c0 .38.31.7.7.7h3.56a5.61 5.61 0 0 0 11.14 0h18.36a5.61 5.61 0 0 0 11.18-.7v-3.5a7 7 0 0 0-6.32-6.95Zm4.91 6.74-.1-.11a5.6 5.6 0 0 0-1.61-1.2l-.23-.1-.3-.12-.23-.09-.33-.09-.23-.06c-.12-.03-.25-.04-.38-.06l-.2-.03a5.67 5.67 0 0 0-1.3.02c-.07 0-.14.02-.2.03-.19.03-.37.06-.55.11l-.15.04c-.22.07-.43.14-.64.23l-.13.07a5.6 5.6 0 0 0-.48.25l-.1.05 1.74-4.32a5.6 5.6 0 0 1 5.42 5.38ZM45.65 9.5a1.47 1.47 0 0 1-1.02.42c-.8 0-1.45-.64-1.45-1.44a1.44 1.44 0 0 1 2.47-1.02 1.43 1.43 0 0 1 0 2.04Zm.93-2.96a2.87 2.87 0 0 0-.18-.16c.1-.03.22-.04.33-.04H51v3.58h-1.91a.7.7 0 0 0-.24-.04H47c.06-.1.12-.21.17-.33l.03-.08c.05-.13.08-.25.11-.38l.03-.13a2.72 2.72 0 0 0-.76-2.42Zm-30.75 4.04c0-1.16.95-2.1 2.1-2.1h8.44c1.16 0 2.1.94 2.1 2.1v4.88a2.1 2.1 0 0 1-2.1 2.1h-8.43a2.1 2.1 0 0 1-2.1-2.1V10.6Zm0 9.92v-.3c0-.69.56-1.24 1.25-1.24H30.73c.7 0 1.25.55 1.25 1.24v.3c0 .69-.56 1.25-1.25 1.25H17.08c-.69 0-1.25-.56-1.25-1.25Zm8.43 15.91a4.2 4.2 0 0 1-4.21-4.19 4.2 4.2 0 0 1 8.42 0 4.2 4.2 0 0 1-4.21 4.2Zm23.4-4.89H29.83c0-.08-.03-.17-.04-.26l-.04-.2a5.52 5.52 0 0 0-.09-.35l-.04-.17a5.52 5.52 0 0 0-.18-.49l-.02-.03c-.06-.15-.14-.3-.21-.44l-.1-.16-.17-.28-.13-.18-.18-.24-.15-.17a5.65 5.65 0 0 0-.2-.22l-.16-.16a5.7 5.7 0 0 0-1.54-1.03l-.21-.1-.29-.1-.21-.07-.31-.08-.21-.05a5.57 5.57 0 0 0-.36-.05l-.18-.03a5.7 5.7 0 0 0-1.1 0l-.18.03-.36.05-.21.05-.31.08-.22.07-.28.1-.21.1a5.75 5.75 0 0 0-1.54 1.03l-.17.16-.2.22-.14.17-.18.24-.13.18-.17.28-.1.16c-.08.14-.15.29-.21.44l-.02.03c-.07.16-.13.33-.18.5l-.04.16-.1.35c0 .07-.02.13-.03.2l-.05.26h-2.85v-4.19a4.2 4.2 0 0 1 4.22-4.18h10.94l4.8 4.76a2.8 2.8 0 0 0 1.98.82h5.27c1.24 0 2.35-.83 2.7-2.02l2.22-7.75c.13-.45.14-.92.05-1.34l-1.14-6.35h1.5l3.13 7.56c.1.19.15.4.15.62v2.16l-.23.58-1.66 4.12-2.1 5.21Zm6.1 4.9a4.2 4.2 0 0 1-4.22-4.2 4.2 4.2 0 0 1 8.43 0 4.2 4.2 0 0 1-4.22 4.2Z" class="main-shape"></path><path fill="url(#scooter-a)" fill-rule="evenodd" d="m14.65 23.45-.37.55c-.5.75-.78 1.63-.79 2.54H5.95a1.54 1.54 0 1 1 0-3.1h8.7Zm-1.16 4.12v3.09H1.83a1.54 1.54 0 1 1 0-3.1H13.5Z" clip-rule="evenodd"></path><defs><linearGradient id="scooter-a" x1=".29" x2="14.65" y1="27.05" y2="27.05" gradientUnits="userSpaceOnUse"><stop></stop><stop offset=".93"></stop></linearGradient></defs></svg></div>
+                                </div>
+                                <span class="header__category-name">Scooters</span>
+                                                    </a>
+                    </li>
+                                    <li class="column has-text-centered">
+                        <a href="https://www.frandroid.com/survoltes/moto" class="gtm-category header__category-link js-category-link header__category-link--survoltes">
+                                                            <div class="header__category-icon category--moto">
+                                    <div class="svg-wrapper has-gradient-primary">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 62 50"><path fill="url(#moto-a)" fill-rule="evenodd" d="M9.45 47.95A10.42 10.42 0 0 1 6 40.08c0-3.2 1.35-6.04 3.45-7.87a8 8 0 1 0 0 15.74Z" clip-rule="evenodd"></path><path d="M46.52 14c-1.57.1-2.7 1.67-2.13 3.12l1.1 2.82c.22.58.18.98-.05 1.05-.32.09-1.19-.05-1.73-.36-1.87-1.04-4.34-1.38-6.94-.98-3.3.52-6.37 2.08-8.1 4.38-.41.54-.68.89-.92 1.06-.23.17-.45.25-1.02.25h-2.15c-.54 0-.5-.03-.67-.22-.17-.19-.45-.67-1.05-1.14a6.55 6.55 0 0 0-4.28-1.6l-6.16-.09c-1.01-.01-1.74.32-2.04 1.16-.28.79.1 1.5.52 2.37.57 1.23 1.7 2.73 3.41 3.06l3.42.66a9.93 9.93 0 0 1 6.17 3.5l-.85.52-.2-.22a8.97 8.97 0 1 0 2.63 6.34v-.28l1.14-.36c.02.24.06.48.07.73 0 1-.15 1.96-.42 2.88-.14.49.22.98.73.98h14.25c.51 0 .88-.5.73-.98a10.3 10.3 0 0 1-.41-2.88c0-3.38 1.76-6.23 4.26-8.1l.47 1.08a8.95 8.95 0 0 0 5.66 15.9 8.98 8.98 0 0 0 6.34-15.31 8.96 8.96 0 0 0-5.86-2.6l-.25-1.15h4.15c.56 0 1.19-.07 1.72-.5.54-.43.8-1.22.67-2.08-.9-5.8-4.65-11.67-11.52-12.96a2.78 2.78 0 0 0-.69-.05Zm.41 1.55c6.14 1.21 9.47 6.37 10.3 11.7.07.5-.01.56-.11.64-.1.08-.4.17-.79.17H51.4c-2.14 0-4.4.8-5.94 1.76a11.65 11.65 0 0 0-5.42 9.95c0 .8.18 1.56.34 2.33h-12.5c.35-1.47.4-2.76.06-4.33a14.39 14.39 0 0 0-1.8-4.4l17.78-7.84c1.26-.55 2.4-1.19 2.9-2.25a4.5 4.5 0 0 0 .09-3.9l-1.1-2.82c-.31-.8.26-1.18 1.12-1Zm-8.22 5.47a8.59 8.59 0 0 1 4.25.95c.86.48 1.9.78 2.91.49l.1-.05a5.34 5.34 0 0 1-2.5 2.07l-9.88 4.35-4.83-2.6c.44-.35.75-.78 1.12-1.27 1.4-1.87 4.16-3.33 7.12-3.8.58-.08 1.15-.13 1.7-.14Zm-26.31 2.8 6.15.1c1.85.02 2.46.57 3.37 1.27.38.3.51.57.85.95.35.38.99.74 1.81.74h2.15c.25 0 .48-.03.7-.07l4.83 2.6-6.76 2.99c-2.28-2.3-5.04-3.9-7.5-4.36l-3.4-.66c-.9-.17-1.9-1.3-2.32-2.21a6.73 6.73 0 0 1-.25-.63c-.16-.43-.15-.73.37-.72Zm38.15 5.41 2.2 9.92c.17.81-.15 1.07-.57 1.19-.4.12-.9.02-1.16-.6l-4.12-9.42a8.9 8.9 0 0 1 3.65-1.09Zm-34.03 3c1.94 0 3.8.77 5.2 2.13l-2.17 1.3a5 5 0 0 0-5.82-.18 5.03 5.03 0 1 0 7.72 5.17l2.5-.78a7.43 7.43 0 0 1-14.87-.19 7.43 7.43 0 0 1 7.44-7.44Zm36.27.06a7.44 7.44 0 1 1-5.86 1.91l1.05 2.4a5.03 5.03 0 1 0 9 2.8 5.05 5.05 0 0 0-3.63-4.57l-.56-2.54Zm-27.9 1.94c.65 1.08 1.1 2.14 1.46 3.3l-8.03 2.5c-.59.18-.98-.09-1.15-.39-.16-.3-.11-.67.4-1l7.32-4.41Zm-8.68 1.56c.78-.06 1.56.13 2.25.53l-1.7 1.03a2.3 2.3 0 0 0-.92 3.03 2.49 2.49 0 0 0 2.93 1.1l1.37-.42a3.87 3.87 0 0 1-7.26 0 3.9 3.9 0 0 1 3.33-5.27Zm37.44.4a3.88 3.88 0 1 1-5.11 1.68l1.08 2.48a2.52 2.52 0 0 0 2.99 1.45 2.49 2.49 0 0 0 1.62-2.98l-.58-2.64Z" class="main-shape"></path><defs><linearGradient id="moto-a" x1="0" x2="9.45" y1="40.08" y2="40.08" gradientUnits="userSpaceOnUse"><stop></stop><stop offset=".93"></stop></linearGradient></defs></svg></div>
+                                </div>
+                                <span class="header__category-name">Motos</span>
+                                                    </a>
+                    </li>
+                                    <li class="column has-text-centered">
+                        <a href="https://www.frandroid.com/survoltes/energie" class="gtm-category header__category-link js-category-link header__category-link--survoltes">
+                                                            <div class="header__category-icon category--energie">
+                                    <div class="svg-wrapper has-gradient-primary">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 0 68 48"><path d="M26.4918 46.0303H27.044C27.3589 47.5981 28.75 48.7825 30.4133 48.7825C32.0766 48.7825 33.4677 47.5981 33.7826 46.0303H34.3348C35.2706 46.0303 36.032 45.271 36.032 44.3377V42.3382H36.3522C36.7259 42.3382 37.0286 42.036 37.0286 41.6636V41.4326C37.0286 40.5913 37.0991 39.7696 37.2276 38.9696C37.2358 38.9391 37.2414 38.9079 37.2452 38.876C37.6027 36.7389 38.4063 34.7705 39.6343 33.0928C41.2227 30.9229 41.9905 28.2426 41.7965 25.5448C41.3898 19.8936 36.8056 15.3697 31.1329 15.0223C27.9452 14.8269 24.9128 15.9165 22.5956 18.0895C20.3105 20.2326 18.9999 23.2554 18.9999 26.3823C18.9999 28.7143 19.7023 30.9562 21.0307 32.8662C22.8411 35.47 23.798 38.4318 23.798 41.4317V41.6636C23.798 42.036 24.1008 42.3382 24.4744 42.3382H24.7946V44.3377C24.7946 45.271 25.556 46.0303 26.4918 46.0303ZM32.0337 26.9638C33.1317 25.5299 35.196 25.0753 36.2064 24.9352C36.337 25.9449 36.4401 28.0503 35.3422 29.4841C34.5377 30.5343 33.2173 31.0562 32.17 31.3168L34.2254 28.633C34.4522 28.337 34.3954 27.9137 34.0986 27.6875C33.802 27.4627 33.3773 27.5184 33.1505 27.8144L31.0939 30.4997C31.0704 29.4233 31.2294 28.0139 32.0337 26.9638ZM29.7327 30.4996L27.6762 27.8144C27.4496 27.518 27.0251 27.4618 26.7281 27.6875C26.4312 27.9137 26.3744 28.337 26.6012 28.633L28.6594 31.3203C27.6133 31.0613 26.2931 30.5399 25.4844 29.4841C24.3864 28.0503 24.4896 25.9444 24.6202 24.9352C25.6311 25.0753 27.6949 25.5303 28.793 26.9638C29.5973 28.014 29.7561 29.4235 29.7327 30.4996ZM35.7961 39.4695C35.7382 39.97 35.6943 40.475 35.6813 40.9891H35.3556H25.471H25.1445C25.1299 40.4802 25.0811 39.974 25.0168 39.4695H35.7961ZM30.4133 47.4334C29.5026 47.4334 28.7348 46.8439 28.4523 46.0303H32.3744C32.0918 46.8439 31.324 47.4334 30.4133 47.4334ZM34.6792 44.3377C34.6792 44.527 34.5246 44.6811 34.3348 44.6811H33.1731H27.6535H26.4918C26.302 44.6811 26.1474 44.527 26.1474 44.3377V42.3382H34.6792V44.3377ZM20.3528 26.3823C20.3528 23.5852 21.4784 20.9893 23.5224 19.0723C25.565 17.1567 28.2396 16.1958 31.0501 16.3688C36.049 16.6754 40.0888 20.6617 40.4472 25.6414C40.6183 28.0213 39.9417 30.3849 38.5417 32.297C37.2917 34.0048 36.4445 35.9824 36.012 38.1204H31.0897V32.8831C32.1735 32.7648 34.9056 32.2763 36.4172 30.3028C38.2907 27.8562 37.4635 24.2023 37.4274 24.0481C37.3536 23.7337 37.0641 23.5075 36.7437 23.5273C36.5847 23.533 32.8321 23.6985 30.9587 26.1452C30.7412 26.4291 30.5635 26.7303 30.4133 27.0395C30.2632 26.7303 30.0854 26.4291 29.8679 26.1452C27.9946 23.6985 24.2419 23.533 24.083 23.5273C23.7577 23.5084 23.4728 23.7337 23.3993 24.0481C23.3632 24.2023 22.5359 27.8562 24.4095 30.3028C25.921 32.2763 28.6531 32.7648 29.7369 32.8831V38.1204H24.7833C24.3248 36.0073 23.4409 33.965 22.1424 32.0976C20.9717 30.4143 20.3528 28.4381 20.3528 26.3823Z" class="main-shape"></path><path fill="url(#energie-a)" fill-rule="evenodd" d="M32.3371 8.79883C32.3371 7.80536 31.5318 7 30.5383 7C29.5448 7 28.7395 7.80536 28.7395 8.79883V13.0785C29.2467 13.0241 29.7622 12.9962 30.2845 12.9962C30.9819 12.9962 31.6673 13.046 32.3371 13.1421V8.79883ZM42.3526 19.7761C41.7464 18.7528 41.0059 17.8138 40.1544 16.9819L43.9978 13.356C44.7093 12.6847 45.8477 12.7005 46.5403 13.3914C47.233 14.0822 47.2177 15.1864 46.5061 15.8577L42.3526 19.7761ZM20.236 17.1596C19.3986 18.0081 18.6743 18.9625 18.0866 20L13.5436 15.714C12.832 15.0427 12.8167 13.9385 13.5093 13.2477C14.202 12.5568 15.3403 12.541 16.0519 13.2123L20.236 17.1596Z" clip-rule="evenodd"></path><defs><linearGradient id="energie-a" x1="12.9997" x2="47.05" y1="13.5" y2="13.5" gradientUnits="userSpaceOnUse"><stop></stop><stop offset="0.932292"></stop></linearGradient></defs></svg></div>
+                                </div>
+                                <span class="header__category-name">Énergie</span>
+                                                    </a>
+                    </li>
+                            </ul>
+        </div>
+    </div>
+                            
+    <div data-react-component="EventBanner" data-props-id="react-props-EventBanner-naqrdyiz29e">
+      <div class="event-banner___X844A" data-id="7" data-event-banner="true"><a class="event-banner__link___tRiQc" href="https://www.frandroid.com/tag/french-days" aria-label="French Days de printemps"><div class="event-banner__container___BCukl"><span class="play-triangle-double___0Fow9" aria-hidden="true"><svg viewBox="0 0 68 80" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M63.138 34.962 8.387 1.365C4.96-.737.5 1.678.5 5.626v66.748c0 3.948 4.46 6.363 7.887 4.27L63.138 45.04c3.6-2.198 3.6-7.88 0-10.078Z"></path></svg><svg viewBox="0 0 68 80" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M63.138 34.962 8.387 1.365C4.96-.737.5 1.678.5 5.626v66.748c0 3.948 4.46 6.363 7.887 4.27L63.138 45.04c3.6-2.198 3.6-7.88 0-10.078Z"></path></svg></span><div class="event-banner__row___b9vTh"><div class="event-banner__text___vu-fy event-banner__text--desktop___WVmu7">French Days de printemps</div><div class="event-banner__text___vu-fy event-banner__text--mobile___Kbh1t"><strong>French Days 2026</strong></div><div class="event-banner__secondary___ovahr event-banner__secondary--desktop___cUiJJ">Toutes les offres en DIRECT 🔥</div><div class="event-banner__posts-count___x-MVP"><span class="event-banner__badge___QU91i">58</span>articles</div></div><span class="event-banner__logo___rA8E2" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="138" height="124" viewBox="0 0 138 124"><g fill-rule="nonzero"><path d="M38 46.7H61v2l-.1 9.2-.1 12v7a27 27 0 005.4 16l.2.1c3.7 4.5 8.5 6.9 15.5 8h1.1l2.4.3h.7l1.3.1h2.5l4.8-.5h.5c6.4-1.1 10.8-3.5 14.3-7.5l.2-.2.2-.3a29 29 0 005.5-18.3V69.8l-.2-17.2h.1V48l22.7-.1v2.8h.1v24.4a50.2 50.2 0 01-11 32.9 45.8 45.8 0 01-30.9 15.7h-.4l-1 .1-4.3.2H82.4l-.5-.1h-1l-.3-.1h-.4a46.4 46.4 0 01-31-15.5l-.3-.3A48 48 0 0138 79.3v-.8-.8.5-.3l-.1-2.1V63.6v10.5h.1V46.7zm0 31.5V85v-6.8z"></path><path d="M23.7 84.6l-23.5.1v-12l-.1-11-.1-11v-.5c.2-13.8 3.8-25 11-33.6l.3-.3A45.5 45.5 0 0140.3 1h.3A51 51 0 0160 .8h.3a45 45 0 0128.9 15.7 51.7 51.7 0 0111 33.6v.5l-.1 11v11l-.1 6v6H76.4V67.4l.2-12V50c-.2-8-2-14-5.3-18l-.1-.1-.2-.2-.1-.1-.4-.5-.4-.4a22.7 22.7 0 00-14.1-6.5l-.6-.1L54 24h-1.2l-1-.1h-1l-.5-.1h-1.9l-.6.1c-9 .7-14.6 3.2-18.8 8.1l-.1.2-.2.2c-3.3 4-5 10-5.2 18.1v5l.1 12v9.4l.1 7.7z"></path></g></svg></span></div></a></div>
+    </div>
+    
+  
+            </header>
+
+<nav id="menu-burger" class="menu-burger js-menu-burger">
+    <div class="container">
+        <div class="menu-burger-background"></div>
+        <div class="m-0 menu-burger__header-wrapper columns is-hidden-touch">
+            <div class="column is-8-desktop">
+                <a href="https://www.frandroid.com/" class="mt-1 menu-burger__logo-wrapper column is-narrow is-hidden-mobile is-hidden-tablet-only is-block-desktop">
+                    <img src="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/images/2019-redesign/logos/frandroid-vCQbpIsLN5czao2wY4sAn.svg" class="menu-burger__logo" alt="La référence tech pour s’informer, comparer et bien acheter" onmousedown="return false;">
+                </a>
+            </div>
+            <div class="ml-5 column">
+                <div class="m-0 columns">
+                    <a href="https://twitter.com/frandroid" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="X"><i class="icon icon-x"></i></a>
+                    <a href="https://www.instagram.com/frandroid_off" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Instagram"><i class="icon icon-instagram"></i></a>
+                    <a href="https://www.facebook.com/frandroidcom" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Facebook"><i class="icon icon-facebook"></i></a>
+                    <a href="https://www.frandroid.com/feed" target="_blank" class="menu-burger__social-icon column is-narrow" aria-label="Feed"><i class="icon icon-rss"></i></a>
+                    <a href="https://www.youtube.com/frandroid" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Youtube"><i class="icon icon-youtube"></i></a>
+                    <a href="https://www.twitch.tv/frandroidlive" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Twitch"><i class="icon icon-twitch"></i></a>
+                    <a href="https://www.tiktok.com/@frandroid_" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Tiktok"><i class="icon icon-tiktok"></i></a>
+                    <a href="https://bsky.app/profile/frandroid.com" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Bluesky"><i class="icon icon-bluesky"></i></a>
+                </div>
+            </div>
+        </div>
+        <div class="menu-burger-inner">
+            <div class="menu-burger-bar has-bg-body-background-secondary-color has-text-weight-medium">
+                <button id="js-menu-burger-close" aria-label="Fermer" class="gtm-menu-close menu-burger__close fr-button-close"></button>
+                <span class="has-text-primary">MENU</span>
+                                                        <a class="menu-burger__profile-link is-hidden-desktop " href="https://www.frandroid.com/connexion" aria-label="Mon compte">
+                        <svg width="20" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path class="menu-burger__profile-path" d="M8.93 9.75c2.48 0 4.5-2.01 4.5-4.5s-2.02-4.5-4.5-4.5-4.5 2.01-4.5 4.5 2.01 4.5 4.5 4.5z" stroke="currentColor" stroke-width="1.5" stroke-miterlimit="10"></path>
+                            <path class="menu-burger__profile-path" d="M17.1 18.75s-2.7-4.67-8.14-4.67h-.07c-5.44 0-8.14 4.67-8.14 4.67h16.34z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                        </svg>
+                    </a>
+                            </div>
+            <div class="content-box">
+                <div class="menu-burger__theme is-hidden-desktop">
+                    <a class="js-show-preferences has-text-primary has-text-weight-bold" data-location="mobile">
+                        <i class="icon icon-settings" aria-label="Thème"></i> Réglages <i class="icon icon-arrow-down ml-2-mobile" aria-label="Réglages"></i>
+                    </a>
+                    <div class="menu-burger__theme-content is-hidden">
+</div>
+                </div>
+                                    <div class="menu-burger__list columns is-gapless is-justified">
+                                                                                    <div class="column is-4">
+                                                        <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  has-text-primary">
+                                    <a href="https://www.frandroid.com/actualites">Actualités</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/telecom">Telecom</a></li>
+                                                                                                    <li class="is-paddingless">
+                                                        <ul>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/bouygues-telecom">Bouygues</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/orange">Orange</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/marques/sfr">SFR</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/tag/free-mobile">Free Mobile</a></li>
+                                                                                                                    </ul>
+                                                    </li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/culture-tech">Société</a></li>
+                                                                                                    <li class="is-paddingless">
+                                                        <ul>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/culture-tech/intelligence-artificielle">Intelligence Artificielle</a></li>
+                                                                                                                    </ul>
+                                                    </li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/services">Services</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/produits-android/hardware">Hardware</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/marques">Marques</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/produits/marques">Toutes les marques</a></li>
+                                                                                                    <li class="is-paddingless">
+                                                        <ul>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/apple">Apple</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/google">Google</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/honor">Honor</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/huawei">Huawei</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/oneplus">OnePlus</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/samsung">Samsung</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/sony">Sony</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/produits/xiaomi">Xiaomi</a></li>
+                                                                                                                    </ul>
+                                                    </li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/produits">Tous les produits</a>
+                                </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/humanoid/video-podcast">Podcast</a>
+                                </li>
+                                                            </ul>
+                                                            </div>
+                                                                                                                <div class="column is-4">
+                                                        <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  has-text-tests">
+                                    <a href="https://www.frandroid.com/android">Android</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/android/mises-a-jour-android">Mises à jour Android</a></li>
+                                                                                                    <li class="is-paddingless">
+                                                        <ul>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/android/mises-a-jour-android/2424108_mise-a-jour-android-16-smartphones-compatibles-nouveautes-dates-tout-ce-quil-faut-savoir">Android 16</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/android/mises-a-jour-android/1981546_mise-a-jour-android-15-smartphones-compatibles-nouveautes-dates-tout-ce-que-lon-sait">Android 15</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/android/mises-a-jour-android/1608531_android-14-date-de-sortie-nouveautes-smartphones-compatibles-tout-savoir-sur-la-mise-a-jour">Android 14</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/android/mises-a-jour-android/1225433_android-13-developer-preview-est-la-premier-apercu-officiel-et-nouveautes-devoilees">Android 13</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/android/mises-a-jour-android/902993_android-12-nouveautes-et-smartphones-compatibles-avec-la-mise-a-jour">Android 12</a></li>
+                                                                                                                            <li class="menu-burger__subitem"><a href="https://www.frandroid.com/android/mises-a-jour-android/675899_android-11-nouveautes-et-smartphones-compatibles-avec-la-mise-a-jour">Android 11</a></li>
+                                                                                                                    </ul>
+                                                    </li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/android/developpement">Développement Android</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/android/android-auto">Android Auto</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/android/android-tv">Android TV</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/comment-faire">Tutoriels</a>
+                                </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/os">Tous les OS</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/os/chrome-os">ChromeOS</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/os/ios">iOS</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/os/ipados">iPadOS</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/os/macos">macOS</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/os/windows">Windows</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/os/android-wear">Wear OS</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/telecharger">Télécharger</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/telecharger/apps">Applications</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/telecharger/jeux">Jeux mobile</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                            </div>
+                                                                                                                <div class="column is-4">
+                                                        <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  has-text-good-deals">
+                                    <a href="https://www.frandroid.com/bons-plans"><i class="icon-fire"></i>Bons Plans</a>
+                                </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/nos-comparateurs">Comparateurs</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/comparateur-forfaits">Les meilleurs forfaits mobiles</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/comparateur-forfaits/comparateur-forfaits-pas-chers">Les meilleurs forfaits pas chers</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/comparateur-forfaits/comparateur-forfaits-5g">Les meilleurs forfaits 5G</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/offre-internet-comparateur-des-meilleures-offres-fibre-et-adsl">Les meilleures offres internet</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/comparatif-meilleures-banques-en-ligne">Les meilleures banques en ligne</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/selection-meilleurs-vpn">Les meilleurs VPN</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/comparateur-fournisseurs-electricite">Les offres des fournisseurs d'électricité</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/guide-dachat">Guides d'achat</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/guide-dachat/smartphones/332196_10-smartphones-attendus-debut-2016">Meilleurs smartphones</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/guide-dachat/guide-audio/482350_quels-sont-les-meilleurs-ecouteurs-true-wireless-a-moins-de-200-euros-en-2018">Meilleurs écouteurs sans fils</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/guide-dachat/smartphones/367607_meilleurs-smartphones-photos">Meilleurs smartphones photo</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/guide-dachat/387028_quelle-box-sous-android-tv-choisir">Meilleurs boîtiers multimédias</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/versus">Les comparatifs</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/test">Tests</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/test/smartphones">Tests smartphones</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/test/casque-audio">Tests casques audio</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.frandroid.com/test/smart-tv">Tests TV connectées</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.frandroid.com/">Communautés</a>
+                                </li>
+                                                                    <li class="is-paddingless">
+                                        <ul>
+                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://forum.frandroid.com/">Forum Frandroid</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://www.facebook.com/groups/techentraide/">Groupe d'entraide Facebook</a></li>
+                                                                                                                                            <li class="menu-burger__subtitle has-text-weight-semibold"><a href="https://discord.com/invite/frandroid-311789172149190657">Discord Frandroid</a></li>
+                                                                                                                                    </ul>
+                                    </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://www.numerama.com/">Numerama</a>
+                                </li>
+                                                            </ul>
+                                                                                                            <ul>
+                                <li class="menu-burger__title has-text-weight-semibold  menu-burger__title--margin-top has-text-primary">
+                                    <a href="https://humanoid.fr/">Humanoid</a>
+                                </li>
+                                                            </ul>
+                                                            </div>
+                                                                        </div>
+                            </div>
+        </div>
+        <div class="menu-burger__footer-wrapper">
+            <div class="ml-4 mr-4 columns is-justify-content-center is-hidden-desktop is-mobile">
+                <a href="https://twitter.com/frandroid" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="X"><i class="icon icon-x"></i></a>
+                <a href="https://www.instagram.com/frandroid_off" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Instagram"><i class="icon icon-instagram"></i></a>
+                <a href="https://www.facebook.com/frandroidcom" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Facebook"><i class="icon icon-facebook"></i></a>
+                <a href="https://www.frandroid.com/feed" target="_blank" class="menu-burger__social-icon column is-narrow" aria-label="Feed"><i class="icon icon-rss"></i></a>
+                <a href="https://www.youtube.com/frandroid" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Youtube"><i class="icon icon-youtube"></i></a>
+                <a href="https://www.twitch.tv/frandroidlive" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Twitch"><i class="icon icon-twitch"></i></a>
+                <a href="https://www.tiktok.com/@frandroid_" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Tiktok"><i class="icon icon-tiktok"></i></a>
+                <a href="https://bsky.app/profile/frandroid.com" target="_blank" rel="noopener" class="menu-burger__social-icon column is-narrow" aria-label="Bluesky"><i class="icon icon-bluesky"></i></a>
+            </div>
+                            <div class="container">
+                    <div class="menu-burger__footer__links has-text-centered-touch has-text-weight-medium">
+                                                    <a href="https://www.frandroid.com/mentions-legales" class="footer__link">Mentions légales</a>
+                                                    • <a href="https://www.frandroid.com/a-propos" class="footer__link">À propos</a>
+                                                    • <a href="https://www.frandroid.com/contact" class="footer__link">Contacts</a>
+                                                    • <a href="https://www.frandroid.com/politique-cookies" class="footer__link">Politique Cookies</a>
+                                                    • <a href="https://www.frandroid.com/politique-donnees-personnelles" class="footer__link">Données personnelles</a>
+                                                    • <a href="https://www.frandroid.com/gerer-le-consentement-utiq" class="footer__link">Gérer UTIQ</a>
+                                            </div>
+                </div>
+                    </div>
+    </div>
+</nav>
+    <div id="ctBoc">
+        <main id="page">
+        
+<div id="js-summary" class="summary is-test">
+    <div class="summary__content has-bg-body-background-secondary-color">
+        <div class="container is-paddingless">
+            <div class="is-hidden-desktop has-text-centered">
+                <a href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#" id="js-summary-button" class="is-uppercase has-text-body is-size-6 summary__content-cta has-text-weight-bold">
+                <i id="js-summary-icon" class="summary__content-icon icon icon-summary is-size-6 has-text-link"></i>&nbsp;&nbsp;Sommaire
+                </a>
+            </div>
+            <ul id="js-summary-content" class="summary__content-list is-hidden-default">
+                                <li>
+                    <a class="js-summary-link" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus#product-resume">
+                        Intersport Nakamura Crosscity Plus                                            </a>
+                                    </li>
+                                <li>
+                    <a class="js-summary-link active" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique">
+                        Test complet                                            </a>
+                                    </li>
+                                <li>
+                    <a class="js-summary-link" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus#product-specs">
+                        Fiche technique                                            </a>
+                                    </li>
+                                <li>
+                    <a class="js-summary-link" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus#product-buying-guides">
+                        Guides d'achats                                            </a>
+                                    </li>
+                                <li>
+                    <a class="js-summary-link" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus#product-news">
+                        Actualités                                            </a>
+                                    </li>
+                                <li>
+                    <a class="js-summary-link" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus#js-technical-specs-list">
+                        Caractéristiques techniques                                            </a>
+                                    </li>
+                                <li>
+                    <a class="js-summary-link" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus#product-similar">
+                        Produits similaires                                            </a>
+                                    </li>
+                            </ul>
+            <noscript>
+                <style>
+                    .summary__content-list.is-hidden-default { display: flex; }
+                    @media screen and (max-width: 1000px) {
+                        .summary { height: inherit; position: relative; margin-bottom: .75rem; }
+                        .summary__content { height: inherit; }
+                    }
+                </style>
+            </noscript>
+        </div>
+    </div>
+</div>
+    <article class="post-test container">
+                    
+
+    <nav class="breadcrumb" data-page-breadcrumb="">
+        <ol>
+                                        <li>
+                                            <a href="https://www.frandroid.com/">Accueil</a>
+                                    </li>
+                            <li>
+                                            <a href="https://www.frandroid.com/produits">Produits</a>
+                                    </li>
+                            <li>
+                                            <a href="https://www.frandroid.com/produits/velo-electrique">Vélos électriques</a>
+                                    </li>
+                            <li>
+                                            <a href="https://www.frandroid.com/produits/velo-electrique/nakamura">Nakamura</a>
+                                    </li>
+                            <li>
+                                            <a href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus">Intersport Nakamura Crosscity Plus</a>
+                                    </li>
+                            <li>
+                                            Test                                    </li>
+                    </ol>
+    </nav>
+        <section class="article-header pt-4">
+            <div class="title-wrapper mb-4-mobile mb-5">
+                <h1 class="has-text-gradient-primary has-text-centered pl-3 pr-3 frandroid-title">
+                    <span>Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?</span>
+                </h1>
+                <p class="has-text-centered is-centered is-block has-text-gradient-primary is-size-5 is-size-5-mobile">
+                                                                        <a href="https://www.frandroid.com/test/velo-electrique/2024">
+                                Vélos électriques                                                                    •
+                                    2024                                                            </a>
+                                                            </p>
+            </div>
+        </section>
+        
+<section class="columns post-test__top">
+    <div class="column container-with-sidebar is-12-touch is-8-desktop">
+                <div class="chapo has-text-weight-semibold mb-5">
+<div>Vélo cargo électrique compact et relativement léger, le Nakamura Crosscity+ n’a certes pas les capacités d’un longtail mais propose un bon équipement et un moteur central performant.</div>
+</div>        <a href="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4" data-lightbox="">
+            <figure class="is-radiused">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?webp=1&amp;key=de7094a4 1200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?webp=1&amp;resize=928,618&amp;key=de7094a4 928w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?webp=1&amp;resize=768,512&amp;key=de7094a4 768w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?webp=1&amp;resize=480,320&amp;key=de7094a4 480w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?webp=1&amp;resize=600,400&amp;key=bad20439 600w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg?webp=1&amp;key=634e66ce 2400w" type="image/webp"><img decoding="async" width="1200" height="800" loading="lazy" alt="Source : M. Lauraux pour Frandroid" title="Source : M. Lauraux pour Frandroid" class="placeholder-default" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4 1200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=928,618&amp;key=de7094a4 928w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=768,512&amp;key=de7094a4 768w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=480,320&amp;key=de7094a4 480w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=600,400&amp;key=bad20439 600w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg?key=634e66ce 2400w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4 1200w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=928,618&amp;key=de7094a4 928w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=768,512&amp;key=de7094a4 768w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=480,320&amp;key=de7094a4 480w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=600,400&amp;key=bad20439 600w, https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg?key=634e66ce 2400w"></picture><noscript><img decoding="async" width="1200" height="800" loading="lazy" alt="Source : M. Lauraux pour Frandroid" title="Source : M. Lauraux pour Frandroid" class="placeholder-default" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?key=de7094a4 1200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=928,618&key=de7094a4 928w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=768,512&key=de7094a4 768w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-1200x800.jpg?resize=480,320&key=de7094a4 480w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=600,400&key=bad20439 600w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg?key=634e66ce 2400w"/></noscript>                <figcaption>Source : M. Lauraux pour Frandroid</figcaption>
+            </figure>
+        </a>
+        <section class="post-header">
+            <div class="columns">
+                <div class="column container-with-sidebar">
+                    <div class="optid-no-ads">
+    <div class="product-prices__title mt-5 has-text-centered-mobile has-text-weight-semibold">
+    <a href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus" class="product-resume__prices-title__product-name has-text-weight-bold">
+    Intersport Nakamura Crosscity Plus    </a>
+        au meilleur prix
+    </div>
+            <p class="has-text-weight-semibold has-text-centered has-text-body-lightest">Il n’y a pas d’offres pour le moment, découvrez</p>
+        <ul>
+                            <li class="product-row__wrapper stretched-link-container">
+    <div class="product-row">
+        <div class="product-row__left">
+            <div class="product-row__cover">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;resize=150,150&amp;key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;resize=75,75&amp;key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;key=c0a31733 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Yuba-Boda-Boda-Frandroid-2025" title="Yuba-Boda-Boda-Frandroid-2025" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&amp;key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&amp;key=c0a31733 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Yuba-Boda-Boda-Frandroid-2025" title="Yuba-Boda-Boda-Frandroid-2025" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&key=c0a31733" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w"/></noscript>            </div>
+            <a href="https://www.frandroid.com/produits/velo-electrique/yuba/2753539-yuba-boda-boda" class="has-text-weight-semibold has-text-body is-align-items-center is-mobile stretched-link">
+                <span>Yuba Boda Boda</span>
+            </a>
+        </div>
+        <div class="product-row__right">
+                            <a href="https://bestengine.humanoid.fr/track/6305533/yuba-boda-boda_upway-reconditionne" target="_blank" rel="nofollow" class="button fr-button price-button fr-button--gradient-orange has-text-centered stretched-link-above nowrap" data-gtm="{&quot;nom_marchand&quot;:&quot;upway-reconditionne&quot;,&quot;nom_produit&quot;:&quot;yuba-boda-boda&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:1,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6305533\/yuba-boda-boda_upway-reconditionne&quot;,&quot;module_produit&quot;:&quot;price_table_alternative&quot;,&quot;zone&quot;:&quot;haut-de-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:15315,&quot;prix_produit&quot;:2199,&quot;bloc_offers_count&quot;:1}">
+                                            <span class="has-text-weight-bold"><span class="price-styled">2&nbsp;199<span class="price-decimal">&nbsp;€</span></span></span>
+                                    </a>
+                                        <div class="product-card__test is-align-content-center">
+                    
+<a href="https://www.frandroid.com/survoltes/velo-electrique/2730375_yuba-boda-boda-un-velo-cargo-sauf-dans-la-conduite" class="fr-button--two-parts is-size-6 has-text-weight-semibold p-0 stretched-link-above">
+            <span class="product-card__rate">8/10</span>
+        <span class="nowrap">Lire le test</span>
+</a>
+                </div>
+                    </div>
+    </div>
+</li>
+                            <li class="product-row__wrapper stretched-link-container">
+    <div class="product-row">
+        <div class="product-row__left">
+            <div class="product-row__cover">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?webp=1&amp;resize=75,75&amp;key=654d6ca0 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?webp=1&amp;resize=150,150&amp;key=703ea086 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?webp=1&amp;key=703ea086 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Decathlon-LD-920-E-Frandroid-2023" title="Decathlon-LD-920-E-Frandroid-2023" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?resize=75,75&amp;key=654d6ca0 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?key=703ea086 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?resize=75,75&amp;key=654d6ca0 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?key=703ea086 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Decathlon-LD-920-E-Frandroid-2023" title="Decathlon-LD-920-E-Frandroid-2023" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&key=703ea086" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?resize=75,75&key=654d6ca0 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&key=703ea086 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?key=703ea086 300w"/></noscript>            </div>
+            <a href="https://www.frandroid.com/produits/velo-electrique/decathlon/1792379-decathlon-ld-920-e" class="has-text-weight-semibold has-text-body is-align-items-center is-mobile stretched-link">
+                <span>Decathlon LD 920 E</span>
+            </a>
+        </div>
+        <div class="product-row__right">
+                            <a href="https://bestengine.humanoid.fr/track/6000177/decathlon-ld-920-e_decathlon" target="_blank" rel="nofollow" class="button fr-button price-button fr-button--gradient-orange has-text-centered stretched-link-above nowrap" data-gtm="{&quot;nom_marchand&quot;:&quot;decathlon&quot;,&quot;nom_produit&quot;:&quot;decathlon-ld-920-e&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:2,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6000177\/decathlon-ld-920-e_decathlon&quot;,&quot;module_produit&quot;:&quot;price_table_alternative&quot;,&quot;zone&quot;:&quot;haut-de-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:12123,&quot;prix_produit&quot;:2499,&quot;bloc_offers_count&quot;:1}">
+                                            <span class="has-text-weight-bold"><span class="price-styled">2&nbsp;499<span class="price-decimal">&nbsp;€</span></span></span>
+                                    </a>
+                                        <div class="product-card__test is-align-content-center">
+                    
+<a href="https://www.frandroid.com/marques/decathlon/1808447_test-du-decathlon-ld-920-e-un-velo-electrique-tout-simplement-genial" class="fr-button--two-parts is-size-6 has-text-weight-semibold p-0 stretched-link-above">
+            <span class="product-card__rate">9/10</span>
+        <span class="nowrap">Lire le test</span>
+</a>
+                </div>
+                    </div>
+    </div>
+</li>
+                            <li class="product-row__wrapper stretched-link-container">
+    <div class="product-row">
+        <div class="product-row__left">
+            <div class="product-row__cover">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?webp=1&amp;resize=75,75&amp;key=9bf4db28 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?webp=1&amp;resize=150,150&amp;key=e677975f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?webp=1&amp;key=e677975f 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Cowboy-Cross-Frandroid-2024" title="Cowboy-Cross-Frandroid-2024" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?resize=75,75&amp;key=9bf4db28 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?key=e677975f 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?resize=75,75&amp;key=9bf4db28 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?key=e677975f 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Cowboy-Cross-Frandroid-2024" title="Cowboy-Cross-Frandroid-2024" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&key=e677975f" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?resize=75,75&key=9bf4db28 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&key=e677975f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?key=e677975f 300w"/></noscript>            </div>
+            <a href="https://www.frandroid.com/produits/velo-electrique/cowboy/1973248-cowboy-cross" class="has-text-weight-semibold has-text-body is-align-items-center is-mobile stretched-link">
+                <span>Cowboy Cross</span>
+            </a>
+        </div>
+        <div class="product-row__right">
+                            <a href="https://bestengine.humanoid.fr/track/6065867/cowboy-cross_cowboy" target="_blank" rel="nofollow" class="button fr-button price-button fr-button--gradient-orange has-text-centered stretched-link-above nowrap" data-gtm="{&quot;nom_marchand&quot;:&quot;cowboy&quot;,&quot;nom_produit&quot;:&quot;cowboy-cross&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:3,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6065867\/cowboy-cross_cowboy&quot;,&quot;module_produit&quot;:&quot;price_table_alternative&quot;,&quot;zone&quot;:&quot;haut-de-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:12815,&quot;prix_produit&quot;:3499,&quot;bloc_offers_count&quot;:1}">
+                                            <span class="has-text-weight-bold"><span class="price-styled">3&nbsp;499<span class="price-decimal">&nbsp;€</span></span></span>
+                                    </a>
+                                        <div class="product-card__test is-align-content-center">
+                    
+<a href="https://www.frandroid.com/marques/cowboy/2571067_on-a-roule-plus-de-100-km-au-guidon-du-nouveau-cowboy-cross-un-velo-electrique-ultra-confortable-a-lautonomie-xxl" class="fr-button--two-parts is-size-6 has-text-weight-semibold p-0 stretched-link-above">
+            <span class="product-card__rate">9/10</span>
+        <span class="nowrap">Lire le test</span>
+</a>
+                </div>
+                    </div>
+    </div>
+</li>
+                    </ul>
+    
+
+</div>
+                                                                                <h2 class="last-title has-text-link has-text-centered">
+                                                <span>Notre avis complet</span><br>
+                                                <span class="has-text-weight-medium is-size-5 is-size-6-mobile">
+                            Intersport Nakamura Crosscity Plus                        </span>
+                    </h2>
+                </div>
+            </div>
+        </section>
+    </div>
+    
+    <div class="column is-4-desktop is-hidden-touch">
+        <div class="sidebar">
+            <div class="sidebar-content-container ">
+    <div class="sticky-content">
+    <div class="is-gastric-kingfisher is-gastric-kingfisherh max-[768px]:hidden is-hidden-mobile"><div class="HalfpageAd_1" style="display:none" id="optidigital-adslot-HalfpageAd_1"></div></div>
+        </div>
+</div>
+        </div>
+    </div>
+    
+</section>
+        <section>
+            <div class="mb-4">
+                    
+
+    <nav class="breadcrumb" data-page-breadcrumb="">
+        <ol>
+                                        <li>
+                                            <a href="https://www.frandroid.com/test">Tests</a>
+                                    </li>
+                            <li>
+                                            <a href="https://www.frandroid.com/test/velo-electrique">Vélos électriques</a>
+                                    </li>
+                            <li>
+                                            <a href="https://www.frandroid.com/produits/nakamura">Nakamura</a>
+                                    </li>
+                            <li>
+                                            Intersport Nakamura Crosscity Plus                                    </li>
+                    </ol>
+    </nav>
+            </div>
+            <div class="columns has-text-centered-mobile mb-0-mobile is-vcentered ">
+                <div class="column nowrap">
+                    <i class="icon icon-clock article-header__time-icon"></i>&nbsp;
+<time class="updated article-header__time" datetime="2026-05-01T18:01:00+02:00" pubdate="pubdate">
+    <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 18:01</time>
+                </div>
+                                <div class="column has-text-right-tablet has-text-centered-mobile nowrap pb-0-mobile">
+                    <div class="share" data-share-api-url="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" data-share-api-title="Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?">
+    <span class="is-uppercase is-size-6 is-hidden-mobile">Partager</span>
+            <a title="Partager sur Facebook" data-placement="header" data-share="facebook" rel="noopener" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" aria-label="Facebook" class="color-facebook is-hidden-js">
+            <i class="icon-facebook"></i>
+        </a>
+        <span title="Partager sur Facebook" data-share-url="aHR0cHM6Ly93d3cuZmFjZWJvb2suY29tL3NoYXJlci9zaGFyZXIucGhwP3U9aHR0cHM6Ly93d3cuZnJhbmRyb2lkLmNvbS9tYXJxdWVzL25ha2FtdXJhLzMwODQwNDlfdGVzdC1uYWthbXVyYS1jcm9zc2NpdHktbGEtbWVpbGxldXJlLWFmZmFpcmUtZHUtbW9tZW50LXBvdXItdHJhbnNwb3J0ZXItdm9zLWVuZmFudHMtYS12ZWxvLWNhcmdvLWVsZWN0cmlxdWU=" data-share="facebook" data-placement="header" class="color-facebook is-hidden-no-js">
+                    <i class="icon-facebook"></i>
+                </span>
+            <a title="Partager sur X" data-placement="header" data-share="x" rel="noopener" target="_blank" href="https://www.twitter.com/share?url=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique&amp;text=Test%20Nakamura%20Crosscity%2B%20%3A%20la%20meilleure%20affaire%20du%20moment%20pour%20transporter%20vos%20enfants%20%C3%A0%20v%C3%A9lo%20cargo%20%C3%A9lectrique%20%3F%20@Frandroid" aria-label="X" class="color-x is-hidden-js">
+            <i class="icon-x"></i>
+        </a>
+        <span title="Partager sur X" data-share-url="aHR0cHM6Ly93d3cudHdpdHRlci5jb20vc2hhcmU/dXJsPWh0dHBzOi8vd3d3LmZyYW5kcm9pZC5jb20vbWFycXVlcy9uYWthbXVyYS8zMDg0MDQ5X3Rlc3QtbmFrYW11cmEtY3Jvc3NjaXR5LWxhLW1laWxsZXVyZS1hZmZhaXJlLWR1LW1vbWVudC1wb3VyLXRyYW5zcG9ydGVyLXZvcy1lbmZhbnRzLWEtdmVsby1jYXJnby1lbGVjdHJpcXVlJnRleHQ9VGVzdCUyME5ha2FtdXJhJTIwQ3Jvc3NjaXR5JTJCJTIwJTNBJTIwbGElMjBtZWlsbGV1cmUlMjBhZmZhaXJlJTIwZHUlMjBtb21lbnQlMjBwb3VyJTIwdHJhbnNwb3J0ZXIlMjB2b3MlMjBlbmZhbnRzJTIwJUMzJUEwJTIwdiVDMyVBOWxvJTIwY2FyZ28lMjAlQzMlQTlsZWN0cmlxdWUlMjAlM0YlMjBARnJhbmRyb2lk" data-share="x" data-placement="header" class="color-x is-hidden-no-js">
+                    <i class="icon-x"></i>
+                </span>
+            <a title="Partager sur Linkedin" data-placement="header" data-share="linkedin" rel="noopener" target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" aria-label="Linkedin" class="color-linkedin is-hidden-js">
+            <i class="icon-linkedin"></i>
+        </a>
+        <span title="Partager sur Linkedin" data-share-url="aHR0cHM6Ly93d3cubGlua2VkaW4uY29tL3NoYXJlQXJ0aWNsZT9taW5pPXRydWUmdXJsPWh0dHBzOi8vd3d3LmZyYW5kcm9pZC5jb20vbWFycXVlcy9uYWthbXVyYS8zMDg0MDQ5X3Rlc3QtbmFrYW11cmEtY3Jvc3NjaXR5LWxhLW1laWxsZXVyZS1hZmZhaXJlLWR1LW1vbWVudC1wb3VyLXRyYW5zcG9ydGVyLXZvcy1lbmZhbnRzLWEtdmVsby1jYXJnby1lbGVjdHJpcXVl" data-share="linkedin" data-placement="header" class="color-linkedin is-hidden-no-js">
+                    <i class="icon-linkedin"></i>
+                </span>
+            <a title="Partager sur Reddit" data-placement="header" data-share="reddit" rel="noopener" target="_blank" href="https://www.reddit.com/submit?url=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique&amp;title=Test%20Nakamura%20Crosscity%2B%20%3A%20la%20meilleure%20affaire%20du%20moment%20pour%20transporter%20vos%20enfants%20%C3%A0%20v%C3%A9lo%20cargo%20%C3%A9lectrique%20%3F%20" aria-label="Reddit" class="color-reddit is-hidden-js">
+            <i class="icon-reddit"></i>
+        </a>
+        <span title="Partager sur Reddit" data-share-url="aHR0cHM6Ly93d3cucmVkZGl0LmNvbS9zdWJtaXQ/dXJsPWh0dHBzOi8vd3d3LmZyYW5kcm9pZC5jb20vbWFycXVlcy9uYWthbXVyYS8zMDg0MDQ5X3Rlc3QtbmFrYW11cmEtY3Jvc3NjaXR5LWxhLW1laWxsZXVyZS1hZmZhaXJlLWR1LW1vbWVudC1wb3VyLXRyYW5zcG9ydGVyLXZvcy1lbmZhbnRzLWEtdmVsby1jYXJnby1lbGVjdHJpcXVlJnRpdGxlPVRlc3QlMjBOYWthbXVyYSUyMENyb3NzY2l0eSUyQiUyMCUzQSUyMGxhJTIwbWVpbGxldXJlJTIwYWZmYWlyZSUyMGR1JTIwbW9tZW50JTIwcG91ciUyMHRyYW5zcG9ydGVyJTIwdm9zJTIwZW5mYW50cyUyMCVDMyVBMCUyMHYlQzMlQTlsbyUyMGNhcmdvJTIwJUMzJUE5bGVjdHJpcXVlJTIwJTNGJTIw" data-share="reddit" data-placement="header" class="color-reddit is-hidden-no-js">
+                    <i class="icon-reddit"></i>
+                </span>
+    </div>
+                </div>
+            </div>
+            
+<div class="is-gastric-kingfisher is-gastric-kingfisherb mb-4 is-flex is-align-items-center is-justify-content-center max-[768px]:hidden is-hidden-mobile"><div class="Billboard_1" style="display:none" id="optidigital-adslot-Billboard_1"></div></div>
+
+        </section>
+        <section class="article-content">
+                        <div class="index-menu-wrapper with-summary with-sub-button">
+    <nav class="index-menu has-bg-sub-card expand-default">
+        <div class="index-menu__inner">
+            <input type="checkbox" id="index-menu__toggle--index-id69f55bfe0f7772.05759099" class="is-hidden index-menu__toggle">
+            <label tabindex="0" for="index-menu__toggle--index-id69f55bfe0f7772.05759099" aria-label="Sommaire" class="is-flex is-align-items-center index-menu__top">
+                <span class="index-menu__title has-text-centered has-text-weight-semibold is-uppercase">Sommaire</span>
+                <i class="icon icon-arrow-down"></i>
+            </label>
+            <div class="index-menu__content medium">
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#fiche-technique" data-type="h2">
+                        <span class="">
+                            Fiche technique                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#design-et-equipement" data-type="h2">
+                        <span class="">
+                            Design et équipement                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#ecran-et-application" data-type="h2">
+                        <span class="">
+                            Ecran et application                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#conduite" data-type="h2">
+                        <span class="">
+                            Conduite                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#autonomie-et-recharge" data-type="h2">
+                        <span class="">
+                            Autonomie et recharge                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#prix-et-disponibilite" data-type="h2">
+                        <span class="">
+                            Prix et disponibilité                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#conclusion" data-type="h2">
+                        <span class="">
+                            Conclusion                        </span>
+                    </a>
+                                    <a class="js-index-menu-item index-menu__item" href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#comments" data-type="h2">
+                        <span class="">
+                            Commentaires                        </span>
+                    </a>
+                            </div>
+        </div>
+                    <div class="index-menu__bottom has-text-centered is-flex">
+                                    <a href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus" class="button fr-button fr-button--pink has-text-weight-semibold nowrap">
+                        Voir la fiche produit <i class="icon icon-arrow-right"></i>                    </a>
+                                            </div>
+            </nav>
+</div>
+            
+
+
+
+
+<p>Le <a href="https://www.frandroid.com/guide-dachat/guides-dachat-survoltes/guides-dachat-velos-electriques/1595501_velo-cargo-electrique-notre-comparatif-des-meilleurs-modeles">vélo cargo électrique</a> est un investissement non négligeable pour la petite famille. Pour dégoter un modèle peu cher, il faut regarder chez l’occasion, ou des versions plus abordables comme le <a href="https://www.frandroid.com/marques/nakamura/2045602_intersport-son-nouveau-velo-electrique-dedie-aux-couples-et-aux-familles-impressionne-par-son-prix">Nakamura Crosscity+</a>. Intersport propose en effet une alternative au longtail classique avec un format midtail, au tarif sous les 2 200 euros.&nbsp;</p>
+
+
+
+<p>Il est ainsi 700 euros moins cher que le grand Nakamura Longtail, mais entraine-t-il des concessions ? Moteur central, charge arrière importante, 80 km d’autonomie, important équipement inclus, ce VAE “augmenté” ne semble rien oublier. Or qu’en est-il vraiment à l’usage ? Frandroid a testé dans multiples situations durant plusieurs semaines.</p>
+
+
+<span class="index" id="fiche-technique" data-title="Fiche technique" tabindex="-1"></span>
+
+<h2 class="wp-block-heading">Fiche technique</h2>
+
+
+<div class="blocks-container mb-5 mb-4-mobile mt-5"><table class="table-products table-2-columns">
+    <thead>
+    <tr>
+        <th>Modèle</th>
+                <th><a href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus">Intersport Nakamura Crosscity Plus</a></th>
+            </tr>
+    </thead>
+    <tbody>
+                    <tr>
+            <td>Vitesse max</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    25 km/h                            </td>
+                    </tr>
+                <tr>
+            <td>Puissance du moteur</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    250 watts                            </td>
+                    </tr>
+                <tr>
+            <td>Nombre d’assistances</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    4                            </td>
+                    </tr>
+                <tr>
+            <td>Autonomie annoncée</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    80 km                            </td>
+                    </tr>
+                <tr>
+            <td>Temps de recharge annoncé</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    210 min                            </td>
+                    </tr>
+                <tr>
+            <td>Batterie amovible</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Oui                            </td>
+                    </tr>
+                <tr>
+            <td>Bluetooth</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Oui                            </td>
+                    </tr>
+                <tr>
+            <td>GPS</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Non                            </td>
+                    </tr>
+                <tr>
+            <td>Écran</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Oui                            </td>
+                    </tr>
+                <tr>
+            <td>Poids</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    25 kg                            </td>
+                    </tr>
+                <tr>
+            <td>Couleur</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Blanc                            </td>
+                    </tr>
+                <tr>
+            <td>Poids maximal supporté</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    160 kg                            </td>
+                    </tr>
+                <tr>
+            <td>Phares</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Oui                            </td>
+                    </tr>
+                <tr>
+            <td>Feu arrière</td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                    Oui                            </td>
+                    </tr>
+                    <tr>
+            <td class="lead-link-wrapper">
+                                                                </td>
+                        <td data-product="Intersport Nakamura Crosscity Plus">
+                                <a class="button fr-button fr-button--pink fr-button--fullwidth has-text-centered" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus">Fiche produit</a>
+                            </td>
+                    </tr>
+    </tbody>
+</table>
+</div>
+
+<span class="index" id="design-et-equipement" data-title="Design et équipement" tabindex="-1"></span>
+
+<h2 class="wp-block-heading">Un biplace plutôt léger, qui permet un (petit) adulte</h2>
+
+
+
+<p>Le Nakamura Crosscity+ est donc un vélo cargo électrique midtail. Cet intermédiaire se voit par un allongement, entre le tube de selle et la roue arrière. Toutefois, les roues de 24 pouces compensent, de quoi conserver une longueur de 1,81 m, soit celle d’un vélo classique. </p>
+
+
+
+<p>Pas d’encombrement supplémentaire, tout en offrant plus en termes de charge : 160 kg en tout, dont 60 kg à l’arrière (ou 2 enfants) et 10 kg sur le panier avant inclus. Cela inclut aussi celui du vélo, qui est plus élevé qu’annoncé : 28,3 kg contre 25 kg. Cela reste inférieur aux <a href="https://www.frandroid.com/survoltes/velo-electrique/1751373_test-du-decathlon-r500elec-un-longtail-electrique-au-rapport-qualite-prix-imbattable">longtails classiques</a>.</p>
+
+
+
+<div class="tiled-gallery type-rectangular tiled-gallery-unresized" data-original-width="928" itemscope="" itemtype="http://schema.org/ImageGallery">
+		<div class="gallery-row" style="width: 928px; height: 149px;" data-original-width="928" data-original-height="149">
+					<div class="gallery-group images-1" style="width: 262px; height: 149px;" data-original-width="262" data-original-height="149">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-guidon.jpg" itemprop="url">
+							<meta itemprop="width" value="258">
+							<meta itemprop="height" value="145">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-guidon.jpg?resize=258,145&amp;key=36ce2aa4" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-guidon.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-guidon-768x432.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-guidon-928x522.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-guidon-300x169.jpg 300w" width="258" height="145" loading="lazy" data-original-width="258" data-original-height="145" itemprop="http://schema.org/image" title="Nakamura Crosscity+ guidon" alt="Nakamura Crosscity+ guidon" style="width: 258px; height: 145px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-1" style="width: 222px; height: 149px;" data-original-width="222" data-original-height="149">
+									<div class="tiled-gallery-item tiled-gallery-item-small" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-potence-reglable.jpg" itemprop="url">
+							<meta itemprop="width" value="218">
+							<meta itemprop="height" value="145">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-potence-reglable.jpg?resize=218,145&amp;key=451ded41" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-potence-reglable.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-potence-reglable-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-potence-reglable-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-potence-reglable-300x200.jpg 300w" width="218" height="145" loading="lazy" data-original-width="218" data-original-height="145" itemprop="http://schema.org/image" title="Nakamura Crosscity+ potence réglable" alt="Nakamura Crosscity+ potence réglable" style="width: 218px; height: 145px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-1" style="width: 222px; height: 149px;" data-original-width="222" data-original-height="149">
+									<div class="tiled-gallery-item tiled-gallery-item-small" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-repose-pied.jpg" itemprop="url">
+							<meta itemprop="width" value="218">
+							<meta itemprop="height" value="145">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-repose-pied.jpg?resize=218,145&amp;key=527dd9fe" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-repose-pied.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-repose-pied-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-repose-pied-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-repose-pied-300x200.jpg 300w" width="218" height="145" loading="lazy" data-original-width="218" data-original-height="145" itemprop="http://schema.org/image" title="Nakamura Crosscity+ repose-pied" alt="Nakamura Crosscity+ repose-pied" style="width: 218px; height: 145px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-1" style="width: 222px; height: 149px;" data-original-width="222" data-original-height="149">
+									<div class="tiled-gallery-item tiled-gallery-item-small" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin.jpg" itemprop="url">
+							<meta itemprop="width" value="218">
+							<meta itemprop="height" value="145">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin.jpg?resize=218,145&amp;key=150b45c2" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin-300x200.jpg 300w" width="218" height="145" loading="lazy" data-original-width="218" data-original-height="145" itemprop="http://schema.org/image" title="Nakamura Crosscity+ coussin" alt="Nakamura Crosscity+ coussin" style="width: 218px; height: 145px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+	</div>
+
+
+
+
+<p>Vrai biplace, le Crossity+ ne peut toutefois qu’emmener un petit adulte, qui profite des repose-pieds rétractables et de protections de roue latérales (aux fixation perfectibles). La poignée sous la selle, utile lorsque l’on doit soulever le vélo, dépanne le maintien du passager sur de courtes distances, or il faudrait un vrai mini-guidon pour les grandes balades.</p>
+
+
+
+<p>Le cadre est ouvert, ce qui permet un enjambement plus facile, avec un seuil à 45 cm du sol, qui aurait pu encore descendre en l’absence de l’imposant moteur.</p>
+
+
+
+<h3 class="wp-block-heading">A peine 16 kg tout équipé</h3>
+
+
+
+<p>La double béquille centrale est pratique, pour que tout le monde monte sans peine, mais cela manque un peu de stabilité. L’équipement ne mérite pas vraiment de critique, avec les éléments pour le passager, l’éclairage lié à la batterie – puissant, au large faisceau – et les garde-boue, que l’on aurait aimé un poil plus long à l’avant afin de protéger les pieds. Pour davantage d’accessoires, le porte-bagages est compatible avec les fixations MIK, bien vu !</p>
+
+
+
+<div class="tiled-gallery type-rectangular tiled-gallery-unresized" data-original-width="928" itemscope="" itemtype="http://schema.org/ImageGallery">
+		<div class="gallery-row" style="width: 928px; height: 414px;" data-original-width="928" data-original-height="414">
+					<div class="gallery-group images-1" style="width: 619px; height: 414px;" data-original-width="619" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-panier-avant.jpg" itemprop="url">
+							<meta itemprop="width" value="615">
+							<meta itemprop="height" value="410">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-panier-avant.jpg?resize=615,410&amp;key=a1a005df" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-panier-avant.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-panier-avant-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-panier-avant-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-panier-avant-300x200.jpg 300w" width="615" height="410" loading="lazy" data-original-width="615" data-original-height="410" itemprop="http://schema.org/image" title="Nakamura Crosscity+ panier avant" alt="Nakamura Crosscity+ panier avant" style="width: 615px; height: 410px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-2" style="width: 309px; height: 414px;" data-original-width="309" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-avant.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-avant.jpg?resize=305,203&amp;key=a2e4d161" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-avant.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-avant-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-avant-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-avant-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ éclairage avant" alt="Nakamura Crosscity+ éclairage avant" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-bequille.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-bequille.jpg?resize=305,203&amp;key=52b2a537" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-bequille.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-bequille-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-bequille-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-bequille-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ béquille" alt="Nakamura Crosscity+ béquille" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+		<div class="gallery-row" style="width: 928px; height: 414px;" data-original-width="928" data-original-height="414">
+					<div class="gallery-group images-1" style="width: 619px; height: 414px;" data-original-width="619" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-jupes-laterales.jpg" itemprop="url">
+							<meta itemprop="width" value="615">
+							<meta itemprop="height" value="410">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-jupes-laterales.jpg?resize=615,410&amp;key=575a868a" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-jupes-laterales.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-jupes-laterales-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-jupes-laterales-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-jupes-laterales-300x200.jpg 300w" width="615" height="410" loading="lazy" data-original-width="615" data-original-height="410" itemprop="http://schema.org/image" title="Nakamura Crosscity+ jupes latérales" alt="Nakamura Crosscity+ jupes latérales" style="width: 615px; height: 410px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-2" style="width: 309px; height: 414px;" data-original-width="309" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin.jpg?resize=305,203&amp;key=150b45c2" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-coussin-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ coussin" alt="Nakamura Crosscity+ coussin" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-arriere.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-arriere.jpg?resize=305,203&amp;key=0b36b319" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-arriere.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-arriere-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-arriere-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-eclairage-arriere-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ éclairage arrière" alt="Nakamura Crosscity+ éclairage arrière" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+	</div>
+
+
+
+<span class="index" id="ecran-et-application" data-title="Ecran et application" tabindex="-1"></span>
+
+<h2 class="wp-block-heading">Un petit écran couleur et une appli en renfort</h2>
+
+
+
+<p>L’écran du Nakamura Crosscity+ n’est pas inconnu, puisqu’il est présent sur d’autres modèles de la marque. Il est certes petit en diagonale, or en couleur, bien rétroéclairé, avec une parfaite lisibilité de nuit comme en plein soleil.</p>
+
+
+
+<div class="tiled-gallery type-rectangular tiled-gallery-unresized" data-original-width="928" itemscope="" itemtype="http://schema.org/ImageGallery">
+		<div class="gallery-row" style="width: 928px; height: 414px;" data-original-width="928" data-original-height="414">
+					<div class="gallery-group images-1" style="width: 619px; height: 414px;" data-original-width="619" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran.jpg" itemprop="url">
+							<meta itemprop="width" value="615">
+							<meta itemprop="height" value="410">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran.jpg?resize=615,410&amp;key=c7a753e3" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-300x200.jpg 300w" width="615" height="410" loading="lazy" data-original-width="615" data-original-height="410" itemprop="http://schema.org/image" title="Nakamura Crosscity+ écran" alt="Nakamura Crosscity+ écran" style="width: 615px; height: 410px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-2" style="width: 309px; height: 414px;" data-original-width="309" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-infos.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-infos.jpg?resize=305,203&amp;key=38e1028f" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-infos.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-infos-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-infos-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-infos-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ écran infos" alt="Nakamura Crosscity+ écran infos" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-reglages.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-reglages.jpg?resize=305,203&amp;key=77944b08" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-reglages.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-reglages-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-reglages-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-reglages-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ écran réglages" alt="Nakamura Crosscity+ écran réglages" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+		<div class="gallery-row" style="width: 928px; height: 928px;" data-original-width="928" data-original-height="928">
+					<div class="gallery-group images-1" style="width: 928px; height: 928px;" data-original-width="928" data-original-height="928">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite.jpg" itemprop="url">
+							<meta itemprop="width" value="924">
+							<meta itemprop="height" value="924">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite.jpg?resize=924,924,1&amp;key=4cb1e628" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite-60x60.jpg 60w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite-768x768.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite-928x928.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-ecran-conduite-300x300.jpg 300w" width="924" height="924" loading="lazy" data-original-width="924" data-original-height="924" itemprop="http://schema.org/image" title="Nakamura Crosscity+ écran conduite" alt="Nakamura Crosscity+ écran conduite" style="width: 924px; height: 924px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+	</div>
+
+
+
+
+<p>C’est peut être moins le cas de la petite information en bas d’affichage, qui défile à l’aide du petit bouton gauche (au passage trop petit lorsque l’on a des gants, au contraire de ceux des modes bien positionnés et larges). </p>
+
+
+
+<p>On y lit les kilométrages, durée, vitesse max ou moyenne, puissance humaine/moteur, les consommation et vitesse moyenne/max. Un menu permet de changer le nombre élevé de données, tout comme de consulter la santé de la batterie ou de changer le mode auto de l’assistance.</p>
+
+
+
+<div class="tiled-gallery type-rectangular tiled-gallery-unresized" data-original-width="928" itemscope="" itemtype="http://schema.org/ImageGallery">
+		<div class="gallery-row" style="width: 928px; height: 638px;" data-original-width="928" data-original-height="638">
+					<div class="gallery-group images-1" style="width: 309px; height: 638px;" data-original-width="309" data-original-height="638">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="634">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats.jpg?resize=305,634&amp;key=2f780228" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats.jpg 1440w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats-819x1700.jpg 819w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats-768x1594.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats-740x1536.jpg 740w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats-987x2048.jpg 987w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats-928x1926.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-stats-300x623.jpg 300w" width="305" height="634" loading="lazy" data-original-width="305" data-original-height="634" itemprop="http://schema.org/image" title="Nakamura Crosscity+ appli stats" alt="Nakamura Crosscity+ appli stats" style="width: 305px; height: 634px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-1" style="width: 309px; height: 638px;" data-original-width="309" data-original-height="638">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="634">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1.jpg?resize=305,634&amp;key=3dd29e90" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1.jpg 1440w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1-819x1700.jpg 819w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1-768x1594.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1-740x1536.jpg 740w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1-987x2048.jpg 987w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1-928x1926.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-conduite-1-300x623.jpg 300w" width="305" height="634" loading="lazy" data-original-width="305" data-original-height="634" itemprop="http://schema.org/image" title="Nakamura Crosscity+ appli conduite" alt="Nakamura Crosscity+ appli conduite" style="width: 305px; height: 634px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-1" style="width: 310px; height: 638px;" data-original-width="310" data-original-height="638">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets.jpg" itemprop="url">
+							<meta itemprop="width" value="306">
+							<meta itemprop="height" value="634">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets.jpg?resize=306,634&amp;key=b350705a" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets.jpg 1440w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets-820x1700.jpg 820w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets-768x1593.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets-741x1536.jpg 741w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets-988x2048.jpg 988w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets-928x1924.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-appli-trajets-300x622.jpg 300w" width="306" height="634" loading="lazy" data-original-width="306" data-original-height="634" itemprop="http://schema.org/image" title="Nakamura Crosscity+ appli trajets" alt="Nakamura Crosscity+ appli trajets" style="width: 306px; height: 634px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+	</div>
+
+
+
+
+<p>L’application Naka E-Power apporte un complément bienvenue à la jauge de batterie floue, grâce au pourcentage. Elle inclut aussi l’enregistrement des trajets (non automatique), durant lequel un compteur aux plusieurs données souligne la carte, et aux quelques statistiques dans le bilan.</p>
+
+
+<span class="index" id="conduite" data-title="Conduite" tabindex="-1"></span>
+
+<h2 class="wp-block-heading">Un moteur central performant</h2>
+
+
+
+<p>Pour pousser la petite famille, le Nakamura Crosscity+ s’équipe d’un moteur central. Le Naka E-Power One n’est pas aussi coupleux que le “Max” présent sur&nbsp;le <a href="https://www.frandroid.com/produits/velo-electrique/nakamura/1894615-nakamura-crossover-longtail" data-type="electric-bike" data-id="1894615">Crossover Longtail</a> (70 vs 100 Nm), mais il assure de belles performances. Rien qu’en mode intermédiaire “Sport”, il suffit sur le plat et les pentes modérées, du moins seul au guidon. Pour les gros dénivelés, le mode maximal Boost est nécessaire, ainsi qu’à deux.</p>
+
+
+
+<figure class="wp-block-image size-large"><a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-moteur.jpg" target="_blank" class="article-content__figure"><img loading="eager" decoding="async" width="1200" height="800" src="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-moteur-1200x800.jpg" alt="Nakamura Crosscity+ moteur" class="wp-image-3084231 wp-image" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-moteur-1200x800.jpg 1200w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-moteur-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-moteur-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-moteur-300x200.jpg 300w" sizes="(max-width: 1200px) 100vw, 1200px"></a><figcaption class="wp-element-caption">Source : M. Lauraux pour Frandroid</figcaption></figure>
+
+
+
+<p>Nous avons testé avec un passager de 60 kg, l’assistance reste douce au démarrage pour ne pas brusquer au premier coup de pédale, et soutenue ailleurs. Sans bruit notable, elle est surtout très naturelle avec un bon capteur de couple. Dommage que la transmission par dérailleur Shimano Altus 8 vitesses – polyvalent donc – se dérègle souvent, de quoi sauter les vitesses.</p>
+
+
+
+<h3 class="wp-block-heading">Bonne stabilité, mais un confort perfectible à deux</h3>
+
+
+
+<p>Le passager est cependant un peu brusqué côté confort, car ressent toutes les imperfections de la route type dos-d’ânes, sauts de trottoirs ou trous dans la chaussée. La stabilité est assez bonne, mais un modèle plus rigide fait mieux (exemple : <a href="https://www.frandroid.com/survoltes/velo-electrique/2773811_ultra-compact-pour-un-biplace-le-nouveau-velo-electrique-de-yuba-impressionne-par-son-gabarit">Yuba Mini Boda Boda</a>), ou vrai longtail fait mieux.</p>
+
+
+
+<div class="tiled-gallery type-rectangular tiled-gallery-unresized" data-original-width="928" itemscope="" itemtype="http://schema.org/ImageGallery">
+		<div class="gallery-row" style="width: 928px; height: 414px;" data-original-width="928" data-original-height="414">
+					<div class="gallery-group images-1" style="width: 619px; height: 414px;" data-original-width="619" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-pneus.jpg" itemprop="url">
+							<meta itemprop="width" value="615">
+							<meta itemprop="height" value="410">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-pneus.jpg?resize=615,410&amp;key=e8891d91" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-pneus.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-pneus-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-pneus-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-pneus-300x200.jpg 300w" width="615" height="410" loading="lazy" data-original-width="615" data-original-height="410" itemprop="http://schema.org/image" title="Nakamura Crosscity+ pneus" alt="Nakamura Crosscity+ pneus" style="width: 615px; height: 410px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-2" style="width: 309px; height: 414px;" data-original-width="309" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-fourche-garde-boue.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-fourche-garde-boue.jpg?resize=305,203&amp;key=3e9c0d55" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-fourche-garde-boue.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-fourche-garde-boue-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-fourche-garde-boue-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-fourche-garde-boue-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ fourche garde-boue" alt="Nakamura Crosscity+ fourche garde-boue" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-freins.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-freins.jpg?resize=305,203&amp;key=722284f8" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-freins.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-freins-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-freins-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-freins-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ freins" alt="Nakamura Crosscity+ freins" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+		<div class="gallery-row" style="width: 928px; height: 620px;" data-original-width="928" data-original-height="620">
+					<div class="gallery-group images-1" style="width: 928px; height: 620px;" data-original-width="928" data-original-height="620">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-velo-biplace.jpg" itemprop="url">
+							<meta itemprop="width" value="924">
+							<meta itemprop="height" value="616">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-velo-biplace.jpg?resize=924,616&amp;key=c6fe266f" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-velo-biplace.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-velo-biplace-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-velo-biplace-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-velo-biplace-300x200.jpg 300w" width="924" height="616" loading="lazy" data-original-width="924" data-original-height="616" itemprop="http://schema.org/image" title="Nakamura Crosscity+ vélo biplace" alt="Nakamura Crosscity+ vélo biplace" style="width: 924px; height: 616px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+	</div>
+
+
+
+
+<p>Rigide avec des roues aux pneus larges (2,4 pouces), le vélo cargo électrique reste sympathique seul, avec sa position de conduite passive, avec son assise généreuse aux ressorts intégrés. Ses freins hydrauliques à disque Tektro sont également performants, de quoi s’immobiliser en environ 3 mètres à 25 km/h (sans passager).</p>
+
+
+<span class="index" id="autonomie-et-recharge" data-title="Autonomie et recharge" tabindex="-1"></span>
+
+<h2 class="wp-block-heading">Une virée de 50 km à deux</h2>
+
+
+
+<p>Pour conserver un poids abordable, le Nakamura Crossity+ n’abuse pas sur la batterie. Sa capacité de 504 Wh autorise 80 km d’autonomie selon la marque, probablement en mode minimal (Eco). Nos mesures diffèrent selon la situation. On note une consommation supérieure à 10 Wh/km par 10°C sous la pluie avec un passager de 60 kg en mode Smart (soit moins de 50 km d’autonomie), et environ 60 km en mode maximal Boost en étant seul par 12°C. </p>
+
+
+
+<p>Le mode Smart seul grimpe à 75 km avec une température plus douce, voire 89 km à 20°C en mode intermédiaire Sport.</p>
+
+
+
+<figure class="wp-block-image size-large"><a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-autonomie.jpg" target="_blank" class="article-content__figure"><img loading="lazy" decoding="async" width="1200" height="800" src="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-autonomie-1200x800.jpg" alt="Nakamura Crosscity+ autonomie" class="wp-image-3084261 wp-image" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-autonomie-1200x800.jpg 1200w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-autonomie-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-autonomie-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-autonomie-300x200.jpg 300w" sizes="auto, (max-width: 1200px) 100vw, 1200px"></a><figcaption class="wp-element-caption">Source : M. Lauraux pour Frandroid</figcaption></figure>
+
+
+
+<p>Comme nous le disions, la jauge de l’écran est plutôt floue, car sans barre, mais il est possible d’afficher l’autonomie théorique estimée (qui évolue selon l’utilisation, et non le mode engagé). L’application indique le pourcentage pour davantage de précision. En recharge, on peut également vérifier le niveau de batterie sur les deux moyens, donc pratique.</p>
+
+
+
+<div class="tiled-gallery type-rectangular tiled-gallery-unresized" data-original-width="928" itemscope="" itemtype="http://schema.org/ImageGallery">
+		<div class="gallery-row" style="width: 928px; height: 414px;" data-original-width="928" data-original-height="414">
+					<div class="gallery-group images-1" style="width: 619px; height: 414px;" data-original-width="619" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-velo.jpg" itemprop="url">
+							<meta itemprop="width" value="615">
+							<meta itemprop="height" value="410">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-velo.jpg?resize=615,410&amp;key=4cb35234" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-velo.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-velo-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-velo-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-velo-300x200.jpg 300w" width="615" height="410" loading="lazy" data-original-width="615" data-original-height="410" itemprop="http://schema.org/image" title="Nakamura Crosscity+ recharge vélo" alt="Nakamura Crosscity+ recharge vélo" style="width: 615px; height: 410px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+					<div class="gallery-group images-2" style="width: 309px; height: 414px;" data-original-width="309" data-original-height="414">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-batterie-amovible.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-batterie-amovible.jpg?resize=305,203&amp;key=bf9c5267" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-batterie-amovible.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-batterie-amovible-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-batterie-amovible-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-batterie-amovible-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ batterie amovible" alt="Nakamura Crosscity+ batterie amovible" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-chargeur.jpg" itemprop="url">
+							<meta itemprop="width" value="305">
+							<meta itemprop="height" value="203">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-chargeur.jpg?resize=305,203&amp;key=3d061999" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-chargeur.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-chargeur-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-chargeur-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-chargeur-300x200.jpg 300w" width="305" height="203" loading="lazy" data-original-width="305" data-original-height="203" itemprop="http://schema.org/image" title="Nakamura Crosscity+ chargeur" alt="Nakamura Crosscity+ chargeur" style="width: 305px; height: 203px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+		<div class="gallery-row" style="width: 928px; height: 620px;" data-original-width="928" data-original-height="620">
+					<div class="gallery-group images-1" style="width: 928px; height: 620px;" data-original-width="928" data-original-height="620">
+									<div class="tiled-gallery-item tiled-gallery-item-large" itemprop="associatedMedia" itemscope="" itemtype="http://schema.org/ImageObject">
+						<a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-batterie.jpg" itemprop="url">
+							<meta itemprop="width" value="924">
+							<meta itemprop="height" value="616">
+							<img class="wp-image" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-batterie.jpg?resize=924,616&amp;key=e109db3f" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-batterie.jpg 1920w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-batterie-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-batterie-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-recharge-batterie-300x200.jpg 300w" width="924" height="616" loading="lazy" data-original-width="924" data-original-height="616" itemprop="http://schema.org/image" title="Nakamura Crosscity+ recharge batterie" alt="Nakamura Crosscity+ recharge batterie" style="width: 924px; height: 616px;">
+						</a>
+													<div class="tiled-gallery-caption" itemprop="caption description">
+								Source : M. Lauraux pour Frandroid							</div>
+											</div>
+							</div> 
+				</div> 
+	</div>
+
+
+
+
+<p>Mieux, le chargeur livré est rapide, car d’intensité 4 A (ou 168 W de puissance). En raison de la capacité de 14 Ah, il suffit d’1h30 pour retrouver la moitié de l’énergie, et 3h30 pour une recharge totale. Attention, le chargeur est assez encombrant, mais chauffe sans excès.</p>
+
+
+<span class="index" id="prix-et-disponibilite" data-title="Prix et disponibilité" tabindex="-1"></span>
+
+<h2 class="wp-block-heading">Tarif très accessible et assemblage en France</h2>
+
+
+
+<p>Le Nakamura Crosscity+ est disponible depuis le début d’année 2025, autant sur le site officiel que dans les magasins Intersport. Il est au prix de <a href="https://www.intersport.fr/blanc-vtc_electrique_adulte_crosscity__-nakamura-p-YF60W5~09N/" target="_blank" rel="noreferrer noopener">2 199,99 euros hors promotion</a>, en incluant les équipements visibles sur le vélo électrique, sauf l’antivol pliant Abus. A noter, il n’existe que dans une taille unique et le coloris blanc.</p>
+
+
+
+<figure class="wp-block-image size-large"><a href="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-prix.jpg" target="_blank" class="article-content__figure"><img loading="lazy" decoding="async" width="1200" height="800" src="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-prix-1200x800.jpg" alt="Nakamura Crosscity+ prix" class="wp-image-3084239 wp-image" srcset="https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-prix-1200x800.jpg 1200w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-prix-768x512.jpg 768w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-prix-928x619.jpg 928w, https://images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-prix-300x200.jpg 300w" sizes="auto, (max-width: 1200px) 100vw, 1200px"></a><figcaption class="wp-element-caption">Source : M. Lauraux pour Frandroid</figcaption></figure>
+
+
+
+<p>À l’instar des autres VAE Intersport Nakamura, le Crosscity+ dispose d’un cadre et d’une fourche garantis à vie. L’assistance possède cependant une garantie classique de 2 ans, tandis que le vélo électrique est assemblé en France dans l’<a href="https://www.frandroid.com/marques/nakamura/3047809_on-a-visite-la-plus-grande-usine-velo-de-france-100-000-velos-dans-un-entrepot-xxl-et-intersport-aux-commandes">usine MFC de Machecoul </a>(Loire-Atlantique).</p>
+        </section>
+        <section class="after-content">
+                            <section id="product-similar" class="pb-4 mt-5">
+                    <h2 class="has-text-link m-0">Produits alternatifs<br>
+                        <span class="has-text-weight-semibold is-size-5 is-size-6-mobile">
+                        Intersport Nakamura Crosscity Plus                    </span>
+                    </h2>
+                    <div class="mt-4 mb-4-mobile product-list-container">
+    <div class="columns is-multiline is-centered product-list">
+                                    <div class="column is-4">
+                                <div class="product-card product-card--vertical product-card--in-article ">
+    <div class="product-card__cover is-relative">
+            <div class="badge badge--top-left badge--inner-top-left has-bg-gradient-orange is-size-5-mobile">
+            <span class="has-text-body is-dark is-flex is-align-items-center">
+                8 <span class="badge__rank-total">/10</span>
+            </span>
+        </div>
+            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?webp=1&amp;resize=150,150&amp;key=b4ba9cb3 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?webp=1&amp;resize=75,75&amp;key=b4ba9cb3 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?webp=1&amp;key=b4ba9cb3 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Velo-de-Ville-Loady-Frandroid-2026" title="Velo-de-Ville-Loady-Frandroid-2026" class="product-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=150,150&amp;key=b4ba9cb3" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=150,150&amp;key=b4ba9cb3" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=150,150&amp;key=b4ba9cb3 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=75,75&amp;key=b4ba9cb3 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?key=b4ba9cb3 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=150,150&amp;key=b4ba9cb3 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=75,75&amp;key=b4ba9cb3 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?key=b4ba9cb3 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Velo-de-Ville-Loady-Frandroid-2026" title="Velo-de-Ville-Loady-Frandroid-2026" class="product-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=150,150&key=b4ba9cb3" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=150,150&key=b4ba9cb3 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?resize=75,75&key=b4ba9cb3 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/velo-de-ville-loady-frandroid-2026-300x300.png?key=b4ba9cb3 300w"/></noscript>    </div>
+    <div class="product-card__content">
+        <div class="product-card__title-container mb-4 mb-3-mobile  has-text-centered-tablet ">
+            <span class="product-card__title is-block has-text-weight-bold is-size-6 is-uppercase m-0">
+                <a href="https://www.frandroid.com/produits/velo-electrique/velo-de-ville/3011555-velo-de-ville-loady">
+                                    <div>Velo de Ville</div>
+                    <div>Loady</div>
+                                </a>
+            </span>
+        </div>
+        <a href="https://www.frandroid.com/produits/velo-electrique/velo-de-ville/3011555-velo-de-ville-loady" class="button fr-button fr-button--fullwidth fr-button--pink has-text-centered is-size-6 mb-4 mb-3-mobile">
+            Fiche produit
+        </a>
+                <a href="https://www.frandroid.com/survoltes/velo-electrique/2986801_jai-teste-le-vello-de-ville-loady-le-velo-cargo-electrique-le-plus-personnalisable-du-marche" class="button fr-button fr-button--fullwidth fr-button--small-icon fr-button--blue fr-button fr-button--fixed-right-icon has-text-centered is-relative mb-4 mb-3-mobile">
+            <span class="is-size-6">Voir l'essai</span> <span class="icon icon-arrow-right"></span>
+        </a>
+        
+        
+            </div>
+</div>
+            </div>
+                        <div class="column is-4">
+                                <div class="product-card product-card--vertical product-card--in-article ">
+    <div class="product-card__cover is-relative">
+            <div class="badge badge--top-left badge--inner-top-left has-bg-gradient-orange is-size-5-mobile">
+            <span class="has-text-body is-dark is-flex is-align-items-center">
+                8 <span class="badge__rank-total">/10</span>
+            </span>
+        </div>
+            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;resize=150,150&amp;key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;resize=75,75&amp;key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;key=c0a31733 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Yuba-Boda-Boda-Frandroid-2025" title="Yuba-Boda-Boda-Frandroid-2025" class="product-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&amp;key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&amp;key=c0a31733 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Yuba-Boda-Boda-Frandroid-2025" title="Yuba-Boda-Boda-Frandroid-2025" class="product-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&key=c0a31733" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w"/></noscript>    </div>
+    <div class="product-card__content">
+        <div class="product-card__title-container mb-4 mb-3-mobile  has-text-centered-tablet ">
+            <span class="product-card__title is-block has-text-weight-bold is-size-6 is-uppercase m-0">
+                <a href="https://www.frandroid.com/produits/velo-electrique/yuba/2753539-yuba-boda-boda">
+                                    <div>Yuba</div>
+                    <div>Boda Boda</div>
+                                </a>
+            </span>
+        </div>
+        <a href="https://www.frandroid.com/produits/velo-electrique/yuba/2753539-yuba-boda-boda" class="button fr-button fr-button--fullwidth fr-button--pink has-text-centered is-size-6 mb-4 mb-3-mobile">
+            Fiche produit
+        </a>
+                <a href="https://www.frandroid.com/survoltes/velo-electrique/2730375_yuba-boda-boda-un-velo-cargo-sauf-dans-la-conduite" class="button fr-button fr-button--fullwidth fr-button--small-icon fr-button--blue fr-button fr-button--fixed-right-icon has-text-centered is-relative mb-4 mb-3-mobile">
+            <span class="is-size-6">Voir l'essai</span> <span class="icon icon-arrow-right"></span>
+        </a>
+        
+        
+                <a href="https://bestengine.humanoid.fr/track/6305533/yuba-boda-boda_upway-reconditionne" target="_blank" rel="nofollow" class="button fr-button fr-button--fullwidth fr-button--inverted product-card__price" data-gtm="{&quot;nom_marchand&quot;:&quot;upway-reconditionne&quot;,&quot;nom_produit&quot;:&quot;yuba-boda-boda&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:0,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6305533\/yuba-boda-boda_upway-reconditionne&quot;,&quot;module_produit&quot;:&quot;product_card_small&quot;,&quot;zone&quot;:&quot;contenu-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:15315,&quot;prix_produit&quot;:2199,&quot;bloc_offers_count&quot;:1}">
+                            <span class="has-text-weight-bold"><span class="price-styled">2&nbsp;199<span class="price-decimal">&nbsp;€</span></span></span>
+                    </a>
+            </div>
+</div>
+            </div>
+                        <div class="column is-4">
+                                <div class="product-card product-card--vertical product-card--in-article ">
+    <div class="product-card__cover is-relative">
+            <div class="badge badge--top-left badge--inner-top-left has-bg-gradient-orange is-size-5-mobile">
+            <span class="has-text-body is-dark is-flex is-align-items-center">
+                5 <span class="badge__rank-total">/10</span>
+            </span>
+        </div>
+            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?webp=1&amp;resize=150,150&amp;key=b421501f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?webp=1&amp;resize=75,75&amp;key=b421501f 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?webp=1&amp;key=b421501f 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Hitway-BK8S-Frandroid-2025" title="Hitway-BK8S-Frandroid-2025" class="product-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=150,150&amp;key=b421501f" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=150,150&amp;key=b421501f" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=150,150&amp;key=b421501f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=75,75&amp;key=b421501f 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?key=b421501f 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=150,150&amp;key=b421501f 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=75,75&amp;key=b421501f 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?key=b421501f 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Hitway-BK8S-Frandroid-2025" title="Hitway-BK8S-Frandroid-2025" class="product-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=150,150&key=b421501f" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=150,150&key=b421501f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?resize=75,75&key=b421501f 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/06/hitway-bk8s-frandroid-2025-300x300.png?key=b421501f 300w"/></noscript>    </div>
+    <div class="product-card__content">
+        <div class="product-card__title-container mb-4 mb-3-mobile  has-text-centered-tablet ">
+            <span class="product-card__title is-block has-text-weight-bold is-size-6 is-uppercase m-0">
+                <a href="https://www.frandroid.com/produits/velo-electrique/hitway/2657879-hitway-bk8s">
+                                    <div>Hitway</div>
+                    <div>BK8S</div>
+                                </a>
+            </span>
+        </div>
+        <a href="https://www.frandroid.com/produits/velo-electrique/hitway/2657879-hitway-bk8s" class="button fr-button fr-button--fullwidth fr-button--pink has-text-centered is-size-6 mb-4 mb-3-mobile">
+            Fiche produit
+        </a>
+                <a href="https://www.frandroid.com/survoltes/velo-electrique/2730861_jai-roule-plusieurs-semaines-avec-un-velo-electrique-a-700-e-on-vous-dit-si-ca-vaut-vraiment-le-coup" class="button fr-button fr-button--fullwidth fr-button--small-icon fr-button--blue fr-button fr-button--fixed-right-icon has-text-centered is-relative mb-4 mb-3-mobile">
+            <span class="is-size-6">Voir l'essai</span> <span class="icon icon-arrow-right"></span>
+        </a>
+        
+        
+            </div>
+</div>
+            </div>
+                            </div>
+</div>
+                </section>
+                                        <span class="index" id="conclusion" data-title="Conclusion"></span>
+<div class="review mt-5">
+    
+<div class="is-gastric-kingfisher is-gastric-kingfisherc max-[768px]:hidden is-hidden-mobile"><div class="Content_1" style="display:none" id="optidigital-adslot-Content_1"></div></div>
+
+
+            <div id="test-conclusion" class="test-conclusion">
+                            <h2 class="test-conclusion__title">
+                                            <span class="has-text-primary">
+                            Notre avis sur Le                         </span>
+                        Nakamura Crosscity+                                    </h2>
+                            <div class="test-conclusion__ratings not-loaded mb-5-mobile mb-6">
+        <div class="columns is-multiline is-variable is-4-tablet is-6-desktop">
+                            <div class="column pb-0 pb-0-mobile product-ratings__single is-half grade">
+                    <div class="grade__criteria">Design</div>
+                    <div class="grade__scale grade__scale--val-7">
+                        <span class="grade__score">7</span>
+                    </div>
+                    <div class="description">Ce n’est certes pas le longtail le plus design, mais il comporte le plein d’équipements au regard du prix dont deux porte-bagages, même si certains sont perfectibles (béquille centrale, garde-boue). Le poids reste raisonnable, et les dimensions celles d’un vélo classique malgré les capacités (60 kg à l’arrière, 160 kg en tout).</div>
+                </div>
+                            <div class="column pb-0 pb-0-mobile product-ratings__single is-half grade">
+                    <div class="grade__criteria">Technologies embarquées</div>
+                    <div class="grade__scale grade__scale--val-7">
+                        <span class="grade__score">7</span>
+                    </div>
+                    <div class="description">L’écran est petit, mais agréable à l’emploi et à lire, tandis qu’il affiche nombre d’informations. Sa jauge de batterie est cependant floue, qui demande à consulter l'application, utile seulement pour le pourcentage et l’enregistrement de trajets.</div>
+                </div>
+                            <div class="column pb-0 pb-0-mobile product-ratings__single is-half grade">
+                    <div class="grade__criteria">Conduite</div>
+                    <div class="grade__scale grade__scale--val-8">
+                        <span class="grade__score">8</span>
+                    </div>
+                    <div class="description">La stabilité est bonne sur ce vélo électrique, même à deux, bien que le passager n’aime pas le confort moyen (qui reste bon en conduite seul). Le moteur permet de faire fi de la charge et des pentes, avec un bel agrément, tandis que le freinage est bon pour la sécurité à deux.</div>
+                </div>
+                            <div class="column pb-0 pb-0-mobile product-ratings__single is-half grade">
+                    <div class="grade__criteria">Autonomie</div>
+                    <div class="grade__scale grade__scale--val-8">
+                        <span class="grade__score">8</span>
+                    </div>
+                    <div class="description">Malgré une capacité modeste de 504 Wh, la batterie assure une autonomie plus que correcte. Elle varie de 50 km par temps frais à deux, pour flirter avec les 90 km seul en mode intermédiaire et en conditions parfaites. La recharge est rapide, avec son chargeur imposant, qui dure 3h30, et 1h30 pour une semi-recharge.</div>
+                </div>
+                        <div class="column is-flex">
+                            </div>
+        </div>
+    </div>
+        </div>
+    
+                    <div class="test-conclusion-card mt-5">
+            <div class="test-conclusion-card__inner">
+                                    <div class="test-conclusion-card__global-grade mb-5 mt-5">
+                        <div class="columns is-vcentered is-mobile is-centered">
+                            <div class="column is-7">
+                                <div class="frandroid-title has-text-weight-bolder is-size-4-mobile is-size-3 test-conclusion-card__title">
+                                    Note finale du test
+                                </div>
+                            </div>
+                            <div class="column has-text-centered">
+                                <div class="test-conclusion-card__grade is-relative">
+                                                                        <div class="badge badge--blue badge--large has-bg-gradient-primary is-inline-flex">
+                                        <span class="has-text-body is-dark is-flex is-align-items-center">7                                            <span class="badge__rank-total">/10</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                
+                <div class="test-conclusion-card__content">
+                    <div class="columns is-centered">
+                        <div class="column is-6-tablet is-7-desktop is-narrow">
+                            <div class="test-conclusion-card__conclusion mb-5">
+                                <span>Bien équipé, raisonnable en poids (même si plus élevé qu’annoncé), capable d’emmener un passager jusqu’à 60 kg en toute stabilité, le Nakamura Crosscity+ respecte sa promesse. Son moteur performant et agréable aide à une conduite agréable, dans une position passive avec un bon confort, sauf en situation biplace où cela secoue généreusement.<br>
+<br>
+La transmission certes polyvalente avec 8 vitesses gâche parfois avec des vitesses qui sautent souvent, mais rien à redire côté freins hydrauliques, tandis que les pneus acceptent les chemins peu accidentés.<br>
+<br>
+L’autonomie surprend, entre 50 et 90 km selon les conditions, soit mieux qu’attendu, de plus avec une recharge rapide. Le vélo cargo électrique compact est loin d’être parfait, mais son tarif excuse certains défauts. A 2 200 euros, peu de concurrents arrive à sa cheville, de plus avec un assemblage en France et au cadre garantie à vie.<br>
+</span>
+                            </div>
+                        </div>
+
+                        <div class="column is-6-tablet is-5-desktop is-narrow">
+                            <div class="test-conclusion-card__good-bad-container">
+        <div class="test-conclusion-card__good column mb-5-mobile mb-6">
+        <h2 class="test-conclusion-card__good-bad-title test-conclusion-card__good-bad-title--good
+        is-uppercase has-text-weight-bold has-text-gradient-green">
+            <i class="icon-plus" aria-hidden="true"></i>Points positifs du Nakamura Crosscity+        </h2>
+        <ul>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Rapport prix/capacités</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Stabilité en biplace</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Moteur performant</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Freins mordants</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Bonne autonomie</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Recharge rapide</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Poids limité</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--good">
+                <h3>Assemblage France</h3>
+                </li>
+                    </ul>
+    </div>
+    <div class="test-conclusion-card__bad column mb-5-mobile mb-6">
+        <h2 class="test-conclusion-card__good-bad-title test-conclusion-card__good-bad-title--bad is-uppercase
+        has-text-weight-bold has-text-gradient-pink">
+            <i class="icon-minus" aria-hidden="true"></i>Points négatifs du Nakamura Crosscity+        </h2>
+        <ul>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--bad">
+                <h3>Confort moyen à deux</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--bad">
+                <h3>Dérailleur qui se dérègle souvent</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--bad">
+                <h3>Des équipements de moyenne qualité</h3>
+                </li>
+                            <li class="test-conclusion-card__good-bad-item test-conclusion-card__good-bad-item--bad">
+                <h3>Non adapté hors bitume</h3>
+                </li>
+                    </ul>
+    </div>
+    </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+                                        <div class="my-5">
+                <div class="columns">
+                    <div class="column container-with-sidebar">
+                        <div class="article-footer mt-4">
+    <div class="optid-no-ads">
+    <div class="product-prices__title mt-5 has-text-centered-mobile has-text-weight-semibold">
+    <a href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus" class="product-resume__prices-title__product-name has-text-weight-bold">
+    Intersport Nakamura Crosscity Plus    </a>
+        au meilleur prix
+    </div>
+            <p class="has-text-weight-semibold has-text-centered has-text-body-lightest">Il n’y a pas d’offres pour le moment, découvrez</p>
+        <ul>
+                            <li class="product-row__wrapper stretched-link-container">
+    <div class="product-row">
+        <div class="product-row__left">
+            <div class="product-row__cover">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;resize=150,150&amp;key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;resize=75,75&amp;key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?webp=1&amp;key=c0a31733 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Yuba-Boda-Boda-Frandroid-2025" title="Yuba-Boda-Boda-Frandroid-2025" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&amp;key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&amp;key=c0a31733 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&amp;key=c0a31733 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Yuba-Boda-Boda-Frandroid-2025" title="Yuba-Boda-Boda-Frandroid-2025" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&key=c0a31733" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=150,150&key=c0a31733 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?resize=75,75&key=c0a31733 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/08/yuba-boda-boda-frandroid-2025-300x300.png?key=c0a31733 300w"/></noscript>            </div>
+            <a href="https://www.frandroid.com/produits/velo-electrique/yuba/2753539-yuba-boda-boda" class="has-text-weight-semibold has-text-body is-align-items-center is-mobile stretched-link">
+                <span>Yuba Boda Boda</span>
+            </a>
+        </div>
+        <div class="product-row__right">
+                            <a href="https://bestengine.humanoid.fr/track/6305533/yuba-boda-boda_upway-reconditionne" target="_blank" rel="nofollow" class="button fr-button price-button fr-button--gradient-orange has-text-centered stretched-link-above nowrap" data-gtm="{&quot;nom_marchand&quot;:&quot;upway-reconditionne&quot;,&quot;nom_produit&quot;:&quot;yuba-boda-boda&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:1,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6305533\/yuba-boda-boda_upway-reconditionne&quot;,&quot;module_produit&quot;:&quot;price_table_alternative&quot;,&quot;zone&quot;:&quot;contenu-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:15315,&quot;prix_produit&quot;:2199,&quot;bloc_offers_count&quot;:1}">
+                                            <span class="has-text-weight-bold"><span class="price-styled">2&nbsp;199<span class="price-decimal">&nbsp;€</span></span></span>
+                                    </a>
+                                        <div class="product-card__test is-align-content-center">
+                    
+<a href="https://www.frandroid.com/survoltes/velo-electrique/2730375_yuba-boda-boda-un-velo-cargo-sauf-dans-la-conduite" class="fr-button--two-parts is-size-6 has-text-weight-semibold p-0 stretched-link-above">
+            <span class="product-card__rate">8/10</span>
+        <span class="nowrap">Lire le test</span>
+</a>
+                </div>
+                    </div>
+    </div>
+</li>
+                            <li class="product-row__wrapper stretched-link-container">
+    <div class="product-row">
+        <div class="product-row__left">
+            <div class="product-row__cover">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?webp=1&amp;resize=75,75&amp;key=654d6ca0 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?webp=1&amp;resize=150,150&amp;key=703ea086 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?webp=1&amp;key=703ea086 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Decathlon-LD-920-E-Frandroid-2023" title="Decathlon-LD-920-E-Frandroid-2023" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?resize=75,75&amp;key=654d6ca0 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?key=703ea086 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?resize=75,75&amp;key=654d6ca0 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&amp;key=703ea086 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?key=703ea086 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Decathlon-LD-920-E-Frandroid-2023" title="Decathlon-LD-920-E-Frandroid-2023" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&key=703ea086" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-120x120.png?resize=75,75&key=654d6ca0 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?resize=150,150&key=703ea086 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2023/09/decathlon-ld-920-e-frandroid-2023-300x300.png?key=703ea086 300w"/></noscript>            </div>
+            <a href="https://www.frandroid.com/produits/velo-electrique/decathlon/1792379-decathlon-ld-920-e" class="has-text-weight-semibold has-text-body is-align-items-center is-mobile stretched-link">
+                <span>Decathlon LD 920 E</span>
+            </a>
+        </div>
+        <div class="product-row__right">
+                            <a href="https://bestengine.humanoid.fr/track/6000177/decathlon-ld-920-e_decathlon" target="_blank" rel="nofollow" class="button fr-button price-button fr-button--gradient-orange has-text-centered stretched-link-above nowrap" data-gtm="{&quot;nom_marchand&quot;:&quot;decathlon&quot;,&quot;nom_produit&quot;:&quot;decathlon-ld-920-e&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:2,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6000177\/decathlon-ld-920-e_decathlon&quot;,&quot;module_produit&quot;:&quot;price_table_alternative&quot;,&quot;zone&quot;:&quot;contenu-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:12123,&quot;prix_produit&quot;:2499,&quot;bloc_offers_count&quot;:1}">
+                                            <span class="has-text-weight-bold"><span class="price-styled">2&nbsp;499<span class="price-decimal">&nbsp;€</span></span></span>
+                                    </a>
+                                        <div class="product-card__test is-align-content-center">
+                    
+<a href="https://www.frandroid.com/marques/decathlon/1808447_test-du-decathlon-ld-920-e-un-velo-electrique-tout-simplement-genial" class="fr-button--two-parts is-size-6 has-text-weight-semibold p-0 stretched-link-above">
+            <span class="product-card__rate">9/10</span>
+        <span class="nowrap">Lire le test</span>
+</a>
+                </div>
+                    </div>
+    </div>
+</li>
+                            <li class="product-row__wrapper stretched-link-container">
+    <div class="product-row">
+        <div class="product-row__left">
+            <div class="product-row__cover">
+                <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?webp=1&amp;resize=75,75&amp;key=9bf4db28 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?webp=1&amp;resize=150,150&amp;key=e677975f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?webp=1&amp;key=e677975f 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Cowboy-Cross-Frandroid-2024" title="Cowboy-Cross-Frandroid-2024" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?resize=75,75&amp;key=9bf4db28 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?key=e677975f 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?resize=75,75&amp;key=9bf4db28 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&amp;key=e677975f 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?key=e677975f 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Cowboy-Cross-Frandroid-2024" title="Cowboy-Cross-Frandroid-2024" class="is-block mx-auto placeholder-product" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&key=e677975f" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-120x120.png?resize=75,75&key=9bf4db28 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?resize=150,150&key=e677975f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/03/cowboy-cross-frandroid-2024-300x300.png?key=e677975f 300w"/></noscript>            </div>
+            <a href="https://www.frandroid.com/produits/velo-electrique/cowboy/1973248-cowboy-cross" class="has-text-weight-semibold has-text-body is-align-items-center is-mobile stretched-link">
+                <span>Cowboy Cross</span>
+            </a>
+        </div>
+        <div class="product-row__right">
+                            <a href="https://bestengine.humanoid.fr/track/6065867/cowboy-cross_cowboy" target="_blank" rel="nofollow" class="button fr-button price-button fr-button--gradient-orange has-text-centered stretched-link-above nowrap" data-gtm="{&quot;nom_marchand&quot;:&quot;cowboy&quot;,&quot;nom_produit&quot;:&quot;cowboy-cross&quot;,&quot;categorie_produit&quot;:&quot;velo-electrique&quot;,&quot;position_marchand&quot;:3,&quot;offer_url&quot;:&quot;https:\/\/bestengine.humanoid.fr\/track\/6065867\/cowboy-cross_cowboy&quot;,&quot;module_produit&quot;:&quot;price_table_alternative&quot;,&quot;zone&quot;:&quot;contenu-page&quot;,&quot;event&quot;:&quot;bestengine&quot;,&quot;best_product_id&quot;:12815,&quot;prix_produit&quot;:3499,&quot;bloc_offers_count&quot;:1}">
+                                            <span class="has-text-weight-bold"><span class="price-styled">3&nbsp;499<span class="price-decimal">&nbsp;€</span></span></span>
+                                    </a>
+                                        <div class="product-card__test is-align-content-center">
+                    
+<a href="https://www.frandroid.com/marques/cowboy/2571067_on-a-roule-plus-de-100-km-au-guidon-du-nouveau-cowboy-cross-un-velo-electrique-ultra-confortable-a-lautonomie-xxl" class="fr-button--two-parts is-size-6 has-text-weight-semibold p-0 stretched-link-above">
+            <span class="product-card__rate">9/10</span>
+        <span class="nowrap">Lire le test</span>
+</a>
+                </div>
+                    </div>
+    </div>
+</li>
+                    </ul>
+    
+
+</div>
+    
+    <div class="columns is-vcentered">
+        <div class="column has-text-left">
+                            <div id="hrr-link" class="mt-4 mb-4 has-text-centered-mobile">
+                    <a href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique?&amp;show_reader_reports" target="_blank" rel="nofollow">
+                        Signaler une erreur dans le texte
+                    </a>
+                </div>
+                    </div>
+        <div class="column has-text-right has-text-centered-mobile">
+            <div class="share" data-share-api-url="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" data-share-api-title="Test Nakamura Crosscity+&nbsp;: la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique&nbsp;?">
+    <span class="is-uppercase is-size-6 is-hidden-mobile">Partager</span>
+            <a title="Partager sur Facebook" data-placement="footer" data-share="facebook" rel="noopener" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" aria-label="Facebook" class="color-facebook is-hidden-js">
+            <i class="icon-facebook"></i>
+        </a>
+        <span title="Partager sur Facebook" data-share-url="aHR0cHM6Ly93d3cuZmFjZWJvb2suY29tL3NoYXJlci9zaGFyZXIucGhwP3U9aHR0cHM6Ly93d3cuZnJhbmRyb2lkLmNvbS9tYXJxdWVzL25ha2FtdXJhLzMwODQwNDlfdGVzdC1uYWthbXVyYS1jcm9zc2NpdHktbGEtbWVpbGxldXJlLWFmZmFpcmUtZHUtbW9tZW50LXBvdXItdHJhbnNwb3J0ZXItdm9zLWVuZmFudHMtYS12ZWxvLWNhcmdvLWVsZWN0cmlxdWU=" data-share="facebook" data-placement="footer" class="color-facebook is-hidden-no-js">
+                    <i class="icon-facebook"></i>
+                </span>
+            <a title="Partager sur X" data-placement="footer" data-share="x" rel="noopener" target="_blank" href="https://www.twitter.com/share?url=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique&amp;text=Test%20Nakamura%20Crosscity%2B%C2%A0%3A%20la%20meilleure%20affaire%20du%20moment%20pour%20transporter%20vos%20enfants%20%C3%A0%20v%C3%A9lo%20cargo%20%C3%A9lectrique%C2%A0%3F%20@Frandroid" aria-label="X" class="color-x is-hidden-js">
+            <i class="icon-x"></i>
+        </a>
+        <span title="Partager sur X" data-share-url="aHR0cHM6Ly93d3cudHdpdHRlci5jb20vc2hhcmU/dXJsPWh0dHBzOi8vd3d3LmZyYW5kcm9pZC5jb20vbWFycXVlcy9uYWthbXVyYS8zMDg0MDQ5X3Rlc3QtbmFrYW11cmEtY3Jvc3NjaXR5LWxhLW1laWxsZXVyZS1hZmZhaXJlLWR1LW1vbWVudC1wb3VyLXRyYW5zcG9ydGVyLXZvcy1lbmZhbnRzLWEtdmVsby1jYXJnby1lbGVjdHJpcXVlJnRleHQ9VGVzdCUyME5ha2FtdXJhJTIwQ3Jvc3NjaXR5JTJCJUMyJUEwJTNBJTIwbGElMjBtZWlsbGV1cmUlMjBhZmZhaXJlJTIwZHUlMjBtb21lbnQlMjBwb3VyJTIwdHJhbnNwb3J0ZXIlMjB2b3MlMjBlbmZhbnRzJTIwJUMzJUEwJTIwdiVDMyVBOWxvJTIwY2FyZ28lMjAlQzMlQTlsZWN0cmlxdWUlQzIlQTAlM0YlMjBARnJhbmRyb2lk" data-share="x" data-placement="footer" class="color-x is-hidden-no-js">
+                    <i class="icon-x"></i>
+                </span>
+            <a title="Partager sur Linkedin" data-placement="footer" data-share="linkedin" rel="noopener" target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" aria-label="Linkedin" class="color-linkedin is-hidden-js">
+            <i class="icon-linkedin"></i>
+        </a>
+        <span title="Partager sur Linkedin" data-share-url="aHR0cHM6Ly93d3cubGlua2VkaW4uY29tL3NoYXJlQXJ0aWNsZT9taW5pPXRydWUmdXJsPWh0dHBzOi8vd3d3LmZyYW5kcm9pZC5jb20vbWFycXVlcy9uYWthbXVyYS8zMDg0MDQ5X3Rlc3QtbmFrYW11cmEtY3Jvc3NjaXR5LWxhLW1laWxsZXVyZS1hZmZhaXJlLWR1LW1vbWVudC1wb3VyLXRyYW5zcG9ydGVyLXZvcy1lbmZhbnRzLWEtdmVsby1jYXJnby1lbGVjdHJpcXVl" data-share="linkedin" data-placement="footer" class="color-linkedin is-hidden-no-js">
+                    <i class="icon-linkedin"></i>
+                </span>
+            <a title="Partager sur Reddit" data-placement="footer" data-share="reddit" rel="noopener" target="_blank" href="https://www.reddit.com/submit?url=https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique&amp;title=Test%20Nakamura%20Crosscity%2B%C2%A0%3A%20la%20meilleure%20affaire%20du%20moment%20pour%20transporter%20vos%20enfants%20%C3%A0%20v%C3%A9lo%20cargo%20%C3%A9lectrique%C2%A0%3F%20" aria-label="Reddit" class="color-reddit is-hidden-js">
+            <i class="icon-reddit"></i>
+        </a>
+        <span title="Partager sur Reddit" data-share-url="aHR0cHM6Ly93d3cucmVkZGl0LmNvbS9zdWJtaXQ/dXJsPWh0dHBzOi8vd3d3LmZyYW5kcm9pZC5jb20vbWFycXVlcy9uYWthbXVyYS8zMDg0MDQ5X3Rlc3QtbmFrYW11cmEtY3Jvc3NjaXR5LWxhLW1laWxsZXVyZS1hZmZhaXJlLWR1LW1vbWVudC1wb3VyLXRyYW5zcG9ydGVyLXZvcy1lbmZhbnRzLWEtdmVsby1jYXJnby1lbGVjdHJpcXVlJnRpdGxlPVRlc3QlMjBOYWthbXVyYSUyMENyb3NzY2l0eSUyQiVDMiVBMCUzQSUyMGxhJTIwbWVpbGxldXJlJTIwYWZmYWlyZSUyMGR1JTIwbW9tZW50JTIwcG91ciUyMHRyYW5zcG9ydGVyJTIwdm9zJTIwZW5mYW50cyUyMCVDMyVBMCUyMHYlQzMlQTlsbyUyMGNhcmdvJTIwJUMzJUE5bGVjdHJpcXVlJUMyJUEwJTNGJTIw" data-share="reddit" data-placement="footer" class="color-reddit is-hidden-no-js">
+                    <i class="icon-reddit"></i>
+                </span>
+    </div>
+        </div>
+    </div>
+
+    <div class="mb-5">
+        
+<div class="event-video-wrapper placement-footer">
+    <div id="event-video-footer" class="event-video is-relative" data-placement="footer" data-lazy-func="load-event-video-footer" data-priority="1" data-muted="1" data-lazy-script-url="https://embed.twitch.tv/embed/v1.js" data-terms-whitelist="marques,nakamura,survoltes,test,velo-electrique,intersport-nakamura-crosscity-plus,nakamura-crosscity,velo-cargo,be_velo-electrique" data-twitch-parent="www.frandroid.com" data-twitch-channel="frandroidlive">
+        <p class="event-video__title is-hidden has-text-gradient-pink-inverted"></p>
+                <div class="event-video-iframe-wrapper twitch-embed"></div>
+    </div>
+</div>
+        </div>
+
+    <div class="tags-wrapper mb-5">
+    <div class="tags-wrapper__overlay"></div>
+    <div class="tags-container">
+        <div class="tags-content">
+                    <a rel="tag" href="https://www.frandroid.com/marques" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> Marques            </a>
+                    <a rel="tag" href="https://www.frandroid.com/marques/nakamura" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> Nakamura par Intersport            </a>
+                    <a rel="tag" href="https://www.frandroid.com/survoltes" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> Survoltés            </a>
+                    <a rel="tag" href="https://www.frandroid.com/survoltes/velo-electrique" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> Vélos électriques            </a>
+                    <a rel="tag" href="https://www.frandroid.com/produits/velo-electrique/nakamura/3049301-intersport-nakamura-crosscity-plus" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> Intersport Nakamura Crosscity Plus            </a>
+                    <a rel="tag" href="https://www.frandroid.com/tag/nakamura-crosscity" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> Nakamura Crosscity+            </a>
+                    <a rel="tag" href="https://www.frandroid.com/tag/velo-cargo" class="article-tag button fr-button fr-button--left-icon mb-3">
+                <i class="icon-hashtag is-size-7"></i> vélo cargo            </a>
+                </div>
+    </div>
+</div>
+
+    <div class="mb-5 mb-4-mobile">
+        <div class="author-card">
+    <div class="author-card__header">
+        <div>
+            <picture><img decoding="async" width="82" height="82" loading="lazy" alt="Matthieu Lauraux" class="author-card__avatar placeholder-square" src="https://c1.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/07/matthieu-lauraux.jpg?resize=200,200" data-src="https://c1.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/07/matthieu-lauraux.jpg?resize=200,200"></picture><noscript><img decoding="async" width="82" height="82" loading="lazy" alt="Matthieu Lauraux" class="author-card__avatar placeholder-square" src="https://c1.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2024/07/matthieu-lauraux.jpg?resize=200,200"/></noscript>        </div>
+        <div class="author-card__info">
+            <a href="https://www.frandroid.com/author/matthieulauraux" rel="author" title="Voir tous ses articles" class="author-card__name">Matthieu Lauraux</a>
+                    </div>
+    </div>
+            <div class="author-card__footer">
+            <ul class="author-card__networks">
+                                    <li>
+                        <a rel="noopener" aria-label="instagram" class="logo-instagram" href="https://instagram.com/mat_lrx" target="_blank">
+                            <span class="icon-instagram"></span>
+                        </a>
+                    </li>
+                                    <li>
+                        <a rel="noopener" aria-label="linkedin" class="logo-linkedin" href="https://fr.linkedin.com/in/matthieulauraux" target="_blank">
+                            <span class="icon-linkedin"></span>
+                        </a>
+                    </li>
+                            </ul>
+        </div>
+    </div>
+    </div>
+
+    
+    
+            <div class="mb-5 mt-4-mobile mt-4">
+            <div class="newsletter-form js-newsletter-form newsletter-form--columns has-bg-body-background-secondary-color is-relative pt-5" data-nosnippet="">
+    <p class="newsletter-form__title is-size-6 is-size-7-mobile is-uppercase has-text-primary has-text-weight-semibold mb-4 px-5">
+        Votre newsletter personnalisée</p>
+    <div class="is-relative px-5">
+        <div class="newsletter-form__success show-on-success columns is-vcentered is-centered is-gapless">
+            <p class="has-text-centered-tablet newsletter-form__subtitle is-size-4 has-text-weight-bold has-text-primary column is-9-tablet is-10-mobile">
+                C'est enregistré ! Surveillez votre boîte aux lettres, vous allez entendre parler de nous&nbsp;!
+            </p>
+        </div>
+
+        <div class="columns hide-on-success">
+            <div class="column is-10-mobile is-3-tablet newsletter-form--first-column">
+                <p class="newsletter-form__subtitle is-size-4 has-text-weight-bolder has-text-primary">Recevez le
+                    meilleur de l'actu</p>
+            </div>
+            
+        </div>
+    </div>
+    <div class="newsletter-form__faq pb-5 mt-4 is-masked">
+        <p class="is-size-7 px-5">
+            Les données transmises par le biais de ce formulaire sont destinées à Humanoid,
+            société éditrice du site Frandroid en sa qualité de responsable de traitement.
+            Elles ne seront en aucun cas cédées à des tiers. Ces données sont traitées sous réserve d'obtention de votre
+            consentement pour vous envoyer par e-mail des actualités et informations relatives aux contenus éditoriaux
+            publiés sur Frandroid. Vous pouvez vous opposer à tout moment à ces e-mails en cliquant
+            sur les liens de désinscriptions présents dans chacun d'eux. Pour plus d'informations, vous pouvez consulter
+            l'intégralité de notre <a href="https://www.frandroid.com/politique-donnees-personnelles">politique de traitement
+            de vos données personnelles</a>. Vous disposez d'un droit d'accès, de rectification, d'effacement,
+            de limitation, de portabilité et d'opposition pour motif légitime aux données personnelles vous concernant.
+            Pour exercer l'un de ces droits, merci d'effectuer votre demande via notre <a href="https://www.frandroid.com/contact/#RGPD">
+            formulaire de demandes d'exercices de droits dédié</a>.
+        </p>
+    </div>
+</div>
+        </div>
+    
+        <div class="article-footer__comments mb-5 mt-4-mobile mt-4" id="comments">
+                    <div class="article-comments px-3 cb visa bg-content" id="respond">
+                <div id="disqus_thread_html">
+    <div id="dsq-content">
+        <ul id="dsq-comments">
+                    </ul>
+    </div>
+</div>
+                <div class="is-provider-disqus">
+                    <div class="embed-container embed-container--with-overlay">
+                        <div class="embed-container-content">
+                            <div id="disqus_thread"></div>
+                        </div>
+                        
+    <div class="embed-consent-overlay is-dark" data-vendor="833" data-nosnippet="">
+        <div class="embed-consent-overlay-text">
+            <p>
+                Ce contenu est bloqué car vous n'avez pas accepté les cookies et autres traceurs. Ce contenu est fourni par Disqus.<br>
+                Pour pouvoir le visualiser, vous devez accepter l'usage étant opéré par Disqus avec vos données qui pourront être utilisées pour les finalités suivantes : vous permettre de visualiser et de partager des contenus avec des médias sociaux, favoriser le développement et l'amélioration des produits d'Humanoid et de ses partenaires, vous afficher des publicités personnalisées par rapport à votre profil et activité, vous définir un profil publicitaire personnalisé, mesurer la performance des publicités et du contenu de ce site et mesurer l'audience de ce site <a href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique#" class="js-privacy" target="_blank">(en savoir plus)</a>
+            </p>
+            <p>
+                En cliquant sur « J’accepte tout », vous consentez aux finalités susmentionnées pour l’ensemble des cookies et autres traceurs déposés par Humanoid et <button type="button" class="js-open-vendors">ses partenaires</button>.
+            </p>
+            <p>
+                Vous gardez la possibilité de retirer votre consentement à tout moment. Pour plus d’informations, nous vous invitons à prendre connaissance de notre <a href="https://www.frandroid.com/politique-cookies">Politique cookies</a>.
+            </p>
+        </div>
+        <div class="embed-consent-overlay-accept-button">
+            <button>J'accepte tout</button>
+        </div>
+        <p class="embed-consent-overlay-manage-choices">
+            <button type="button" class="js-open-vendors">Gérer mes choix</button>
+        </p>
+    </div>
+                    </div>
+                </div>
+                
+<div id="disqus_thread"></div>
+                
+            </div>
+            </div>
+    
+    
+    
+<div class="is-gastric-kingfisher is-gastric-kingfishercb min-[769px]:hidden is-hidden-tablet"><div class="Mobile_Bottom" style="display:none" id="optidigital-adslot-Mobile_Bottom"></div></div>
+<div class="is-gastric-kingfisher is-gastric-kingfishercb max-[768px]:hidden is-hidden-mobile"><div class="Content_Bottom" style="display:none" id="optidigital-adslot-Content_Bottom"></div></div>
+
+    
+
+            <aside class="article-footer__related-posts mt-4">
+            <div class="mb-4">
+                <p class="article-footer__related-posts-title is-size-3 has-text-weight-bolder">Lectures liées</p>
+            </div>
+            <div class="scroller--horizontal columns is-multiline">
+                                    <div class="column is-4-desktop is-3-tablet scroller-element">
+                        
+<div class="post-card post-card--vertical">
+    <div class="post-card__link-container stretched-link-container">
+            <img src="https://native.humanoid.fr/register-impression?s_id=2&amp;sp_id=5&amp;c_id=4018" alt="Humanoid Native" class="p-native" width="1px" height="1px" style="width: 1px; height: 1px">            <div class="post-card__cover">
+                    <div class="post-card__cover-inner">
+                            <picture><source data-srcset="https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?webp=1&amp;resize=200,175&amp;key=0a159041 200w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?webp=1&amp;resize=100,87&amp;key=0a159041 100w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?webp=1&amp;resize=400,350&amp;key=0a159041 400w" type="image/webp"><img decoding="async" width="200" height="175" loading="lazy" alt="RTX 5060 et Ryzen 7 : pourquoi ce PC portable de 18 pouces est la machine ultime pour les joueurs" class="post-card__image placeholder-square" src="data:image/svg+xml;utf8,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%27200%27%20height=%27175%27/%3E" data-src="https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=200,175&amp;key=0a159041" data-srcset="https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=200,175&amp;key=0a159041 200w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=100,87&amp;key=0a159041 100w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=400,350&amp;key=0a159041 400w"></picture><noscript><img decoding="async" width="200" height="175" loading="lazy" alt="RTX 5060 et Ryzen 7 : pourquoi ce PC portable de 18 pouces est la machine ultime pour les joueurs" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=200,175&key=0a159041" srcset="https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=200,175&key=0a159041 200w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=100,87&key=0a159041 100w,https://c0.lestechnophiles.com/www.frandroid.com/wp-content/uploads/2026/04/ASUS-TUF-A18.webp?resize=400,350&key=0a159041 400w"/></noscript>                        </div>
+                </div>
+
+    
+        <div class="post-card__title-container">
+                    <p class="post-card__title">
+                <a class="post-card__link stretched-link" href="https://native.humanoid.fr/register-click?s_id=2&amp;sp_id=5&amp;c_id=4018" rel="nofollow">
+                    RTX 5060 et Ryzen 7 : pourquoi ce PC portable de 18 pouces est la machine ultime pour les joueurs                </a>
+            </p>
+                                </div>
+    </div>
+
+
+
+</div>
+
+                    </div>
+                                                    <div class="column is-4-desktop is-3-tablet scroller-element">
+                        <div class="post-card post-card--vertical category--survoltes category--velo-electrique">
+    <div class="post-card__link-container stretched-link-container">
+            <div class="post-card__cover">
+                    <div class="post-card__cover-inner">
+                            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?webp=1&amp;resize=200,175&amp;key=de233071 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?webp=1&amp;resize=100,87&amp;key=9e7220e1 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?webp=1&amp;key=9e7220e1 400w" type="image/webp"><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Sugg" title="Source : Sugg" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?resize=200,175&amp;key=de233071" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?resize=200,175&amp;key=de233071" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?resize=200,175&amp;key=de233071 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?resize=100,87&amp;key=9e7220e1 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?key=9e7220e1 400w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?resize=200,175&amp;key=de233071 200w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?resize=100,87&amp;key=9e7220e1 100w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?key=9e7220e1 400w"></picture><noscript><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Sugg" title="Source : Sugg" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?resize=200,175&key=de233071" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-300x200.jpg?resize=200,175&key=de233071 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?resize=100,87&key=9e7220e1 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/sugg-cargo-kids-velo-cargo-electrique-768x512.jpg?key=9e7220e1 400w"/></noscript>                        </div>
+                </div>
+
+    
+        <div class="post-card__title-container">
+                    <p class="post-card__title">
+                <a class="post-card__link stretched-link" href="https://www.frandroid.com/survoltes/velo-electrique/3065943_transporter-200-kg-et-2-enfants-sur-un-velo-de-moins-de-2-metres-la-grosse-promesse-du-velo-electrique-sugg-cargo-kids">
+                    Transporter 200 kg et 2 enfants sur un vélo de moins de 2 mètres : la grosse promesse du vélo électrique Sugg Cargo &amp; Kids                </a>
+            </p>
+                                </div>
+    </div>
+
+
+
+</div>
+                    </div>
+                                    <div class="column is-4-desktop is-3-tablet scroller-element">
+                        <div class="post-card post-card--vertical category--accessoires category--decathlon category--marques category--produits-android category--survoltes category--velo-electrique">
+    <div class="post-card__link-container stretched-link-container">
+            <div class="post-card__cover">
+                    <div class="post-card__cover-inner">
+                            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?webp=1&amp;resize=200,175&amp;key=71ea481e 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?webp=1&amp;resize=100,87&amp;key=0bee049a 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?webp=1&amp;key=0bee049a 400w" type="image/webp"><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Decathlon" title="Source : Decathlon" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?resize=200,175&amp;key=71ea481e" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?resize=200,175&amp;key=71ea481e" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?resize=200,175&amp;key=71ea481e 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?resize=100,87&amp;key=0bee049a 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?key=0bee049a 400w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?resize=200,175&amp;key=71ea481e 200w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?resize=100,87&amp;key=0bee049a 100w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?key=0bee049a 400w"></picture><noscript><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Decathlon" title="Source : Decathlon" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?resize=200,175&key=71ea481e" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-300x200.jpeg?resize=200,175&key=71ea481e 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?resize=100,87&key=0bee049a 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/remorque-velo-decathlon-bis-2-resized-768x512.jpeg?key=0bee049a 400w"/></noscript>                        </div>
+                </div>
+
+    
+        <div class="post-card__title-container">
+                    <p class="post-card__title">
+                <a class="post-card__link stretched-link" href="https://www.frandroid.com/marques/decathlon/3032353_la-tente-quechua-des-remorques-velo-decathlon-degaine-laccessoire-ultime-pour-transporter-vos-enfants">
+                    La tente Quechua des remorques vélo : Decathlon dégaine l’accessoire ultime pour transporter vos enfants                </a>
+            </p>
+                                </div>
+    </div>
+
+
+
+</div>
+                    </div>
+                                    <div class="column is-4-desktop is-3-tablet scroller-element">
+                        <div class="post-card post-card--vertical category--gaya category--marques category--survoltes category--velo-electrique">
+    <div class="post-card__link-container stretched-link-container">
+            <div class="post-card__cover">
+                    <div class="post-card__cover-inner">
+                            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?webp=1&amp;resize=200,175&amp;key=430cdccc 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?webp=1&amp;resize=100,87&amp;key=a422b21d 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?webp=1&amp;key=a422b21d 400w" type="image/webp"><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Gaya" title="Source : Gaya" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?resize=200,175&amp;key=430cdccc" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?resize=200,175&amp;key=430cdccc" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?resize=200,175&amp;key=430cdccc 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?resize=100,87&amp;key=a422b21d 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?key=a422b21d 400w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?resize=200,175&amp;key=430cdccc 200w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?resize=100,87&amp;key=a422b21d 100w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?key=a422b21d 400w"></picture><noscript><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Gaya" title="Source : Gaya" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?resize=200,175&key=430cdccc" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-300x199.jpg?resize=200,175&key=430cdccc 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?resize=100,87&key=a422b21d 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/03/gaya-octobre25-111-768x509.jpg?key=a422b21d 400w"/></noscript>                        </div>
+                </div>
+
+    
+        <div class="post-card__title-container">
+                    <p class="post-card__title">
+                <a class="post-card__link stretched-link" href="https://www.frandroid.com/marques/gaya/3029695_transporter-sa-poussette-yoyo-a-velo-la-solution-geniale-et-inedite-de-cette-marque-francaise-de-cargo-electrique">
+                    Transporter sa poussette YOYO à vélo : la solution géniale et inédite de cette marque française de cargo électrique                </a>
+            </p>
+                                </div>
+    </div>
+
+
+
+</div>
+                    </div>
+                                    <div class="column is-4-desktop is-3-tablet scroller-element">
+                        <div class="post-card post-card--vertical category--accessoires category--produits-android category--survoltes category--velo-electrique">
+    <div class="post-card__link-container stretched-link-container">
+            <div class="post-card__cover">
+                    <div class="post-card__cover-inner">
+                            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?webp=1&amp;resize=200,175&amp;key=74a709c4 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?webp=1&amp;resize=100,87&amp;key=9966bb48 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?webp=1&amp;key=9966bb48 400w" type="image/webp"><img decoding="async" width="200" height="175" loading="lazy" alt="Source : BikeCarGo" title="Source : BikeCarGo" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?resize=200,175&amp;key=74a709c4" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?resize=200,175&amp;key=74a709c4" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?resize=200,175&amp;key=74a709c4 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?resize=100,87&amp;key=9966bb48 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?key=9966bb48 400w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?resize=200,175&amp;key=74a709c4 200w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?resize=100,87&amp;key=9966bb48 100w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?key=9966bb48 400w"></picture><noscript><img decoding="async" width="200" height="175" loading="lazy" alt="Source : BikeCarGo" title="Source : BikeCarGo" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?resize=200,175&key=74a709c4" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-300x200.jpeg?resize=200,175&key=74a709c4 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?resize=100,87&key=9966bb48 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/09/bikecargo-768x512.jpeg?key=9966bb48 400w"/></noscript>                        </div>
+                </div>
+
+    
+        <div class="post-card__title-container">
+                    <p class="post-card__title">
+                <a class="post-card__link stretched-link" href="https://www.frandroid.com/survoltes/velo-electrique/2786933_ce-porte-velo-fait-ce-quaucun-autre-porte-velo-nest-capable-de-faire-transporter-des-velos-cargo-electriques">
+                    Ce porte-vélo fait ce qu’aucun autre porte-vélo n’est capable de faire : transporter des vélos cargo électriques                </a>
+            </p>
+                                </div>
+    </div>
+
+
+
+</div>
+                    </div>
+                                    <div class="column is-4-desktop is-3-tablet scroller-element">
+                        <div class="post-card post-card--vertical category--accessoires category--marques category--produits-android category--survoltes category--tern category--velo-electrique">
+    <div class="post-card__link-container stretched-link-container">
+            <div class="post-card__cover">
+                    <div class="post-card__cover-inner">
+                            <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?webp=1&amp;resize=200,175&amp;key=b18cd42d 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?webp=1&amp;resize=100,87&amp;key=f464cf52 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?webp=1&amp;key=f464cf52 400w" type="image/webp"><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Tern" title="Source : Tern" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?resize=200,175&amp;key=b18cd42d" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?resize=200,175&amp;key=b18cd42d" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?resize=200,175&amp;key=b18cd42d 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?resize=100,87&amp;key=f464cf52 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?key=f464cf52 400w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?resize=200,175&amp;key=b18cd42d 200w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?resize=100,87&amp;key=f464cf52 100w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?key=f464cf52 400w"></picture><noscript><img decoding="async" width="200" height="175" loading="lazy" alt="Source : Tern" title="Source : Tern" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?resize=200,175&key=b18cd42d" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-300x200.jpeg?resize=200,175&key=b18cd42d 200w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?resize=100,87&key=f464cf52 100w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2025/10/tern-ruffhouse-2-768x512.jpeg?key=f464cf52 400w"/></noscript>                        </div>
+                </div>
+
+    
+        <div class="post-card__title-container">
+                    <p class="post-card__title">
+                <a class="post-card__link stretched-link" href="https://www.frandroid.com/marques/tern/2817789_tern-degaine-un-panier-velo-avant-tres-pratique-capable-de-transporter-vos-animaux">
+                    Tern dégaine un panier vélo avant très pratique capable de transporter vos animaux                </a>
+            </p>
+                                </div>
+    </div>
+
+
+
+</div>
+                    </div>
+                            </div>
+        </aside>
+    </div>
+                    </div>
+                    <div class="column is-narrow is-hidden-mobile is-hidden-tablet-only">
+                        
+<div class="sidebar">
+    <div class="sidebar-content-container ">
+    <div class="sticky-content">
+    <div class="is-gastric-kingfisher is-gastric-kingfisherh max-[768px]:hidden is-hidden-mobile"><div class="HalfpageAd_2" style="display:none" id="optidigital-adslot-HalfpageAd_2"></div></div>
+        </div>
+</div>
+</div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+        
+<div class="is-gastric-kingfisher is-gastric-kingfisherb mb-4 is-flex is-align-items-center is-justify-content-center max-[768px]:hidden is-hidden-mobile"><div class="Billboard_2" style="display:none" id="optidigital-adslot-Billboard_2"></div></div>
+
+    </article>
+    <aside class="container">
+        <section class="my-4">
+            <div class="js-feed-posts home-posts mb-5-mobile " data-paged="1" data-redirect-path="" data-slug="single" data-id="" data-tagid="" data-fragment="1" data-postnotin="">
+
+        <div class="columns mb-5">
+        <div class="column is-9-desktop">
+            <div class="mt-5-mobile">
+                                                    <p class="is-title is-title--fake-h2 has-text-gradient-primary-inverted mb-0 mb-3-mobile">
+                                                    Les derniers articles
+                                                </p>
+                                                </div>
+        </div>
+
+                    </div>
+    
+                        
+        <ul>
+                                    
+<li class="post-card post-3056419 category--apple category--versus category--marques">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?webp=1&amp;resize=150,150&amp;key=f65397cc 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?webp=1&amp;resize=75,75&amp;key=a58d19f1 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?webp=1&amp;resize=169,169&amp;key=a58d19f1 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="iPhone 17e vs iPhone 17&nbsp;: quel iPhone «&nbsp;abordable&nbsp;» choisir&nbsp;?" title="iPhone 17e vs iPhone 17&nbsp;: quel iPhone «&nbsp;abordable&nbsp;» choisir&nbsp;?" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?resize=150,150&amp;key=f65397cc" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?resize=150,150&amp;key=f65397cc" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?resize=150,150&amp;key=f65397cc 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?resize=75,75&amp;key=a58d19f1 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?resize=169,169&amp;key=a58d19f1 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?resize=150,150&amp;key=f65397cc 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?resize=75,75&amp;key=a58d19f1 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?resize=169,169&amp;key=a58d19f1 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="iPhone 17e vs iPhone 17 : quel iPhone « abordable » choisir ?" title="iPhone 17e vs iPhone 17 : quel iPhone « abordable » choisir ?" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?resize=150,150&key=f65397cc" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-300x169.jpg?resize=150,150&key=f65397cc 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?resize=75,75&key=a58d19f1 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/iphone-17e-vs-iphone-17-768x432.jpg?resize=169,169&key=a58d19f1 300w"/></noscript>                                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/versus" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    Comparatifs                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/versus/3056419_iphone-17e-vs-iphone-17-quel-iphone-abordable-choisir" class="post-card__title-link stretched-link">
+                    iPhone 17e vs iPhone 17&nbsp;: quel iPhone «&nbsp;abordable&nbsp;» choisir&nbsp;?                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 20:00            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+<li class="post-card post-3082449 post-card--good-deal category--audio category--bons-plans category--bons-plans-audio category--bons-plans-ecouteurs-sans-fil category--ecouteurs-true-wireless category--huawei category--marques category--produits-android">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?webp=1&amp;resize=150,150&amp;key=b080cea8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?webp=1&amp;resize=75,75&amp;key=5ea6f959 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?webp=1&amp;resize=169,169&amp;key=5ea6f959 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="À moins de 90 € pendant les French Days, ces récents écouteurs Huawei avec ANC et audio spatial valent encore plus le détour" title="À moins de 90 € pendant les French Days, ces récents écouteurs Huawei avec ANC et audio spatial valent encore plus le détour" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?resize=150,150&amp;key=b080cea8" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?resize=150,150&amp;key=b080cea8" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?resize=150,150&amp;key=b080cea8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?resize=75,75&amp;key=5ea6f959 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?resize=169,169&amp;key=5ea6f959 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?resize=150,150&amp;key=b080cea8 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?resize=75,75&amp;key=5ea6f959 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?resize=169,169&amp;key=5ea6f959 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="À moins de 90 € pendant les French Days, ces récents écouteurs Huawei avec ANC et audio spatial valent encore plus le détour" title="À moins de 90 € pendant les French Days, ces récents écouteurs Huawei avec ANC et audio spatial valent encore plus le détour" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?resize=150,150&key=b080cea8" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-300x169.jpg?resize=150,150&key=b080cea8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?resize=75,75&key=5ea6f959 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/huawei-freebuds-6-french-days-2026-768x432.jpg?resize=169,169&key=5ea6f959 300w"/></noscript>                                </div>
+                            <div class="post-card__badge badge badge--top-left badge--fixed-mobile
+                     has-bg-gradient-pink-inverted">
+                    <span aria-label="Bon plan" class="post-card__badge-icon has-text-body is-dark icon icon-fire"></span>
+                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/bons-plans" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    Bons plans                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/bons-plans/3082449_a-moins-de-90-e-pendant-les-french-days-ces-recents-ecouteurs-huawei-avec-anc-et-audio-spatial-valent-encore-plus-le-detour" class="post-card__title-link stretched-link">
+                    À moins de 90 € pendant les French Days, ces récents écouteurs Huawei avec ANC et audio spatial valent encore plus le détour                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 19:38            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+<li class="post-card post-3084049 post-card--featured category--marques category--nakamura category--survoltes category--test category--velo-electrique">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?webp=1&amp;resize=150,150&amp;key=43049772 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?webp=1&amp;resize=75,75&amp;key=bad20439 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?webp=1&amp;resize=200,200&amp;key=bad20439 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?" title="Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?resize=150,150&amp;key=43049772" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?resize=150,150&amp;key=43049772" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?resize=150,150&amp;key=43049772 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=75,75&amp;key=bad20439 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=200,200&amp;key=bad20439 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?resize=150,150&amp;key=43049772 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=75,75&amp;key=bad20439 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=200,200&amp;key=bad20439 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?" title="Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?resize=150,150&key=43049772" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-300x200.jpg?resize=150,150&key=43049772 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=75,75&key=bad20439 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo-768x512.jpg?resize=200,200&key=bad20439 300w"/></noscript>                                </div>
+                            <div class="badge badge--top-left has-bg-gradient-pink">
+                    <span class="has-text-body is-dark is-flex is-align-items-center">
+                        7<span class="badge__rank-total">/10</span>
+                    </span>
+                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/marques/nakamura" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    <span class="has-text-weight-bold">Nakamura par Intersport</span>                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique" class="post-card__title-link stretched-link">
+                    Test Nakamura Crosscity+ : la meilleure affaire du moment pour transporter vos enfants à vélo cargo électrique ?                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 18:01            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+
+    <img src="https://native.humanoid.fr/register-impression?s_id=2&amp;sp_id=3&amp;c_id=4021" alt="Humanoid Native" class="p-native" width="1px" height="1px" style="width: 1px; height: 1px"><div class="post-card">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?webp=1&amp;resize=150,150&amp;key=5feb94c8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?webp=1&amp;resize=75,75&amp;key=5feb94c8 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?webp=1&amp;resize=300,300&amp;key=5feb94c8 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Le Dreame Z30 Pro Aqua vous débarrasse en un clin d’œil de toutes les saletés" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=150,150&amp;key=5feb94c8" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=150,150&amp;key=5feb94c8" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=150,150&amp;key=5feb94c8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=75,75&amp;key=5feb94c8 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=300,300&amp;key=5feb94c8 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=150,150&amp;key=5feb94c8 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=75,75&amp;key=5feb94c8 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=300,300&amp;key=5feb94c8 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Le Dreame Z30 Pro Aqua vous débarrasse en un clin d’œil de toutes les saletés" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=150,150&key=5feb94c8" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=150,150&key=5feb94c8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=75,75&key=5feb94c8 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/charging-storage-1200x675.jpg?resize=300,300&key=5feb94c8 300w"/></noscript>                                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__title has-text-weight-semibold">
+                <a href="https://native.humanoid.fr/register-click?s_id=2&amp;sp_id=3&amp;c_id=4021" class="post-card__title-link stretched-link" rel="nofollow">
+                    Le Dreame Z30 Pro Aqua vous débarrasse en un clin d’œil de toutes les saletés                </a>
+            </p>
+                        </div>
+    </div>
+
+
+
+
+</div>
+
+                                                
+<li class="post-card post-3085897 category--android category--google category--marques category--polestar category--renault category--survoltes category--voitures-electriques category--volvo">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?webp=1&amp;resize=150,150&amp;key=3fa2bb21 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?webp=1&amp;resize=75,75&amp;key=cf9fdb84 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?webp=1&amp;resize=169,169&amp;key=cf9fdb84 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Gemini remplace Google Assistant dans 4 millions de voitures GM et arrive bientôt chez Renault, Volvo et Polestar" title="Gemini remplace Google Assistant dans 4 millions de voitures GM et arrive bientôt chez Renault, Volvo et Polestar" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?resize=150,150&amp;key=3fa2bb21" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?resize=150,150&amp;key=3fa2bb21" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?resize=150,150&amp;key=3fa2bb21 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?resize=75,75&amp;key=cf9fdb84 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?resize=169,169&amp;key=cf9fdb84 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?resize=150,150&amp;key=3fa2bb21 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?resize=75,75&amp;key=cf9fdb84 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?resize=169,169&amp;key=cf9fdb84 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Gemini remplace Google Assistant dans 4 millions de voitures GM et arrive bientôt chez Renault, Volvo et Polestar" title="Gemini remplace Google Assistant dans 4 millions de voitures GM et arrive bientôt chez Renault, Volvo et Polestar" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?resize=150,150&key=3fa2bb21" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x169.png?resize=150,150&key=3fa2bb21 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?resize=75,75&key=cf9fdb84 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x433.png?resize=169,169&key=cf9fdb84 300w"/></noscript>                                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/survoltes/voitures-electriques" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    <span class="has-text-weight-bold">Voitures électriques</span>                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/survoltes/voitures-electriques/3085897_gemini-remplace-google-assistant-dans-4-millions-de-voitures-gm-et-arrive-bientot-chez-renault-volvo-et-polestar" class="post-card__title-link stretched-link">
+                    Gemini remplace Google Assistant dans 4 millions de voitures GM et arrive bientôt chez Renault, Volvo et Polestar                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 17:46            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+<li class="post-card post-3082479 post-card--good-deal category--bons-plans category--camera-connectee category--maison-connectee category--produits-android category--securite-connectee">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?webp=1&amp;resize=150,150&amp;key=cdcd4194 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?webp=1&amp;resize=75,75&amp;key=810e6412 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?webp=1&amp;resize=169,169&amp;key=810e6412 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="La Tapo C720 prend toute la lumière pendant ces French Days avec une promotion de 23 % chez Amazon" title="La Tapo C720 prend toute la lumière pendant ces French Days avec une promotion de 23 % chez Amazon" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?resize=150,150&amp;key=cdcd4194" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?resize=150,150&amp;key=cdcd4194" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?resize=150,150&amp;key=cdcd4194 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?resize=75,75&amp;key=810e6412 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?resize=169,169&amp;key=810e6412 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?resize=150,150&amp;key=cdcd4194 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?resize=75,75&amp;key=810e6412 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?resize=169,169&amp;key=810e6412 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="La Tapo C720 prend toute la lumière pendant ces French Days avec une promotion de 23 % chez Amazon" title="La Tapo C720 prend toute la lumière pendant ces French Days avec une promotion de 23 % chez Amazon" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?resize=150,150&key=cdcd4194" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-300x169.jpg?resize=150,150&key=cdcd4194 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?resize=75,75&key=810e6412 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-8-768x432.jpg?resize=169,169&key=810e6412 300w"/></noscript>                                </div>
+                            <div class="post-card__badge badge badge--top-left badge--fixed-mobile
+                     has-bg-gradient-pink-inverted">
+                    <span aria-label="Bon plan" class="post-card__badge-icon has-text-body is-dark icon icon-fire"></span>
+                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/bons-plans" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    Bons plans                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/bons-plans/3082479_la-tapo-c720-prend-toute-la-lumiere-pendant-ces-french-days-avec-une-promotion-de-23-chez-amazon" class="post-card__title-link stretched-link">
+                    La Tapo C720 prend toute la lumière pendant ces French Days avec une promotion de 23 % chez Amazon                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 17:40            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+
+<li class="post-card post-3083443 category--maison-connectee">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?webp=1&amp;resize=150,150&amp;key=542ff48f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?webp=1&amp;resize=75,75&amp;key=d0593244 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?webp=1&amp;resize=200,200&amp;key=d0593244 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Concilier technologie et BTP : voici le pari du cursus Bâtiment Numérique d’Ynov Campus" title="Concilier technologie et BTP : voici le pari du cursus Bâtiment Numérique d’Ynov Campus" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?resize=150,150&amp;key=542ff48f" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?resize=150,150&amp;key=542ff48f" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?resize=150,150&amp;key=542ff48f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?resize=75,75&amp;key=d0593244 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?resize=200,200&amp;key=d0593244 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?resize=150,150&amp;key=542ff48f 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?resize=75,75&amp;key=d0593244 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?resize=200,200&amp;key=d0593244 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Concilier technologie et BTP : voici le pari du cursus Bâtiment Numérique d’Ynov Campus" title="Concilier technologie et BTP : voici le pari du cursus Bâtiment Numérique d’Ynov Campus" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?resize=150,150&key=542ff48f" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-300x200.jpg?resize=150,150&key=542ff48f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?resize=75,75&key=d0593244 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/evgeniy-surzhan-vfmhqkil6e4-unsplash-resultat-768x512.jpg?resize=200,200&key=d0593244 300w"/></noscript>                                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/produits-android/maison-connectee" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    <span class="has-text-weight-bold">Maison connectée</span>                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/produits-android/maison-connectee/3083443_concilier-technologie-et-btp-voici-le-pari-du-cursus-batiment-numerique-dynov-campus" class="post-card__title-link stretched-link">
+                    Concilier technologie et BTP : voici le pari du cursus Bâtiment Numérique d’Ynov Campus                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 17:03            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+
+                                                
+<li class="post-card post-3069331 category--maison-connectee category--marques category--nuki category--produits-android category--securite-connectee category--serrures-connectees category--test">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?webp=1&amp;resize=150,150&amp;key=20b04a6f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?webp=1&amp;resize=75,75&amp;key=5d2daa8a 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?webp=1&amp;resize=225,225&amp;key=5d2daa8a 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="J’ai testé le Nuki Keypad 2 NFC : quand mon smartphone se prend pour une clé" title="J’ai testé le Nuki Keypad 2 NFC : quand mon smartphone se prend pour une clé" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?resize=150,150&amp;key=20b04a6f" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?resize=150,150&amp;key=20b04a6f" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?resize=150,150&amp;key=20b04a6f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?resize=75,75&amp;key=5d2daa8a 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?resize=225,225&amp;key=5d2daa8a 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?resize=150,150&amp;key=20b04a6f 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?resize=75,75&amp;key=5d2daa8a 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?resize=225,225&amp;key=5d2daa8a 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="J&rsquo;ai testé le Nuki Keypad 2 NFC : quand mon smartphone se prend pour une clé" title="J&rsquo;ai testé le Nuki Keypad 2 NFC : quand mon smartphone se prend pour une clé" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?resize=150,150&key=20b04a6f" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-300x225.jpg?resize=150,150&key=20b04a6f 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?resize=75,75&key=5d2daa8a 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nuki-keypad-2-nfc-hero-768x576.jpg?resize=225,225&key=5d2daa8a 300w"/></noscript>                                </div>
+                            <div class="badge badge--top-left has-bg-gradient-pink">
+                    <span class="has-text-body is-dark is-flex is-align-items-center">
+                        8<span class="badge__rank-total">/10</span>
+                    </span>
+                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/marques" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    Marques                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/marques/3069331_jai-teste-le-nuki-keypad-2-nfc-quand-mon-smartphone-se-prend-pour-une-cle" class="post-card__title-link stretched-link">
+                    J’ai testé le Nuki Keypad 2 NFC : quand mon smartphone se prend pour une clé                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 17:00            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+<li class="post-card post-3081489 category--android category--applications category--comment-faire category--survoltes category--tutoriaux category--tutoriels-auto-mobilite category--voitures-electriques category--voitures-hybrides">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?webp=1&amp;resize=150,150&amp;key=dabf1732 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?webp=1&amp;resize=75,75&amp;key=f7e31794 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?webp=1&amp;resize=150,150&amp;key=f7e31794 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Essence pas chère : les meilleurs comparateurs de prix carburant à utiliser en France" title="Essence pas chère : les meilleurs comparateurs de prix carburant à utiliser en France" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?resize=150,150&amp;key=dabf1732" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?resize=150,150&amp;key=dabf1732" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?resize=150,150&amp;key=dabf1732 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?resize=75,75&amp;key=f7e31794 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?resize=150,150&amp;key=f7e31794 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?resize=150,150&amp;key=dabf1732 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?resize=75,75&amp;key=f7e31794 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?resize=150,150&amp;key=f7e31794 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Essence pas chère : les meilleurs comparateurs de prix carburant à utiliser en France" title="Essence pas chère : les meilleurs comparateurs de prix carburant à utiliser en France" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?resize=150,150&key=dabf1732" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-300x150.jpg?resize=150,150&key=dabf1732 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?resize=75,75&key=f7e31794 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/05/image-768x384.jpg?resize=150,150&key=f7e31794 300w"/></noscript>                                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/android/applications" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    <span class="has-text-weight-bold">Applications <span class="has-text-weight-medium">Android</span></span>                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/android/applications/3081489_essence-pas-chere-les-meilleurs-comparateurs-de-prix-carburant-a-utiliser-en-france" class="post-card__title-link stretched-link">
+                    Essence pas chère : les meilleurs comparateurs de prix carburant à utiliser en France                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 16:48            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+<li class="post-card post-3084929 post-card--featured category--versus category--lg category--marques category--produits-android category--samsung category--test category--tv-connectee-produits">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?webp=1&amp;resize=150,150&amp;key=672fe9d3 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?webp=1&amp;resize=75,75&amp;key=ee8907ac 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?webp=1&amp;resize=169,169&amp;key=ee8907ac 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="LG G6 vs Samsung S99H : quel est le meilleur téléviseur ? Et pourquoi" title="LG G6 vs Samsung S99H : quel est le meilleur téléviseur ? Et pourquoi" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?resize=150,150&amp;key=672fe9d3" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?resize=150,150&amp;key=672fe9d3" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?resize=150,150&amp;key=672fe9d3 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?resize=75,75&amp;key=ee8907ac 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?resize=169,169&amp;key=ee8907ac 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?resize=150,150&amp;key=672fe9d3 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?resize=75,75&amp;key=ee8907ac 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?resize=169,169&amp;key=ee8907ac 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="LG G6 vs Samsung S99H : quel est le meilleur téléviseur ? Et pourquoi" title="LG G6 vs Samsung S99H : quel est le meilleur téléviseur ? Et pourquoi" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?resize=150,150&key=672fe9d3" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-300x169.jpg?resize=150,150&key=672fe9d3 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?resize=75,75&key=ee8907ac 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/xiaomi-poco-f8-ultra-vs-google-pixel-10-1-768x432.jpg?resize=169,169&key=ee8907ac 300w"/></noscript>                                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/produits-android/tv-connectee-produits" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    <span class="has-text-weight-bold">TV</span>                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/produits-android/tv-connectee-produits/3084929_lg-g6-vs-samsung-s99h-quel-est-le-meilleur-televiseur-et-pourquoi" class="post-card__title-link stretched-link">
+                    LG G6 vs Samsung S99H : quel est le meilleur téléviseur ? Et pourquoi                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 16:00            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                                                
+<li class="post-card post-3081385 post-card--good-deal category--bons-plans category--bons-plans-pc-portable category--marques category--microsoft category--ordinateurs category--pc-portables category--produits-android">
+    <div class="columns is-vcentered is-mobile stretched-link-container m-0">
+        <div class="column is-narrow is-relative">
+            <div class="post-card__cover">
+                <div class="post-card__cover-inner">
+                                    <picture><source data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?webp=1&amp;resize=150,150&amp;key=e5db71e8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?webp=1&amp;resize=75,75&amp;key=56ece1f6 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?webp=1&amp;resize=169,169&amp;key=56ece1f6 300w" type="image/webp"><img decoding="async" width="150" height="150" loading="lazy" alt="Le Microsoft Surface Laptop 7 sous Snapdragon X Elite s’allège de 600 euros pendant les French Days" title="Le Microsoft Surface Laptop 7 sous Snapdragon X Elite s’allège de 600 euros pendant les French Days" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?resize=150,150&amp;key=e5db71e8" data-src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?resize=150,150&amp;key=e5db71e8" data-srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?resize=150,150&amp;key=e5db71e8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?resize=75,75&amp;key=56ece1f6 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?resize=169,169&amp;key=56ece1f6 300w" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?resize=150,150&amp;key=e5db71e8 150w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?resize=75,75&amp;key=56ece1f6 75w, https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?resize=169,169&amp;key=56ece1f6 300w"></picture><noscript><img decoding="async" width="150" height="150" loading="lazy" alt="Le Microsoft Surface Laptop 7 sous Snapdragon X Elite s&rsquo;allège de 600 euros pendant les French Days" title="Le Microsoft Surface Laptop 7 sous Snapdragon X Elite s&rsquo;allège de 600 euros pendant les French Days" class="post-card__image placeholder-square" src="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?resize=150,150&key=e5db71e8" srcset="https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-300x169.jpg?resize=150,150&key=e5db71e8 150w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?resize=75,75&key=56ece1f6 75w,https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/copie-de-french-days-printemps-frandroid-solo-7-768x432.jpg?resize=169,169&key=56ece1f6 300w"/></noscript>                                </div>
+                            <div class="post-card__badge badge badge--top-left badge--fixed-mobile
+                     has-bg-gradient-pink-inverted">
+                    <span aria-label="Bon plan" class="post-card__badge-icon has-text-body is-dark icon icon-fire"></span>
+                </div>
+                        </div>
+        </div>
+        <div class="column post-card__text">
+                            <p class="post-card__category-line">
+                <a href="https://www.frandroid.com/bons-plans" class="post-card__category is-uppercase has-text-weight-semibold stretched-link-above
+                   ">
+                    Bons plans                </a>
+            </p>
+                    <p class="post-card__title has-text-weight-semibold">
+                <a href="https://www.frandroid.com/bons-plans/3081385_le-microsoft-surface-laptop-7-sous-snapdragon-x-elite-sallege-de-600-euros-pendant-les-french-days" class="post-card__title-link stretched-link">
+                    Le Microsoft Surface Laptop 7 sous Snapdragon X Elite s’allège de 600 euros pendant les French Days                </a>
+            </p>
+                            <p class="post-card__date has-text-right-mobile">
+                <span class="has-text-weight-semibold is-hidden-mobile">01 mai 2026</span><span class="has-text-weight-semibold is-hidden-tablet">01/05/2026</span> • 15:22            </p>
+                </div>
+    </div>
+
+
+
+
+</li>
+                        </ul>
+    
+                                        <div class="pagination js-no-pagination">
+    <div class="clearfix pagination-index bar-header" data-numarticles="10"><div class="pagination__simple"><a class="active" href="https://www.frandroid.com/">1</a><a class="inactive" href="https://www.frandroid.com/page/2">2</a><a class="inactive" href="https://www.frandroid.com/page/3">3</a><a class="inactive" href="https://www.frandroid.com/page/4">4</a><a class="inactive" href="https://www.frandroid.com/page/5">5</a><a class="inactive" href="https://www.frandroid.com/page/6">6</a><a class="inactive" href="https://www.frandroid.com/page/7">7</a><a class="inactive" href="https://www.frandroid.com/page/8">8</a><a class="inactive" href="https://www.frandroid.com/page/9">9</a><a class="inactive arrow next" href="https://www.frandroid.com/page/10"><i aria-hidden="true" class="icon-arrow-right"></i></a><a class="inactive arrow last" href="https://www.frandroid.com/page/11486"><span class="icon-last"></span></a></div><div class="pagination__jumps"><div><a class="inactive" href="https://www.frandroid.com/page/10">10</a><a class="inactive" href="https://www.frandroid.com/page/20">20</a><a class="inactive" href="https://www.frandroid.com/page/30">30</a><a class="inactive" href="https://www.frandroid.com/page/40">40</a><a class="inactive" href="https://www.frandroid.com/page/50">50</a><a class="inactive" href="https://www.frandroid.com/page/60">60</a><a class="inactive" href="https://www.frandroid.com/page/70">70</a><a class="inactive" href="https://www.frandroid.com/page/80">80</a><a class="inactive" href="https://www.frandroid.com/page/90">90</a></div><div><a class="inactive" href="https://www.frandroid.com/page/100">100</a><a class="inactive" href="https://www.frandroid.com/page/200">200</a><a class="inactive" href="https://www.frandroid.com/page/300">300</a><a class="inactive" href="https://www.frandroid.com/page/400">400</a><a class="inactive" href="https://www.frandroid.com/page/500">500</a><a class="inactive" href="https://www.frandroid.com/page/600">600</a><a class="inactive" href="https://www.frandroid.com/page/700">700</a><a class="inactive" href="https://www.frandroid.com/page/800">800</a><a class="inactive" href="https://www.frandroid.com/page/900">900</a></div><div><a class="inactive" href="https://www.frandroid.com/page/1000">1000</a><a class="inactive" href="https://www.frandroid.com/page/2000">2000</a><a class="inactive" href="https://www.frandroid.com/page/3000">3000</a><a class="inactive" href="https://www.frandroid.com/page/4000">4000</a><a class="inactive" href="https://www.frandroid.com/page/5000">5000</a><a class="inactive" href="https://www.frandroid.com/page/6000">6000</a><a class="inactive" href="https://www.frandroid.com/page/7000">7000</a><a class="inactive" href="https://www.frandroid.com/page/8000">8000</a><a class="inactive" href="https://www.frandroid.com/page/9000">9000</a></div></div></div></div>
+    </div>
+        </section>
+    </aside>
+
+            </main>
+        </div>
+
+        <footer role="contentinfo" class="py-600 xl:py-800">
+  <div class="o-wrapper o-flow [--o-flow-spce:theme(spacing.800)] [--o-pill-color:theme(colors.primary)] [--wrapper-max-size:62.5rem]">
+    <div class="site-footer-logo">
+      <svg width="574" height="157" viewBox="0 0 574 157"><title>Frandroid, La référence tech pour s’informer, comparer et bien acheter</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/logos/survoltes-logo-CCuvPa8h.svg#survoltes-logocombined"></use></svg>
+    </div>
+
+        <p class="sr-only">frandroid sur les reseaux sociaux</p>
+    <ul class="o-cluster justify-center site-footer-networks">
+              <li><a href="https://x.com/frandroid" target="_blank" title="X" rel="noopener"><svg width="22" height="32" viewBox="0 0 22 32" class="svg-monochrome"><title>X</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/x-social-D_DnH6zA.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://www.instagram.com/frandroid_off" target="_blank" title="Instagram" rel="noopener"><svg width="26" height="32" viewBox="0 0 26 32" class="svg-monochrome"><title>Instagram</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/instagram-CIO3lLh6.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://www.facebook.com/frandroidcom" target="_blank" title="Facebook" rel="noopener"><svg width="14" height="32" viewBox="0 0 14 32" class="svg-monochrome"><title>Facebook</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/facebook-DEFveSjP.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://www.frandroid.com/feed" target="_blank" title="RSS" rel="noopener"><svg width="25" height="32" viewBox="0 0 25 32" class="svg-monochrome"><title>RSS</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/rss-Do3QjRMt.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://www.youtube.com/frandroid" target="_blank" title="YouTube" rel="noopener"><svg width="27" height="32" viewBox="0 0 27 32" class="svg-monochrome"><title>YouTube</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/youtube-CMifUhgJ.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://www.twitch.tv/frandroidlive" target="_blank" title="Twitch" rel="noopener"><svg width="24" height="32" viewBox="0 0 24 32" class="svg-monochrome"><title>Twitch</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/twitch-C3kXzQp5.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://www.tiktok.com/@frandroid_" target="_blank" title="TikTok" rel="noopener"><svg width="20" height="32" viewBox="0 0 20 32" class="svg-monochrome"><title>TikTok</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/tiktok-BWIQeLNI.svg#root"></use></svg></a>
+</li>
+              <li><a href="https://bsky.app/profile/frandroid.com" target="_blank" title="Bluesky" rel="noopener"><svg width="25" height="32" viewBox="0 0 25 32" class="svg-monochrome"><title>Bluesky</title><use href="https://www.frandroid.com/wp-content/mu-plugins/optimus/build/images/icons/bluesky-sUdumn3r.svg#root"></use></svg></a>
+</li>
+          </ul>
+    
+        <nav class="footer-categories" aria-label="Navigation par catégories">
+      <ul data-menu-depth="0">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones" target="_self">
+          Smartphones
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/apple" target="_self">
+          Apple iPhone
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/google" target="_self">
+          Google Pixel
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/huawei" target="_self">
+          Huawei
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/motorola" target="_self">
+          Motorola
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/oppo" target="_self">
+          Oppo
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/samsung" target="_self">
+          Samsung Galaxy
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/sony" target="_self">
+          Sony Xperia
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smartphones/xiaomi" target="_self">
+          Xiaomi
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles" target="_self">
+          Gaming
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/asus" target="_self">
+          ASUS
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/ayaneo" target="_self">
+          Ayaneo
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/lenovo" target="_self">
+          Lenovo Legion
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/microsoft" target="_self">
+          Microsoft Xbox
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/nintendo" target="_self">
+          Nintendo
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/box-multimedia/nvidia" target="_self">
+          Nvidia Shield
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/sony" target="_self">
+          Sony Playstation
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/consoles/valve" target="_self">
+          Valve
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables" target="_self">
+          PC Portables
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/acer" target="_self">
+          Acer
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/apple" target="_self">
+          Apple Macbook
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/dell" target="_self">
+          Dell
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/lenovo" target="_self">
+          Lenovo
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/honor" target="_self">
+          Honor
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/hp" target="_self">
+          HP
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/microsoft" target="_self">
+          Microsoft Surface
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/pc-portables/samsung" target="_self">
+          Samsung Chromebook
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures" target="_self">
+          Automobile
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/audi" target="_self">
+          Audi
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/byd" target="_self">
+          BYD
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/citroen" target="_self">
+          Citroën
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/ford" target="_self">
+          Ford
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/mg" target="_self">
+          MG
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/peugeot" target="_self">
+          Peugeot
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/renault" target="_self">
+          Renault
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/tesla" target="_self">
+          Tesla
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/voitures/volkswagen" target="_self">
+          Volkswagen
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv" target="_self">
+          TV
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/hisense" target="_self">
+          Hisense
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/lg" target="_self">
+          LG
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/panasonic" target="_self">
+          Panasonic
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/philips" target="_self">
+          Philips
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/samsung" target="_self">
+          Samsung
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/sony" target="_self">
+          Sony
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/tcl" target="_self">
+          TCL
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/videoprojecteurs/xgimi" target="_self">
+          Xgimi
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/smart-tv/xiaomi" target="_self">
+          Xiaomi
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/audio-casques-ecouteurs" target="_self">
+          Audio
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/ecouteurs-true-wireless/apple" target="_self">
+          Apple Airpods
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/casque-audio/bose" target="_self">
+          Bose
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/ecouteurs-true-wireless/jabra" target="_self">
+          Jabra
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/casque-audio/jbl" target="_self">
+          JBL
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/casque-audio/nothing" target="_self">
+          Nothing
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/ecouteurs-true-wireless/samsung" target="_self">
+          Samsung Galaxy Buds
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/casque-audio/sennheiser" target="_self">
+          Sennheiser
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/casque-audio/sony" target="_self">
+          Sony
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/ecouteurs-true-wireless/xiaomi" target="_self">
+          Xiaomi
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes" target="_self">
+          Montres connectées
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/amazfit" target="_self">
+          Amazfit
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/apple" target="_self">
+          Apple Watch
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/fitbit" target="_self">
+          Fitbit
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/garmin" target="_self">
+          Garmin
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/huawei" target="_self">
+          Huawei
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/samsung" target="_self">
+          Samsung Galaxy Watch
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/montres-bracelet-connectes/xiaomi" target="_self">
+          Xiaomi
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles" target="_self">
+          Tablettes
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles/apple" target="_self">
+          Apple iPad
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles/huawei" target="_self">
+          Huawei
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles/lenovo" target="_self">
+          Lenovo
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles/microsoft" target="_self">
+          Microsoft Surface
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles/samsung" target="_self">
+          Samsung Galaxy Tab
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/tablettes-tactiles/xiaomi" target="_self">
+          Xiaomi
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique" target="_self">
+          Vélos électriques
+                  </a>
+      
+              <ul class="submenu" data-menu-depth="1">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/cowboy" target="_self">
+          Cowboy
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/decathlon" target="_self">
+          Decathlon
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/gaya" target="_self">
+          Gaya
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/moustache" target="_self">
+          Moustache
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/nakamura" target="_self">
+          Nakamura
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/tenways" target="_self">
+          Tenways
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/produits/velo-electrique/vanmoof" target="_self">
+          Vanmoof
+                  </a>
+      
+          </li>
+  </ul>
+
+          </li>
+  </ul>
+
+    </nav>
+    
+          <p class="sr-only">En tendances</p>
+      <ul class="o-cluster justify-center items-center [--o-cluster-gap:1.5ch] text-4xs text-primary font-semibold">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/guide-dachat/smartphones/332196_10-smartphones-attendus-debut-2016#utm_medium=frandroid&amp;utm_source=header_tendance&amp;utm_campaign=2002_meilleurs_smartphones" target="_self">
+          Meilleurs smartphones
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/comparateur-forfaits" target="_self">
+          Forfaits mobile
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/guide-dachat/smartphones/275349_quel-smartphone-choisir-moins-de-200-euros" target="_self">
+          Smartphone pas cher
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/marques/apple/2362376_test-de-liphone-16-un-bon-smartphone-mais-pas-pour-tout-le-monde" target="_self">
+          Test iPhone 17
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/produits/xiaomi/smartphones/597372-xiaomi-redmi-k20-pro" target="_self">
+          Xiaomi Mi 9T Pro
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/android/mises-a-jour-android/2424108_mise-a-jour-android-16-smartphones-compatibles-nouveautes-dates-tout-ce-quil-faut-savoir" target="_self">
+          Android 16
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/comparatif-meilleures-banques-en-ligne" target="_self">
+          Comparateur banques en ligne
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/offre-internet-comparateur-des-meilleures-offres-fibre-et-adsl" target="_self">
+          Box internet
+                  </a>
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a class="o-pill" href="https://www.frandroid.com/marques/samsung/2482652_test-samsung-galaxy-s25-ultra" target="_self">
+          Test Samsung S25 Ultra
+                  </a>
+          </li>
+  </ul>
+
+    
+        <nav class="site-footer-metas" aria-label="Navigation de pied de page">
+      <ul data-menu-depth="0">
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/mentions-legales" target="_self">
+          Mentions légales
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-post_type menu-item-object-page">
+              <a href="https://www.frandroid.com/a-propos" target="_self">
+          À propos
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/contact" target="_self">
+          Contacts
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-custom menu-item-object-custom">
+              <a href="https://www.frandroid.com/politique-cookies" target="_self">
+          Politique Cookies
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-post_type menu-item-object-page">
+              <a href="https://www.frandroid.com/politique-donnees-personnelles" target="_self">
+          Données personnelles
+                  </a>
+      
+          </li>
+      <li class=" menu-item menu-item-type-post_type menu-item-object-page">
+              <a href="https://www.frandroid.com/gerer-le-consentement-utiq" target="_self">
+          Gérer UTIQ
+                  </a>
+      
+          </li>
+  </ul>
+
+    </nav>
+    
+    <p class="site-footer-copyright">Humanoid © 2026 - Frandroid, tous droits réservés</p>
+  </div>
+</footer>
+        
+<div class="search-modal js-search-modal ">
+    <div class="container">
+        <button class="search-modal__close fr-button-close js-close-search" aria-label="Fermer"></button>
+        <div class="search-modal__content mt-6-mobile">
+                <div class="search-text-above mb-4">
+        <span>Recherche IA boostée par</span>
+        <div class="svg-wrapper perplexity-icon">
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24"><path fill="#21808d" d="M19.785 0v7.272H22.5V17.62h-2.935V24l-7.037-6.194v6.145h-1.091v-6.152L4.392 24v-6.465H1.5V7.188h2.884V0l7.053 6.494V.19h1.09v6.49L19.786 0zm-7.257 9.044v7.319l5.946 5.234V14.44l-5.946-5.397zm-1.099-.08l-5.946 5.398v7.235l5.946-5.234V8.965zm8.136 7.58h1.844V8.349H13.46l6.105 5.54v2.655zm-8.982-8.28H2.59v8.195h1.8v-2.576l6.192-5.62zM5.475 2.476v4.71h5.115l-5.115-4.71zm13.219 0l-5.115 4.71h5.115v-4.71z"></path></svg></div>
+        <span class="svg-perplexity-text">
+            <div class="svg-wrapper ">
+    <svg xmlns="http://www.w3.org/2000/svg" height="1em" fill="currentColor" fill-rule="evenodd" style="flex:none;line-height:1" viewBox="0 0 117 24"><title>Perplexity</title><path d="M38.542 5.218h1.151V7.59h-1.49c-1.167 0-2.036.281-2.612.843-.575.563-.863 1.485-.863 2.768v7.773h-2.351V5.271h2.351v2.187c0 .123.062.185.184.185.069 0 .121-.017.157-.053a.58.58 0 00.104-.211c.453-1.44 1.577-2.16 3.371-2.16h-.002zm15.36 2.938c.617 1.098.928 2.42.928 3.966 0 1.545-.309 2.867-.928 3.965-.62 1.098-1.42 1.92-2.404 2.464a6.446 6.446 0 01-3.174.817c-2.23 0-3.797-.896-4.703-2.688-.069-.14-.157-.211-.262-.211-.105 0-.157.052-.157.158v7.352h-2.351V5.271h2.351v2.345c0 .106.052.159.157.159.105 0 .191-.07.262-.211.906-1.793 2.473-2.689 4.703-2.689 1.132 0 2.19.272 3.174.817.984.545 1.785 1.366 2.404 2.464zm-1.424 3.966c0-1.617-.43-2.877-1.292-3.781-.862-.904-1.998-1.357-3.41-1.357-1.413 0-2.548.453-3.41 1.357-.863.905-1.179 2.166-1.179 3.78 0 1.616.316 2.878 1.178 3.782.863.905 2 1.356 3.41 1.356 1.411 0 2.549-.453 3.411-1.356.862-.904 1.292-2.166 1.292-3.781zM15.05 8.177c.618 1.098.928 2.42.928 3.965 0 1.546-.308 2.868-.928 3.966-.619 1.098-1.42 1.919-2.403 2.464a6.448 6.448 0 01-3.175.817c-2.23 0-3.797-.896-4.702-2.688-.07-.14-.158-.212-.262-.212-.105 0-.158.053-.158.159V24H2V5.292h2.351v2.345c0 .106.053.159.158.159.104 0 .19-.07.261-.212.906-1.792 2.473-2.688 4.703-2.688 1.132 0 2.19.272 3.175.817.983.545 1.784 1.366 2.403 2.464h-.002zm-1.423 3.965c0-1.616-.43-2.877-1.293-3.78-.862-.904-1.998-1.357-3.41-1.357-1.412 0-2.548.453-3.41 1.357-.862.905-1.178 2.165-1.178 3.78 0 1.615.316 2.878 1.178 3.781.862.906 1.998 1.357 3.41 1.357 1.412 0 2.548-.453 3.41-1.357.863-.903 1.293-2.166 1.293-3.78zm14.422 2.481h2.482c-.33 1.283-1.006 2.395-2.023 3.334-1.02.94-2.479 1.41-4.378 1.41-1.429 0-2.686-.295-3.775-.884a6.13 6.13 0 01-2.521-2.516c-.593-1.089-.889-2.372-.889-3.847 0-1.476.288-2.758.863-3.847.574-1.089 1.38-1.928 2.417-2.517 1.036-.588 2.25-.883 3.644-.883 1.393 0 2.547.29 3.514.87.968.58 1.69 1.349 2.168 2.305.48.959.719 2.008.719 3.15v1.58H19.427c.086 1.37.544 2.46 1.37 3.268.828.807 1.939 1.213 3.332 1.213 1.132 0 2-.232 2.6-.698.601-.466 1.04-1.111 1.32-1.938zm-8.595-3.82h8.204c0-1.194-.305-2.13-.914-2.807-.61-.676-1.568-1.015-2.874-1.015-1.22 0-2.217.33-2.99.988-.775.659-1.25 1.604-1.424 2.832l-.002.002zm37.238 8.17h2.352V0H56.69v18.974-.002zM89.316 3.774h2.747V.81h-2.747v2.966zm9.688 13.156c-.426.043-.684.066-.77.066a.39.39 0 01-.289-.106.395.395 0 01-.104-.29c0-.087.022-.348.065-.778.043-.43.066-1.094.066-1.988V7.279h3.354l-.66-2.008h-2.692v-3.69h-2.352v3.688h-2.557v2.008h2.557v7.214c0 1.512.367 2.636 1.098 3.374.732.737 1.846 1.107 3.345 1.107h1.83v-2.107h-.915c-.889 0-1.547.022-1.974.066h-.002zm13.759-11.662l-3.893 11.498c-.053.141-.135.326-.402.326-.268 0-.35-.185-.402-.326l-3.893-11.498h-2.398l4.508 13.703h1.594a.81.81 0 01.235.026c.053.017.096.06.131.133.07.105.06.264-.026.473l-.731 2.002c-.105.264-.305.396-.6.396-.106 0-.349-.023-.732-.066a13.71 13.71 0 00-1.49-.066h-1.907v2.107h2.508c1.463 0 2.344-.25 3.102-.75.757-.5 1.345-1.383 1.764-2.65L115 5.795v-.526h-2.237v.001zm-31.127 5.113L77.953 5.27h-2.588v.527l4.415 5.93-5.382 6.72v.526h2.64l4.285-5.507 3.998 5.507h2.535v-.526l-4.677-6.324 5.07-6.298v-.553h-2.64l-3.971 5.113-.002-.002zm7.931 8.59h2.351v-13.7h-2.35v13.702-.002zm-15.062-4.349c-.331 1.283-1.006 2.395-2.024 3.334-1.02.94-2.479 1.41-4.377 1.41-1.43 0-2.686-.295-3.775-.884a6.13 6.13 0 01-2.522-2.516c-.593-1.089-.888-2.372-.888-3.847 0-1.476.288-2.758.862-3.847.574-1.089 1.38-1.928 2.417-2.517 1.036-.588 2.25-.883 3.644-.883 1.394 0 2.547.29 3.515.87.967.58 1.689 1.349 2.168 2.305.479.959.718 2.008.718 3.15v1.58H63.401c.086 1.37.544 2.46 1.371 3.268.827.807 1.938 1.213 3.332 1.213 1.132 0 2-.232 2.6-.698.6-.466 1.04-1.111 1.319-1.938h2.482zm-11.078-3.82h8.205c0-1.194-.305-2.13-.915-2.807-.61-.676-1.568-1.015-2.873-1.015-1.22 0-2.217.33-2.991.988-.775.659-1.25 1.604-1.424 2.832l-.002.002z"></path></svg></div>
+        </span>
+    </div>
+
+<div class="search-field">
+    
+</div>
+        </div>
+    </div>
+</div>
+        
+<div class="modal is-hidden" id="js-main-modal">
+  <div class="modal__content">
+    <p class="modal__title is-size-5 has-text-gradient-primary">Réglages</p>
+    <a class="modal__close" id="js-main-modal-close">
+      <i class="icon icon-cross-light"></i>
+    </a>
+    
+  </div>
+</div>
+        <div id="react-alert-root"></div>
+        
+                
+                    
+            
+<link rel="stylesheet" id="theme-off-screen-6253a6e5b3fd52a0-css" href="https://www.frandroid.com/wp-content/themes/humanoid-redesign/dist/styles/off-screen-vCFdZRffGAcavufenVth8.css" type="text/css" media="all">
+
+
+
+
+
+
+
+        <div id="react-cookies-popin-root"></div>
+    
+
+
+</body></html>

--- a/src/extractors/custom/index.js
+++ b/src/extractors/custom/index.js
@@ -198,3 +198,4 @@ export * from './gr.euronews.com';
 export * from './www.ilfattoquotidiano.it';
 export * from './actualidad.rt.com';
 export * from './www.tweaktown.com';
+export * from './www.frandroid.com';

--- a/src/extractors/custom/www.frandroid.com/index.js
+++ b/src/extractors/custom/www.frandroid.com/index.js
@@ -1,0 +1,40 @@
+export const WwwFrandroidComExtractor = {
+  domain: 'www.frandroid.com',
+
+  title: {
+    selectors: [['meta[name="og:title"]', 'value']],
+  },
+
+  author: {
+    selectors: [['meta[name="parsely-author"]', 'value']],
+  },
+
+  date_published: {
+    selectors: [['meta[name="article:published_time"]', 'value']],
+  },
+
+  dek: {
+    selectors: [['meta[name="og:description"]', 'value']],
+  },
+
+  lead_image_url: {
+    selectors: [['meta[name="og:image"]', 'value']],
+  },
+
+  content: {
+    selectors: ['section.article-content'],
+
+    transforms: {},
+
+    clean: [
+      '.index-menu-wrapper',
+      '.is-gastric-kingfisher',
+      '.newsletter-form',
+      '.share',
+      '.article-footer',
+      '.js-feed-posts',
+      '.optidigital-adslot',
+      '[id^="optidigital-adslot"]',
+    ],
+  },
+};

--- a/src/extractors/custom/www.frandroid.com/index.test.js
+++ b/src/extractors/custom/www.frandroid.com/index.test.js
@@ -1,0 +1,80 @@
+import assert from 'assert';
+import * as cheerio from 'cheerio';
+
+import Parser from 'mercury';
+import getExtractor from 'extractors/get-extractor';
+import { excerptContent } from 'utils/text';
+
+const fs = require('fs');
+
+describe('WwwFrandroidComExtractor', () => {
+  describe('initial test case', () => {
+    let result;
+    let url;
+    beforeAll(() => {
+      url =
+        'https://www.frandroid.com/marques/nakamura/3084049_test-nakamura-crosscity-la-meilleure-affaire-du-moment-pour-transporter-vos-enfants-a-velo-cargo-electrique';
+      const html = fs.readFileSync(
+        './fixtures/www.frandroid.com/1777688498862.html'
+      );
+      result = Parser.parse(url, { html, fallback: false });
+    });
+
+    it('is selected properly', () => {
+      const extractor = getExtractor(url);
+      assert.strictEqual(extractor.domain, new URL(url).hostname);
+    });
+
+    it('returns the title', async () => {
+      const { title } = await result;
+
+      assert.strictEqual(
+        title,
+        `La nouvelle pépite d’Intersport : on a roulé avec ce vélo cargo compact à moins de 2200 €`
+      );
+    });
+
+    it('returns the author', async () => {
+      const { author } = await result;
+
+      assert.strictEqual(author, 'Matthieu Lauraux');
+    });
+
+    it('returns the date_published', async () => {
+      const { date_published } = await result;
+
+      assert.strictEqual(date_published, `2026-05-01T16:02:11.000Z`);
+    });
+
+    it('returns the dek', async () => {
+      const { dek } = await result;
+
+      assert.strictEqual(
+        dek,
+        'Vélo cargo électrique compact et relativement léger, le Nakamura Crosscity+ n’a certes pas les capacités d’un longtail mais propose un bon équipement et un moteur central performant.'
+      );
+    });
+
+    it('returns the lead_image_url', async () => {
+      const { lead_image_url } = await result;
+
+      assert.strictEqual(
+        lead_image_url,
+        `https://c0.lestechnophiles.com/images.frandroid.com/wp-content/uploads/2026/04/nakamura-crosscity-essai-velo-electrique-cargo.jpg?resize=1600,900&key=393ce73a&watermark`
+      );
+    });
+
+    it('returns the content', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      const first13 = excerptContent($('*').first().text(), 13);
+
+      assert.strictEqual(
+        first13,
+        'Le vélo cargo électrique est un investissement non négligeable pour la petite famille.'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a custom mercury-parser extractor for `www.frandroid.com` to address `jocmp/capyreader#1721` ("half of articles don't show at all in full content").
- Pulls article body from `section.article-content` (single selector) so the article wrapper is consistently picked up regardless of layout, with newsletter/related/ad blocks cleaned out.
- Uses meta tags for title, date, dek, and lead image. Author falls back to `parsely-author` because the page emits multiple `meta[name="author"]` tags which Mercury's meta extractor skips.

## Test plan
- [x] `npx jest src/extractors/custom/www.frandroid.com/index.test.js` passes (7/7)
- [ ] Verify in capyreader against a sample of articles from `http://feeds.feedburner.com/frandroid`

Refs jocmp/capyreader#1721