### PR TITLE
Add motorsport.com custom parser

### DIFF
--- a/fixtures/www.motorsport.com/1770093049254.html
+++ b/fixtures/www.motorsport.com/1770093049254.html
@@ -1,0 +1,8933 @@
+<!DOCTYPE html><html id="document" class="document" prefix="og: http://ogp.me/ns#" lang="en" dir="ltr"><head>
+    <title>"Very unfortunate" Isack Hadjar crash leaves Red Bull undecided on third F1 test day</title><meta name="robots" value="max-snippet:500, max-image-preview:large, max-video-preview:10">
+<meta value="&amp;quot;Very unfortunate&amp;quot; Isack Hadjar crash leaves Red Bull undecided on third F1 test day" name="og:title">
+<meta value="article" name="og:type">
+<meta value="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www" name="og:url">
+<meta value="https://cdn-2.motorsport.com/images/amp/01QdMbx0/s6/isack-hadjar-red-bull-racing.jpg" name="og:image">
+<meta value="1200" name="og:image:width">
+<meta value="800" name="og:image:height">
+<meta value="Hadjar crashed his Red Bull RB22 on a treacherous wet second day of Formula 1's Barcelona shakedown" name="og:description">
+<meta value="100001157785488" name="fb:admins">
+<meta value="1017388998271288" name="fb:app_id">
+<meta value="263938209441" name="fb:pages">
+<meta value="summary_large_image" name="twitter:card">
+<link href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" rel="canonical">
+<link href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" hreflang="x-default" rel="alternate">
+<link href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" hreflang="en" rel="alternate">
+<link href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" hreflang="en-US" rel="alternate">
+<link href="https://au.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793340/" hreflang="en-AU" rel="alternate">
+<link href="https://www.autosport.com/f1/news/red-bull-undecided-on-third-barcelona-f1-test-day-after-very-unfortunate-hadjar-crash/10793341/" hreflang="en-GB" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-AR" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-CO" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-CL" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-VE" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-PE" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-UY" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-EC" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-MX" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-PY" rel="alternate">
+<link href="https://lat.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793343/" hreflang="es-BO" rel="alternate">
+<link href="https://espanol.motorsport.com/f1/news/accidente-hadjar-deja-red-bull-dudas-rodar-miercoles-barcelona/10793344/" hreflang="es-US" rel="alternate">
+<link href="https://jp.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793351/" hreflang="ja" rel="alternate">
+<link href="https://www.motorsport.com/rss/google/" type="application/rss+xml" rel="alternate">
+                <meta name="viewport" value="width=device-width, initial-scale=1">
+        
+    
+    
+    
+
+
+    <link rel="preconnect" href="https://fonts.googleapis.com/">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:ital,wght@0,400;0,700;1,400;1,700&amp;family=Barlow:ital,wght@0,400;0,700;1,400;1,700&amp;display=fallback" rel="stylesheet">
+
+    
+        <meta name="apple-itunes-app" data-icon-url="/design/images/webapp/i196.png" data-params="ct=smart-banner&amp;mt=8" value="app-id=1459863859">
+    <meta name="google-play-app" data-icon-url="/design/images/webapp/i196.png" data-params="referrer=https%3A%2F%2Fwww.motorsport.com%2Ff1%2Fnews%2Fvery-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day%2F10793339%2F&amp;utm_campaign=installations&amp;utm_medium=smart-banner&amp;utm_source=www.motorsport.com" value="app-id=com.motorsport.application">
+    
+    <link href="https://www.motorsport.com/design/images/webapp/i57.png" sizes="57x57" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i72.png" sizes="72x72" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i76.png" sizes="76x76" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i128.png" sizes="128x128" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i144.png" sizes="144x144" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i152.png" sizes="152x152" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i180.png" sizes="180x180" rel="apple-touch-icon-precomposed">
+    <link href="https://www.motorsport.com/design/images/webapp/i196.png" sizes="196x196" rel="apple-touch-icon-precomposed">
+
+            <link rel="shortcut icon" type="image/x-icon" href="https://www.motorsport.com/favicon-v2.ico">
+        <link rel="manifest" href="https://www.motorsport.com/manifest.json">
+
+    <meta name="pubdate" value="20260127">
+<meta name="datePublished" value="2026-01-27T20:16:22Z">
+<meta http-equiv="Content-Type" value="text/html;charset=utf-8">
+<meta http-equiv="X-UA-Compatible" value="IE=Edge">
+<meta name="alexaVerifyID" value="bVEzjJq-W0PC2QTcmK4a8fz6__k">        <link rel="preload" as="image" imagesrcset="https://cdn-6.motorsport.com/images/amp/01QdMbx0/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1200/isack-hadjar-red-bull-racing.webp 1200w" imagesizes="(min-width: 1025px) 1000px" fetchpriority="high">
+        
+
+
+
+
+
+
+
+
+
+    
+        
+
+
+
+
+    
+                    
+                    
+                    
+                        
+    <link rel="preload" as="script" fetchpriority="high" href="https://motorsport-cdn.relevant-digital.com/static/tags/66a797d49cab8178d07a57e0.js">
+    <link rel="preload" as="script" fetchpriority="high" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js?network-code=6122441">
+        
+<link rel="preconnect" fetchpriority="high" href="https://froomle-proxy.motorsport.com/">    
+
+
+    
+
+    
+
+
+
+
+
+    
+    
+        
+</head>
+<body id="app_article_detail" class="
+                            " data-edtn="global" data-edtn-rtl="0" data-has-parent-edtn="" data-page-type="detail" data-page-content-type="article" data-edtn-locale="en-US">
+    <div class="ms-apb ms-apb-outstream "><div id="ads_6122441_MST_global_Outstream_adhesion_1770093040" class="ms-ap" data-id="8" data-ad-unit-id="/6122441/MST/global/Outstream/adhesion" style="width:1px;min-height:1px;" data-dfp-code="MST/global/Outstream" data-width="1" data-height="1" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;adhesion&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;adhesion&quot;}" data-msnt-label="Advertisement"></div></div>    <div class="ms-apb ms-apb-overlay "><div id="ads_6122441_MST_global_Overlay_overlay_1770093040" class="ms-ap" data-id="8" data-ad-unit-id="/6122441/MST/global/Overlay/overlay" style="width:0px;min-height:0px;" data-dfp-code="MST/global/Overlay" data-width="0" data-height="0" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;overlay&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;overlay&quot;}" data-msnt-label="Advertisement"></div></div>
+    
+    <div class="root">
+        <a href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www#main-content" class="absolute z-max -start-full focus:start-0 p-2 bg-menu-bg-main text-menu-fg-main">Skip to main content</a>
+        
+        <header class="ms-header ms-mobile-header">
+    <div class="ms-mobile-header__row ms-mobile-header__row--start">
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--lg msnt-icon-button--rounded-default ms-mobile-header__menu-btn" title="Main menu" commandfor="main-menu-drawer" command="--show">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-8 w-8 h-8 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#menu-2"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-8 w-8 h-8 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        <div class="ms-mobile-header__center mr-auto">
+            
+<div class="ms-header__logo-wrapper">
+    <a href="https://www.motorsport.com/">
+                                    <svg class="ms-header__logo" aria-label="Motorsport.com">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-logo"></use>
+                </svg>
+                        </a>
+</div>        </div>
+
+        <div class="ms-mobile-header__end">
+            
+<msnt-color-scheme-switcher state="" class="msnt-color-scheme-switcher  ">
+                    
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-color-scheme-option msnt-color-scheme-option--default -mx-2" title="System">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href=""></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-color-scheme-option msnt-color-scheme-option--light -mx-2" title="Light">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#sun"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-color-scheme-option msnt-color-scheme-option--dark -mx-2" title="Dark">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#moon"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+    </msnt-color-scheme-switcher>
+            
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default ms-user-avatar" title="User menu" commandfor="msnt-user-menu-drawer" command="--show">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#user-circle"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+        </div>
+    </div>
+
+    <div class="ms-mobile-header__row ms-mobile-header__row--end border-b border-b-menu-border-main ">
+        
+<nav class="ms-mobile-menu-wrapper default visible">
+    <ul class="ms-mobile-menu text-3.5 leading-4 font-bold uppercase  ms-mobile-menu--series default">
+                            <li class="ms-mobile-menu__item current ws sticky">
+    <div class="w-full h-full relative">
+        <div class="ms-mobile-menu-select__label h-full w-full bg-menu-bg font-secondary pr-1">
+            <span>Formula 1</span>
+            <svg class="w-3 h-3" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+            </svg>
+        </div>
+        <select name="series-select" id="ms-mobile-menu-select" class="ms-mobile-menu__select">
+            
+                            <option value="All Series" data-url="/">             
+                    All Series                </option>
+                            <option value="Formula 1" data-url="/f1/" selected="">             
+                    Formula 1                </option>
+                            <option value="MotoGP" data-url="/motogp/">             
+                    MotoGP                </option>
+                            <option value="NASCAR Cup" data-url="/nascar-cup/">             
+                    NASCAR Cup                </option>
+                            <option value="WEC" data-url="/wec/">             
+                    WEC                </option>
+                            <option value="IndyCar" data-url="/indycar/">             
+                    IndyCar                </option>
+                            <option value="WRC" data-url="/wrc/">             
+                    WRC                </option>
+                            <option value="IMSA" data-url="/imsa/">             
+                    IMSA                </option>
+                            <option value="FIA F2" data-url="/fia-f2/">             
+                    FIA F2                </option>
+                    </select>
+    </div>    
+</li>
+
+    <li class="ms-mobile-menu__subitem  ">
+        <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/">
+            <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Home</span>
+        </a>
+    </li>
+
+    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/news/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">News</span>
+    </a>
+</li>    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/schedule/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Schedule</span>
+    </a>
+</li>    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/results/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Results</span>
+    </a>
+</li>    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/standings/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Standings</span>
+    </a>
+</li>    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/videos/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Videos</span>
+    </a>
+</li>    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/drivers/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Drivers</span>
+    </a>
+</li>    
+<li class="ms-mobile-menu__subitem ws ">
+    <a class="ms-mobile-menu__subitem-link" href="https://www.motorsport.com/f1/teams/">
+        <span class="ms-mobile-menu__subitem-title text-3.5 leading-3.5 uppercase font text-menu-fg">Teams</span>
+    </a>
+</li>            </ul>
+</nav>
+    </div>
+
+    </header><header class="ms-header ms-desktop-header-container">
+    <div class="ms-desktop-header">
+        <div class="ms-desktop-header__start">
+            
+<div class="ms-header__logo-wrapper">
+    <a href="https://www.motorsport.com/">
+                                    <svg class="ms-header__logo" aria-label="Motorsport.com">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-logo"></use>
+                </svg>
+                        </a>
+</div>        </div>
+        <nav class="ms-desktop-header__center">
+            
+<div class="ms-desktop-menu default visible">
+    <ul class="ms-desktop-menu__main">
+                            
+<li class="ms-desktop-menu__item current ws" style="anchor-name: --msnt-mm-1-0;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/f1/" interestfor="msnt-mm-1-0">
+        Formula 1    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-0" style="position-anchor: --msnt-mm-1-0; anchor-name: --msnt-mm-2-0;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/news/">
+                        News                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/schedule/">
+                        Schedule                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/results/">
+                        Results                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/standings/">
+                        Standings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/galleries/">
+                        Photo galleries                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/videos/">
+                        Videos                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/drivers/">
+                        Drivers                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/teams/">
+                        Teams                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1/driver-ratings/">
+                        Ratings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/live/">
+                        Live                    </a>
+
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-1;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/" interestfor="msnt-mm-1-1">
+        MotoGP    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-1" style="position-anchor: --msnt-mm-1-1; anchor-name: --msnt-mm-2-1;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/news/">
+                        News                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/schedule/">
+                        Schedule                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/results/">
+                        Results                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/standings/">
+                        Standings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/galleries/">
+                        Photo galleries                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/videos/">
+                        Videos                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/drivers/">
+                        Drivers                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/motogp/teams/">
+                        Teams                    </a>
+
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-2;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/" interestfor="msnt-mm-1-2">
+        NASCAR Cup    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-2" style="position-anchor: --msnt-mm-1-2; anchor-name: --msnt-mm-2-2;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/news/">
+                        News                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/schedule/">
+                        Schedule                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/results/">
+                        Results                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/standings/">
+                        Standings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/galleries/">
+                        Photo galleries                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/videos/">
+                        Videos                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/drivers/">
+                        Drivers                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-cup/teams/">
+                        Teams                    </a>
+
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-3;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/" interestfor="msnt-mm-1-3">
+        IndyCar    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-3" style="position-anchor: --msnt-mm-1-3; anchor-name: --msnt-mm-2-3;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/news/">
+                        News                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/schedule/">
+                        Schedule                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/results/">
+                        Results                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/standings/">
+                        Standings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/galleries/">
+                        Photo galleries                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/videos/">
+                        Videos                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/drivers/">
+                        Drivers                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indycar/teams/">
+                        Teams                    </a>
+
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-4;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/wec/" interestfor="msnt-mm-1-4">
+        WEC    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-4" style="position-anchor: --msnt-mm-1-4; anchor-name: --msnt-mm-2-4;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/news/">
+                        News                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/schedule/">
+                        Schedule                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/results/">
+                        Results                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/standings/">
+                        Standings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/galleries/">
+                        Photo galleries                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/videos/">
+                        Videos                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/drivers/">
+                        Drivers                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wec/teams/">
+                        Teams                    </a>
+
+                                    </li>
+                    </ul>
+    </li>                            
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-5;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/" interestfor="msnt-mm-1-5">
+        IMSA    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-5" style="position-anchor: --msnt-mm-1-5; anchor-name: --msnt-mm-2-5;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/news/">
+                        News                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/schedule/">
+                        Schedule                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/results/">
+                        Results                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/standings/">
+                        Standings                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/galleries/">
+                        Photo galleries                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/videos/">
+                        Videos                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/drivers/">
+                        Drivers                    </a>
+
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/imsa/teams/">
+                        Teams                    </a>
+
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-6;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/category/openwheel/" interestfor="msnt-mm-1-6">
+        Open wheel    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-6" style="position-anchor: --msnt-mm-1-6; anchor-name: --msnt-mm-2-6;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/" interestfor="msnt-mm-2-6-0">
+                        Formula E                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-6-0" style="position-anchor: --msnt-mm-2-6;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/formula-e/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/" interestfor="msnt-mm-2-6-1">
+                        FIA F2                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-6-1" style="position-anchor: --msnt-mm-2-6;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f2/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/" interestfor="msnt-mm-2-6-2">
+                        FIA F3                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-6-2" style="position-anchor: --msnt-mm-2-6;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/fia-f3/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/" interestfor="msnt-mm-2-6-3">
+                        Super Formula                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-6-3" style="position-anchor: --msnt-mm-2-6;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/super-formula/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1-academy/" interestfor="msnt-mm-2-6-4">
+                        F1 Academy                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-6-4" style="position-anchor: --msnt-mm-2-6;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1-academy/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1-academy/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1-academy/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1-academy/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/f1-academy/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/" interestfor="msnt-mm-2-6-5">
+                        Indy NXT                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-6-5" style="position-anchor: --msnt-mm-2-6;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/indylights/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-7;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/category/rally/" interestfor="msnt-mm-1-7">
+        Rally    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-7" style="position-anchor: --msnt-mm-1-7; anchor-name: --msnt-mm-2-7;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/" interestfor="msnt-mm-2-7-0">
+                        WRC                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-7-0" style="position-anchor: --msnt-mm-2-7;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wrc/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dakar/" interestfor="msnt-mm-2-7-1">
+                        Dakar                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-7-1" style="position-anchor: --msnt-mm-2-7;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dakar/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dakar/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dakar/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dakar/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dakar/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-8;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/category/sportscar/" interestfor="msnt-mm-1-8">
+        Sportscars    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-8" style="position-anchor: --msnt-mm-1-8; anchor-name: --msnt-mm-2-8;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/lemans/" interestfor="msnt-mm-2-8-0">
+                        Le Mans                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-8-0" style="position-anchor: --msnt-mm-2-8;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/lemans/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/lemans/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/lemans/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/lemans/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/supergt/" interestfor="msnt-mm-2-8-1">
+                        Super GT                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-8-1" style="position-anchor: --msnt-mm-2-8;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/supergt/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/supergt/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/supergt/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-9;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/category/bikes/" interestfor="msnt-mm-1-9">
+        Bikes    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-9" style="position-anchor: --msnt-mm-1-9; anchor-name: --msnt-mm-2-9;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/" interestfor="msnt-mm-2-9-0">
+                        Moto2                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-9-0" style="position-anchor: --msnt-mm-2-9;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto2/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/" interestfor="msnt-mm-2-9-1">
+                        Moto3                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-9-1" style="position-anchor: --msnt-mm-2-9;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/moto3/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/" interestfor="msnt-mm-2-9-2">
+                        World Superbike                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-9-2" style="position-anchor: --msnt-mm-2-9;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/news/" rel="nofollow">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/schedule/" rel="nofollow">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/results/" rel="nofollow">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/standings/" rel="nofollow">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/videos/" rel="nofollow">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/drivers/" rel="nofollow">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/wsbk/teams/" rel="nofollow">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-10;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/category/nascar/" interestfor="msnt-mm-1-10">
+        Other NASCAR    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-10" style="position-anchor: --msnt-mm-1-10; anchor-name: --msnt-mm-2-10;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/" interestfor="msnt-mm-2-10-0">
+                        NASCAR O'Reilly                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-10-0" style="position-anchor: --msnt-mm-2-10;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-os/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/" interestfor="msnt-mm-2-10-1">
+                        NASCAR Truck                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-10-1" style="position-anchor: --msnt-mm-2-10;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-truck/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-euro/" interestfor="msnt-mm-2-10-2">
+                        NASCAR Euro                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-10-2" style="position-anchor: --msnt-mm-2-10;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-euro/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-euro/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/nascar-euro/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                    </ul>
+    </li>                    
+<li class="ms-desktop-menu__item ws" style="anchor-name: --msnt-mm-1-11;">
+    <a class="ms-desktop-menu__item-link text-body-lg font-bold uppercase font-primary" href="https://www.motorsport.com/category/touring/" interestfor="msnt-mm-1-11">
+        Touring    </a>
+            <svg class="ms-desktop-menu__item__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    
+            <ul class="ms-desktop-menu__item-submenu" popover="hint" id="msnt-mm-1-11" style="position-anchor: --msnt-mm-1-11; anchor-name: --msnt-mm-2-11;">
+                                        <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/" interestfor="msnt-mm-2-11-0">
+                        Supercars                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-11-0" style="position-anchor: --msnt-mm-2-11;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/v8supercars/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                            <li class="ms-desktop-menu__item-lvl2 ws type-series">
+                    <a class="ms-desktop-menu__item-lvl2-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/" interestfor="msnt-mm-2-11-1">
+                        DTM                    </a>
+
+                                            <ul popover="hint" class="ms-desktop-menu__item-lvl2-submenu" id="msnt-mm-2-11-1" style="position-anchor: --msnt-mm-2-11;">
+                                                                                        <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/news/">
+                                        News                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/schedule/">
+                                        Schedule                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/results/">
+                                        Results                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/standings/">
+                                        Standings                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/galleries/">
+                                        Photo galleries                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/videos/">
+                                        Videos                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/drivers/">
+                                        Drivers                                    </a>
+                                </li>
+                                                            <li class="ms-desktop-menu__item-lvl3 ">
+                                    <a class="ms-desktop-menu__item-lvl3-link text-body font-bold uppercase font-primary" href="https://www.motorsport.com/dtm/teams/">
+                                        Teams                                    </a>
+                                </li>
+                                                    </ul>
+                                    </li>
+                    </ul>
+    </li>                                </ul>
+
+                    <div class="ms-desktop-menu__item">
+            
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--md w-auto text-menu-fg-main uppercase" style="font-size: var(--vmsf-body-lg);" commandfor="main-menu-drawer" command="--show">
+        
+                    <span class="msnt-button__text inline ">All Series</span>
+                
+            
+            <div class="-me-1 flex gap-2 items-center">
+            <svg class="w-5 h-5 " aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#grid-dots"></use>
+            </svg>
+        </div>
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+        </div>
+    </div>        </nav>
+        <div class="ms-desktop-header__end">
+            
+<msnt-color-scheme-switcher state="" class="msnt-color-scheme-switcher  ">
+                    
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-color-scheme-option msnt-color-scheme-option--default -mx-2" title="System">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href=""></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-color-scheme-option msnt-color-scheme-option--light -mx-2" title="Light">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#sun"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-color-scheme-option msnt-color-scheme-option--dark -mx-2" title="Dark">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#moon"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+    </msnt-color-scheme-switcher>            
+            
+            <search class="ms-search-box">
+    
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default ms-search-box__button -mx-2" title="Search" popovertarget="msnt-search-panel">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#search"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+    <div class="ms-search-panel" popover="auto" id="msnt-search-panel">
+         
+    </div>
+</search>
+
+            
+<div class="ms-header-dropdown">
+    
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default ms-user-avatar -mx-2" title="User menu" interestfor="msnt-user-menu-popover">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#user-circle"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+        
+    <div class="ms-header-dropdown__items border border-menu-border-main border-t-0" id="msnt-user-menu-popover" popover="auto">
+        
+<div class="ms-user-menu bg-menu-bg ">
+            <div class="px-3 pt-3 ">
+            <h3 class="text-body-lg text-menu-fg font-bold font-secondary uppercase">Sign up for free</h3>
+        </div>
+        <ul class="flex flex-col gap-4 px-3 pt-3 pb-4 ">
+            <li class="flex items-center gap-2">
+                <svg class="w-6 h-6 min-w-6 block text-menu-auth-modal-benefits" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#news"></use>
+                </svg>
+                <p class="text-body text-menu-auth-modal-benefits font font-secondary">Get quick access to your favorite articles</p>
+            </li>
+            <li class="flex items-center gap-2">
+                <svg class="w-6 h-6 min-w-6 block text-menu-auth-modal-benefits" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#bell"></use>
+                </svg>
+                <p class="text-body text-menu-auth-modal-benefits font font-secondary">Manage alerts on breaking news and favorite drivers</p>
+            </li>
+            <li class="flex items-center gap-2">
+                <svg class="w-6 h-6 min-w-6 block text-menu-auth-modal-benefits" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#message-circle-2"></use>
+                </svg>
+                <p class="text-body text-menu-auth-modal-benefits font font-secondary">Make your voice heard with article commenting.</p>
+            </li>
+        </ul>
+        <div class="px-3 flex flex-col gap-2 pb-3 ">
+                            
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--outline-on-dark border msnt-button--sm w-full justify-center uppercase italic " commandfor="document" command="--show-dialog-auth">
+        
+                    <span class="msnt-button__text inline ">Sign in</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+                    </div>
+
+                
+                    
+<div class="w-full h-px bg-menu-divider-100 "></div>
+            
+            
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden text-start msnt-button--ghost-on-dark w-full justify-center uppercase italic p-3" title="Select edition" commandfor="select-edition-drawer" command="--show">
+        
+            
+<h3 class="text-body-sm font-bold text-menu-accent uppercase pb-2">Edition</h3>
+
+<div class="flex items-center gap-2">
+    <img src="https://cdn-1.motorsport.com/static/img/cf/global-2.svg" alt="Global" title="Global" width="34" height="20" loading="lazy">
+    
+    <span class="text-body-lg text-menu-fg uppercase font-bold mr-auto">
+        Global    </span>
+
+    <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180">
+        <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+    </svg>
+</div>    
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+            
+    </div>    </div>
+</div>
+        </div>
+    </div>
+
+    
+<nav class="ms-desktop-quick-links " aria-labelledby="quick-links-desktop">
+    <h3 id="quick-links-desktop" class="font-bold uppercase font-primary text-3.5 leading-3.5">
+        Quick links:    </h3>
+    
+    <ul class="flex justify-between items-center gap-9">
+                    <li class="ms-desktop-quick-links__item">
+                <a href="https://www.motorsport.com/f1/schedule/2026/" class="font-primary text-3.5 leading-3.5">
+                    F1 Schedule 2026                </a>
+            </li>
+                    <li class="ms-desktop-quick-links__item">
+                <a href="https://www.motorsport.com/all/galleries/" class="font-primary text-3.5 leading-3.5">
+                    Photo Galleries                </a>
+            </li>
+                    <li class="ms-desktop-quick-links__item">
+                <a href="https://www.motorsport.com/all/videos/" class="font-primary text-3.5 leading-3.5">
+                    Videos                </a>
+            </li>
+                    <li class="ms-desktop-quick-links__item">
+                <a href="https://www.motorsport.com/topic/autosport-awards/2333/" class="font-primary text-3.5 leading-3.5">
+                    2026 Autosport Awards                </a>
+            </li>
+            </ul>
+</nav>
+
+    
+
+    </header>
+                    
+<msnt-sticky-recommendations-strip data-widget="recommendations-strip" class="msnt-sticky-recommendations-strip block fixed left-0 right-0 z-20 py-2 border-b bg-bg-surface-brand t:bg-bg-page border-b-menu-border-main t:border-b-divider-100 " role="region" aria-labelledby="recommendations-strip-widget-title">
+    <h3 id="recommendations-strip-widget-title" class="font-secondary text-3.5 leading-4 font-bold uppercase relative ms-2 t:ms-4 mb-2 text-fg-on-color t:text-fg-default">
+        <span class="relative z-20 pe-1.5 bg-bg-surface-brand t:bg-bg-page">Recommended for you</span>
+        <span class="absolute z-10 h-px top-1/2 left-0 right-0 bg-menu-border-main t:bg-divider-100"></span>
+    </h3>
+
+    
+<msnt-scroller class="msnt-scroller atStart atEnd block relative overflow-hidden  " style="">
+    
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default msnt-scroller__btn msnt-scroller__btn-start left-0 msnt-scroller__btn absolute z-10  top-0 bottom-0" title="Scroll left">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        <div tabindex="-1" class="msnt-scroller__scroller ms-scrollbar relative overflow-x-auto overflow-y-hidden overscroll-contain ">
+                <div class="msnt-scroller__content min-w-full inline-flex items-start gap-2 t:gap-6 px-2 t:px-4">
+            
+<a href="https://www.motorsport.com/nascar-cup/news/kyle-busch-says-we-got-away-from-the-chase-for-a-reason/10794832/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794832" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s200/kyle-busch-richard-childress-r.webp 200w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s300/kyle-busch-richard-childress-r.webp 300w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s400/kyle-busch-richard-childress-r.webp 400w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s500/kyle-busch-richard-childress-r.webp 500w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s600/kyle-busch-richard-childress-r.webp 600w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s700/kyle-busch-richard-childress-r.webp 700w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s800/kyle-busch-richard-childress-r.webp 800w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s900/kyle-busch-richard-childress-r.webp 900w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s1000/kyle-busch-richard-childress-r.webp 1000w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s1100/kyle-busch-richard-childress-r.webp 1100w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s1200/kyle-busch-richard-childress-r.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s200/kyle-busch-richard-childress-r.jpg 200w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s300/kyle-busch-richard-childress-r.jpg 300w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s400/kyle-busch-richard-childress-r.jpg 400w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s500/kyle-busch-richard-childress-r.jpg 500w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s600/kyle-busch-richard-childress-r.jpg 600w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s700/kyle-busch-richard-childress-r.jpg 700w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s800/kyle-busch-richard-childress-r.jpg 800w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s900/kyle-busch-richard-childress-r.jpg 900w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s1000/kyle-busch-richard-childress-r.jpg 1000w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s1100/kyle-busch-richard-childress-r.jpg 1100w, https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s1200/kyle-busch-richard-childress-r.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/amp/6DGqqrxY/s200/kyle-busch-richard-childress-r.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Kyle Busch says 'we got away from the Chase for a reason'        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">NASCAR Cup</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">NASCAR Cup</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Cook Out Clash at Bowman Gray</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-03T02:26:44Z">
+                2 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Kyle Busch says 'we got away from the Chase for a reason'</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/formula-e/news/abbi-pulling-explains-why-formula-e-is-cut-throat-after-miami-eprix-rookie-run/10794818/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794818" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s200/abbi-pulling-and-nissan-formul.webp 200w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s300/abbi-pulling-and-nissan-formul.webp 300w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s400/abbi-pulling-and-nissan-formul.webp 400w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s500/abbi-pulling-and-nissan-formul.webp 500w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s600/abbi-pulling-and-nissan-formul.webp 600w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s700/abbi-pulling-and-nissan-formul.webp 700w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s800/abbi-pulling-and-nissan-formul.webp 800w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s900/abbi-pulling-and-nissan-formul.webp 900w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s1000/abbi-pulling-and-nissan-formul.webp 1000w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s1100/abbi-pulling-and-nissan-formul.webp 1100w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s1200/abbi-pulling-and-nissan-formul.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s200/abbi-pulling-and-nissan-formul.jpg 200w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s300/abbi-pulling-and-nissan-formul.jpg 300w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s400/abbi-pulling-and-nissan-formul.jpg 400w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s500/abbi-pulling-and-nissan-formul.jpg 500w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s600/abbi-pulling-and-nissan-formul.jpg 600w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s700/abbi-pulling-and-nissan-formul.jpg 700w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s800/abbi-pulling-and-nissan-formul.jpg 800w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s900/abbi-pulling-and-nissan-formul.jpg 900w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s1000/abbi-pulling-and-nissan-formul.jpg 1000w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s1100/abbi-pulling-and-nissan-formul.jpg 1100w, https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s1200/abbi-pulling-and-nissan-formul.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/amp/2GdwVd1Y/s200/abbi-pulling-and-nissan-formul.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Abbi Pulling explains why Formula E is "cut-throat" after Miami ePrix rookie run        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula E</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula E</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Miami ePrix</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T22:51:57Z">
+                5 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Abbi Pulling explains why Formula E is "cut-throat" after Miami ePrix rookie run</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/f1/news/mercedes-announces-new-development-driver-signing-as-full-line-up-confirmed/10794816/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794816" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s200/george-russell-mercedes.webp 200w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s300/george-russell-mercedes.webp 300w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s400/george-russell-mercedes.webp 400w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s500/george-russell-mercedes.webp 500w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s600/george-russell-mercedes.webp 600w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s700/george-russell-mercedes.webp 700w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s800/george-russell-mercedes.webp 800w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s900/george-russell-mercedes.webp 900w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s1000/george-russell-mercedes.webp 1000w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s1100/george-russell-mercedes.webp 1100w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s1200/george-russell-mercedes.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s200/george-russell-mercedes.jpg 200w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s300/george-russell-mercedes.jpg 300w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s400/george-russell-mercedes.jpg 400w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s500/george-russell-mercedes.jpg 500w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s600/george-russell-mercedes.jpg 600w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s700/george-russell-mercedes.jpg 700w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s800/george-russell-mercedes.jpg 800w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s900/george-russell-mercedes.jpg 900w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s1000/george-russell-mercedes.jpg 1000w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s1100/george-russell-mercedes.jpg 1100w, https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s1200/george-russell-mercedes.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/amp/Y9lL5Lq2/s200/george-russell-mercedes.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Mercedes announces new development driver signing as full line-up confirmed        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Mercedes launch</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T22:47:59Z">
+                5 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Mercedes announces new development driver signing as full line-up confirmed</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/nascar-cup/news/nascar-cup-drivers-are-helping-with-snow-removal-at-bowman-gray/10794793/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794793" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s200/ricky-stenhouse-jr-hyak-motors.webp 200w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s300/ricky-stenhouse-jr-hyak-motors.webp 300w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s400/ricky-stenhouse-jr-hyak-motors.webp 400w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s500/ricky-stenhouse-jr-hyak-motors.webp 500w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s600/ricky-stenhouse-jr-hyak-motors.webp 600w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s700/ricky-stenhouse-jr-hyak-motors.webp 700w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s800/ricky-stenhouse-jr-hyak-motors.webp 800w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s900/ricky-stenhouse-jr-hyak-motors.webp 900w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s1000/ricky-stenhouse-jr-hyak-motors.webp 1000w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s1100/ricky-stenhouse-jr-hyak-motors.webp 1100w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s1200/ricky-stenhouse-jr-hyak-motors.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s200/ricky-stenhouse-jr-hyak-motors.jpg 200w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s300/ricky-stenhouse-jr-hyak-motors.jpg 300w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s400/ricky-stenhouse-jr-hyak-motors.jpg 400w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s500/ricky-stenhouse-jr-hyak-motors.jpg 500w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s600/ricky-stenhouse-jr-hyak-motors.jpg 600w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s700/ricky-stenhouse-jr-hyak-motors.jpg 700w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s800/ricky-stenhouse-jr-hyak-motors.jpg 800w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s900/ricky-stenhouse-jr-hyak-motors.jpg 900w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s1000/ricky-stenhouse-jr-hyak-motors.jpg 1000w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s1100/ricky-stenhouse-jr-hyak-motors.jpg 1100w, https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s1200/ricky-stenhouse-jr-hyak-motors.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/amp/2y3eE8n6/s200/ricky-stenhouse-jr-hyak-motors.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            NASCAR Cup drivers are helping shovel snow at Bowman Gray after storm        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">NASCAR Cup</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">NASCAR Cup</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Cook Out Clash at Bowman Gray</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T19:29:29Z">
+                9 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">NASCAR Cup drivers are helping shovel snow at Bowman Gray after storm</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/f1/news/f1-management-set-for-new-93500-sq-ft-london-headquarters/10794801/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794801" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s200/40-broadway-st-james-park-web2.webp 200w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s300/40-broadway-st-james-park-web2.webp 300w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s400/40-broadway-st-james-park-web2.webp 400w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s500/40-broadway-st-james-park-web2.webp 500w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s600/40-broadway-st-james-park-web2.webp 600w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s700/40-broadway-st-james-park-web2.webp 700w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s800/40-broadway-st-james-park-web2.webp 800w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s900/40-broadway-st-james-park-web2.webp 900w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s1000/40-broadway-st-james-park-web2.webp 1000w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s1100/40-broadway-st-james-park-web2.webp 1100w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s1200/40-broadway-st-james-park-web2.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s200/40-broadway-st-james-park-web2.jpg 200w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s300/40-broadway-st-james-park-web2.jpg 300w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s400/40-broadway-st-james-park-web2.jpg 400w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s500/40-broadway-st-james-park-web2.jpg 500w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s600/40-broadway-st-james-park-web2.jpg 600w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s700/40-broadway-st-james-park-web2.jpg 700w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s800/40-broadway-st-james-park-web2.jpg 800w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s900/40-broadway-st-james-park-web2.jpg 900w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s1000/40-broadway-st-james-park-web2.jpg 1000w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s1100/40-broadway-st-james-park-web2.jpg 1100w, https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s1200/40-broadway-st-james-park-web2.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s200/40-broadway-st-james-park-web2.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            F1 management set for new 93,500 sq ft London headquarters        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T19:12:24Z">
+                9 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">F1 management set for new 93,500 sq ft London headquarters</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/motogp/news/motogp-sepang-test-schedules-riders-how-to-follow/10794798/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794798" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/amp/YpNrKN30/s200/marc-marquez-ducati-team.webp 200w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s300/marc-marquez-ducati-team.webp 300w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s400/marc-marquez-ducati-team.webp 400w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s500/marc-marquez-ducati-team.webp 500w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s600/marc-marquez-ducati-team.webp 600w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s700/marc-marquez-ducati-team.webp 700w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s800/marc-marquez-ducati-team.webp 800w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s900/marc-marquez-ducati-team.webp 900w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s1000/marc-marquez-ducati-team.webp 1000w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s1100/marc-marquez-ducati-team.webp 1100w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s1200/marc-marquez-ducati-team.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/amp/YpNrKN30/s200/marc-marquez-ducati-team.jpg 200w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s300/marc-marquez-ducati-team.jpg 300w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s400/marc-marquez-ducati-team.jpg 400w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s500/marc-marquez-ducati-team.jpg 500w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s600/marc-marquez-ducati-team.jpg 600w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s700/marc-marquez-ducati-team.jpg 700w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s800/marc-marquez-ducati-team.jpg 800w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s900/marc-marquez-ducati-team.jpg 900w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s1000/marc-marquez-ducati-team.jpg 1000w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s1100/marc-marquez-ducati-team.jpg 1100w, https://cdn-7.motorsport.com/images/amp/YpNrKN30/s1200/marc-marquez-ducati-team.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-7.motorsport.com/images/amp/YpNrKN30/s200/marc-marquez-ducati-team.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            MotoGP Sepang test: Schedule, entry list and how to follow        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">MotoGP</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">MotoGP</span>
+            
+                            <div class="ms-item__info-conditional">
+                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T18:44:27Z">
+                9 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">MotoGP Sepang test: Schedule, entry list and how to follow</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/nascar-truck/news/kaulig-racing-reveals-crew-chief-roster-for-five-truck-ram-program/10794791/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794791" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/amp/6AErwPD6/s200/kaulig-racing-ram-announcement.webp 200w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s300/kaulig-racing-ram-announcement.webp 300w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s400/kaulig-racing-ram-announcement.webp 400w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s500/kaulig-racing-ram-announcement.webp 500w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s600/kaulig-racing-ram-announcement.webp 600w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s700/kaulig-racing-ram-announcement.webp 700w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s800/kaulig-racing-ram-announcement.webp 800w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s900/kaulig-racing-ram-announcement.webp 900w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s1000/kaulig-racing-ram-announcement.webp 1000w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s1100/kaulig-racing-ram-announcement.webp 1100w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s1200/kaulig-racing-ram-announcement.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/amp/6AErwPD6/s200/kaulig-racing-ram-announcement.jpg 200w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s300/kaulig-racing-ram-announcement.jpg 300w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s400/kaulig-racing-ram-announcement.jpg 400w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s500/kaulig-racing-ram-announcement.jpg 500w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s600/kaulig-racing-ram-announcement.jpg 600w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s700/kaulig-racing-ram-announcement.jpg 700w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s800/kaulig-racing-ram-announcement.jpg 800w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s900/kaulig-racing-ram-announcement.jpg 900w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s1000/kaulig-racing-ram-announcement.jpg 1000w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s1100/kaulig-racing-ram-announcement.jpg 1100w, https://cdn-1.motorsport.com/images/amp/6AErwPD6/s1200/kaulig-racing-ram-announcement.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/amp/6AErwPD6/s200/kaulig-racing-ram-announcement.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Kaulig Racing reveals crew chief roster for five-truck Ram program        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">NASCAR Truck</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">NASCAR Truck</span>
+            
+                            <div class="ms-item__info-conditional">
+                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T18:18:03Z">
+                10 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Kaulig Racing reveals crew chief roster for five-truck Ram program</div>
+
+        
+            </div>
+</a>
+<a href="https://www.motorsport.com/imsa/news/whats-behind-cadillacs-strikingly-low-lmdh-rear-wing/10794786/" class="ms-item ms-items-skeleton-single ms-item--dark-m ms-item-hor-d ms-item-hor-t ms-item-thumb-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794786" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/amp/6O79mKm6/s200/10-cadillac-wayne-taylor-racin.webp 200w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s300/10-cadillac-wayne-taylor-racin.webp 300w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s400/10-cadillac-wayne-taylor-racin.webp 400w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s500/10-cadillac-wayne-taylor-racin.webp 500w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s600/10-cadillac-wayne-taylor-racin.webp 600w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s700/10-cadillac-wayne-taylor-racin.webp 700w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s800/10-cadillac-wayne-taylor-racin.webp 800w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s900/10-cadillac-wayne-taylor-racin.webp 900w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s1000/10-cadillac-wayne-taylor-racin.webp 1000w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s1100/10-cadillac-wayne-taylor-racin.webp 1100w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s1200/10-cadillac-wayne-taylor-racin.webp 1200w" sizes="200px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/amp/6O79mKm6/s200/10-cadillac-wayne-taylor-racin.jpg 200w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s300/10-cadillac-wayne-taylor-racin.jpg 300w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s400/10-cadillac-wayne-taylor-racin.jpg 400w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s500/10-cadillac-wayne-taylor-racin.jpg 500w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s600/10-cadillac-wayne-taylor-racin.jpg 600w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s700/10-cadillac-wayne-taylor-racin.jpg 700w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s800/10-cadillac-wayne-taylor-racin.jpg 800w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s900/10-cadillac-wayne-taylor-racin.jpg 900w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s1000/10-cadillac-wayne-taylor-racin.jpg 1000w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s1100/10-cadillac-wayne-taylor-racin.jpg 1100w, https://cdn-9.motorsport.com/images/amp/6O79mKm6/s1200/10-cadillac-wayne-taylor-racin.jpg 1200w" sizes="200px">
+            
+    <img loading="lazy" width="200" height="133" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/amp/6O79mKm6/s200/10-cadillac-wayne-taylor-racin.jpg" alt="" fetchpriority="low">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            What’s behind Cadillac's strikingly low LMDh rear wing?        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">IMSA</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">IMSA</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Rolex 24 Hours</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T18:01:52Z">
+                10 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">What’s behind Cadillac's strikingly low LMDh rear wing?</div>
+
+        
+            </div>
+</a>        </div>
+    </div>
+
+    
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default msnt-scroller__btn msnt-scroller__btn-end right-0 msnt-scroller__btn absolute z-10  top-0 bottom-0" title="Scroll right">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+</msnt-scroller></msnt-sticky-recommendations-strip>        
+        <main class="ms-page-wrapper" id="main-content" tabindex="-1">
+            
+
+
+
+<div class="ms-skin-super-poster ms-skin-click"></div><div class="ms-hapb ms-hapb-top ms-skin-front msnt-skin " id="page_skin_top"><div class="ms-apb ms-apb-mleaderboard ms-skin-click"><div id="ads_6122441_MST_global_Mobile_leaderboard_top_1770093040" class="ms-ap" data-id="10" data-ad-unit-id="/6122441/MST/global/Mobile_leaderboard/top" style="width:320px;min-height:100px;" data-dfp-code="MST/global/Mobile_leaderboard" data-sizes="320x100,320x50,320x1" data-width="320" data-height="100" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;top&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;top&quot;,&quot;ms_viewport&quot;:&quot;small&quot;}" data-msnt-label="Advertisement"></div></div><div class="ms-apb ms-apb-leaderboard ms-skin-click"><div id="ads_6122441_MST_global_Leaderboard_top_1770093040_2" class="ms-ap" data-id="1" data-ad-unit-id="/6122441/MST/global/Leaderboard/top" style="width:728px;min-height:90px;" data-dfp-code="MST/global/Leaderboard" data-sizes="728x90,728x1" data-width="728" data-height="90" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;top&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;top&quot;,&quot;ms_viewport&quot;:&quot;medium&quot;}" data-msnt-label="Advertisement"></div></div><div class="ms-apb ms-apb-super ms-skin-click"><div id="ads_6122441_MST_global_Super_top_1770093040_3" class="ms-ap" data-id="6" data-ad-unit-id="/6122441/MST/global/Super/top" style="width:970px;min-height:90px;" data-dfp-code="MST/global/Super" data-sizes="970x90,970x250,980x250,970x1" data-width="970" data-height="90" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;top&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;top&quot;,&quot;ms_viewport&quot;:&quot;large&quot;}" data-msnt-label="Advertisement"></div></div></div>
+<div class="ms-page-content ms-layout-spaced">
+    
+
+
+
+<article class="ms-page ms-content ms-content--plain ms-centered  ms-content--default" data-media-type="none" data-title="&quot;Very unfortunate&quot; Isack Hadjar crash leaves Red Bull undecided on third F1 test day" data-url="/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www" data-comments="1" data-prime="0" data-ads="1" data-entity-id="10793339" data-entity-type="article">
+    <div class="ms-content ms-content--nested">
+        <div class="ms-content__main ms-content__main--regular">
+            
+<div class="msnt-entity-header flex flex-col gap-3 t:gap-4 pb-6 pt-4 t:pb-8 t:pt-0  " style="">
+    <div class="flex flex-wrap items-start gap-px">
+        
+                            
+        
+<div class="msnt-breadcrumbs font-secondary text-3.5 leading-4 font-bold flex items-center gap-px ">
+                        <a class="msnt-breadcrumbs__item flex items-center relative py-1 px-1.5 uppercase -skew-x-3" href="https://www.motorsport.com/f1/">
+                <span class="skew-x-3">Formula 1</span>
+            </a>
+                                <a class="msnt-breadcrumbs__item flex items-center relative py-1 px-1.5 uppercase -skew-x-3" href="https://www.motorsport.com/location/circuit-de-barcelona-catalunya/70/">
+                <span class="skew-x-3">Barcelona-Catalunya Pre-Season Testing</span>
+            </a>
+            </div>    </div>
+
+
+        
+    <div class="flex flex-col gap-2">
+        <h1 class="text-h1 font-primary font-primary-bold uppercase text-fg-on-color t:text-fg-default">
+                                "Very unfortunate" Isack Hadjar crash leaves Red Bull undecided on third F1 test day                    </h1>
+        <h2 class="text-article-description font-primary font-secondary-regular text-fg-on-color-soft t:text-fg-soft">
+                            Hadjar crashed his Red Bull RB22 on a treacherous wet second day of Formula 1's Barcelona shakedown                    </h2>
+    </div>
+
+            <div class="flex flex-col gap-2">
+            
+            
+<div class="msnt-author-toolbar  max-w-full flex flex-wrap justify-between gap-2 text-fg-on-color t:text-fg-default text-body-sm leading-none  ">
+    <div class="font-secondary flex items-center gap-1.5">
+        
+<div class="msnt-userpic aspect-square rounded-full overflow-hidden w-8 ">
+      <img class="w-full" src="https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s2/img546558274-2-2.jpg" alt="Filip Cleeren" title="Filip Cleeren" width="10" height="10">
+  
+</div>
+        <div class="flex flex-col gap-1">
+                            <a href="https://www.motorsport.com/info/about-us/filip_cleeren/4294/" class="font-bold text-3.5 leading-none hover:underline text-fg-link-on-color t:text-fg-link">Filip Cleeren</a>
+                        
+            
+                            <div class="text-3 leading-3 text-fg-muted">
+                    <span>Edited:</span>
+                    <time class="ms-date-with-timezone invisible" datetime="2026-01-27T20:55:13Z" data-date="Tue, 27 Jan 2026 20:55:13 +0000" data-lang="">
+                        Jan 27, 2026, 8:55 PM                    </time>
+                </div>
+                    </div>
+    </div>
+
+    <div class="contents t:flex items-center gap-2">
+        <div class="flex flex-wrap items-center justify-end">
+                        
+<msnt-share class="msnt-share hidden flex flex-wrap gap-2
+         
+            " data-share-url="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" data-share-title="&quot;Very unfortunate&quot; Isack Hadjar crash leaves Red Bull undecided on third F1 test day" data-share-text="&quot;Very unfortunate&quot; Isack Hadjar crash leaves Red Bull undecided on third F1 test day" data-share-image="https://cdn-6.motorsport.com/images/amp/01QdMbx0/s2/isack-hadjar-red-bull-racing.jpg" data-entity-type="article" data-entity-id="10793339">
+
+        
+    <div class="relative msnt-share__box">
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__native msnt-share__android" title="Share">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-13-ac7e51d77a1c06140ec15a43b8cd8d90.svg#share"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__native msnt-share__ios" title="Share">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-13-ac7e51d77a1c06140ec15a43b8cd8d90.svg#share-2"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__native msnt-share__windows" title="Share">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#share-3"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        <div class="msnt-share__drawer group open-up absolute my-2  flex flex-col gap-1 py-2 px-1 border-neutral-100 border z-10 hidden msnt-share__drawer--contrast t:msnt-share__drawer--soft">
+
+            <span class="msnt-share__arrow absolute w-3 h-3 border-neutral-100 msnt-share__arrow--contrast t:msnt-share__arrow--soft"></span>
+
+            <div class="border-b border-neutral-100 rounded-none pb-1 flex flex-col">
+                
+<button data-href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" data-propagation="1" type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button msnt-share__button--copy">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-13-ac7e51d77a1c06140ec15a43b8cd8d90.svg#link"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Copy link</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+            </div>
+
+            
+<a href="https://www.facebook.com/sharer/sharer.php?u=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" target="_blank" data-name="facebook" data-width="600" data-height="600" data-official-name="Facebook" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-facebook"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Facebook</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://twitter.com/intent/tweet?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;text=%22Very%20unfortunate%22%20Isack%20Hadjar%20crash%20leaves%20Red%20Bull%20undecided%20on%20third%20F1%20test%20day&amp;via=motorsport" target="_blank" data-name="twitter" data-width="600" data-height="450" data-official-name="Twitter" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-x"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Twitter</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://api.whatsapp.com/send?text=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" target="_blank" data-name="whatsapp" data-width="1024" data-height="768" data-official-name="WhatsApp" data-collect="" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-whatsapp"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on WhatsApp</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://www.linkedin.com/cws/share?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;mini=true&amp;source=motorsport.com" target="_blank" data-name="linkedin" data-width="600" data-height="600" data-official-name="LinkedIn" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-linkedin"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Linkedin</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://www.pinterest.com/pin/create/button/?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;media=https://cdn-6.motorsport.com/images/amp/01QdMbx0/s2/isack-hadjar-red-bull-racing.jpg&amp;description=%22Very%20unfortunate%22%20Isack%20Hadjar%20crash%20leaves%20Red%20Bull%20undecided%20on%20third%20F1%20test%20day" target="_blank" data-name="pinterest" data-width="700" data-height="550" data-official-name="Pinterest" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-pinterest"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Pinterest</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="viber://forward?text=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" target="_blank" data-name="viber" data-width="500" data-height="500" data-official-name="Viber" data-collect="" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic t:msnt-button--ghost msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-viber"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Viber</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+        </div>
+    </div>
+</msnt-share>
+            
+                            
+<button onclick="" type="button" data-auth-required="1" data-url="https://pageinfo-k8s.motorsport.com/favorite/" data-favorites-url="/dashboard/favorite-news/" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default " title="Favorite" commandfor="document" command="--toggle-favorite">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill group-[.wait]:hidden group-[.active]:hidden" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-14-eb78580f9053c252fa0632ddee8c4fa0.svg#bookmark"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill hidden group-[.wait]:hidden group-[.active]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-14-eb78580f9053c252fa0632ddee8c4fa0.svg#bookmark-filled"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 t:msnt-svg-icon--no-fill animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+            
+                            
+<div class="coral-count-wrapper ">
+    
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden text-start msnt-button--ghost-on-dark w-auto uppercase italic t:msnt-button--ghost msnt-entity-comments-count flex items-center p-button-px-medium h-button-medium-height" title="Comments" commandfor="comments-drawer" command="--show">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#message-circle-2"></use>
+        </svg>
+        
+            <span class="coral-count text-body font-bold !text-article-sharing-contrast-fg t:!text-icon-button-ghost-icon-color dark:t:!text-article-sharing-contrast-fg" data-coral-notext="true" data-coral-id="article__10793339"></span>    
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+</div>
+
+                    </div>
+
+        
+
+<a href="https://google.com/preferences/source?q=https%3A%2F%2Fwww.motorsport.com" rel="noopener" target="_blank" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--neutral msnt-button--md w-full justify-center uppercase italic t:w-auto ms-auto">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#logo-google"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Add as a preferred source</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+    </div>
+</div>        </div>
+
+
+        
+            </div>
+            <div class="ms-article_detail">
+                <div class="ms-gtm-data-container" data-page-type="detail" data-entity-url="/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" data-entity-id="10793339" data-entity-type="article" data-media-type="none" data-event="entityReady" data-current-series="f1"></div>                <div class="ms-gtm-data-container--article-new-section" data-event="newSection"></div>
+                
+                
+<div class="ms-entity-promo relative flex flex-col gap-1 mb-6">
+            
+<picture class="ms-item__picture ms-article__main-img border-t-4 border-accent-color-default" data-large-img="https://cdn-2.motorsport.com/images/amp/01QdMbx0/s6/isack-hadjar-red-bull-racing.jpg" data-photo-id="72159743" data-detail-url="/all/photos/isack-hadjar-red-bull-racing-72159743/72159743/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/amp/01QdMbx0/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width: 700px) 1000px, (min-width: 400px) and (max-width: 699px) 700px, (max-width: 399px) 400px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/amp/01QdMbx0/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-6.motorsport.com/images/amp/01QdMbx0/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width: 700px) 1000px, (min-width: 400px) and (max-width: 699px) 700px, (max-width: 399px) 400px">
+            
+    <img loading="eager" width="1000" height="666" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/amp/01QdMbx0/s1000/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing
+">
+    </picture>
+                    <p class="text-fg-default text-body font-bold">Isack Hadjar, Red Bull Racing</p>
+        
+                    <p class="text-fg-muted text-body-sm">Photo by: Red Bull Content Pool</p>
+                
+    </div>
+                
+                <div class="ms-article__main mb-dynamic">
+    <div class="ms-article__body">
+        <div id="ms-piano_article-precontent" class="empty:contents"></div>
+
+        <div class="ms-article-content-wrapper my-dynamic">
+
+            
+
+            
+<div class="ms-article-content msnt-styled-content" data-position="embed" data-series="f1" data-autoplay="0" data-mute="0">
+
+    
+                        <p>The Red Bull Formula 1 team is still evaluating its plans for a final day of Barcelona running after <a href="https://www.motorsport.com/driver/isack-hadjar/827922/" target="_blank" rel="noopener">Isack Hadjar</a> suffered a crash with the new RB22 on Tuesday.</p><div class="ms-apb ms-apb-inarticle ms-apb-inarticle-after-preview-without-sidebar " data-msnt-label="Advertisement"><div id="ads_6122441_MST_global_Rectangle_rectangle_first_1770093040" class="ms-ap" data-id="2" data-ad-unit-id="/6122441/MST/global/Rectangle/rectangle_first" style="width:300px;min-height:250px;" data-dfp-code="MST/global/Rectangle" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;rectangle_first&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;inarticle-after-preview-without-sidebar&quot;}" data-msnt-label="Advertisement"></div></div>
+<p>In tricky wet conditions, Hadjar spun backwards into the wall at Barcelona's final corner, damaging the rear of Red Bull's 2026 challenger in the process and ending the Frenchman's day. Given the limited information available from the behind-closed-doors test, it is not yet clear whether Hadjar made an error or whether there was an issue with his car.</p>
+<section class="relatedContent" contenteditable="false" draggable="true" data-widget="related-content" data-widget-size="content" data-params="%7B%22type_id%22%3A0%2C%22title_id%22%3A%220_0%22%2C%22items%22%3A%5B%7B%22article_edition_id%22%3A%2210793292%22%2C%22title%22%3A%22Isack%20Hadjar%20crashes%20Red%20Bull%E2%80%99s%20new%20F1%20car%22%2C%22alias%22%3A%22isack-hadjar-crashes-red-bulls-new-f1-car%22%2C%22front_url%22%3A%22https%3A%2F%2Fwww.motorsport.com%2Ff1%2Fnews%2Fisack-hadjar-crashes-red-bulls-new-f1-car%2F10793292%2F%22%2C%22series%22%3A%22Formula%201%22%2C%22photo%22%3A%22%2F%2Fcdn.motorsport.com%2Fimages%2Famp%2F6Vy74qnY%2Fs2%2Fisack-hadjar-red-bull-racing.jpg%22%7D%5D%7D"><span class="relatedContent__title">Read Also:</span>
+<ul>
+<li><a href="https://www.motorsport.com/f1/news/isack-hadjar-crashes-red-bulls-new-f1-car/10793292/"><img src="https://cdn.motorsport.com/images/amp/6Vy74qnY/s2/isack-hadjar-red-bull-racing.jpg" width="160" height="107" loading="lazy">
+<div class="relatedContent__info"><span class="relatedContent__series">Formula 1</span><span class="relatedContent__text">Isack Hadjar crashes Red Bull’s new F1 car</span></div>
+</a></li>
+</ul>
+</section>
+<p>Hadjar's team-mate <a href="https://www.motorsport.com/driver/max-verstappen/17529/" target="_blank" rel="noopener">Max Verstappen</a> had completed the morning session, getting only one dry run in before the expected rain arrived. But given the huge amount Red Bull has to discover about its car and its first-ever in-house power unit, it felt running in the wet was still worth it.</p><div class="outstream_partner UOL_VIDEO"></div>
+<p>Red Bull team principal Laurent Mekies says the team is still evaluating its plans for the coming days following Hadjar's accident. With Red Bull having tested on Monday and all 11 teams restricted to three days out of a possible five, the squad is not under pressure to get out on Wednesday morning as it has already completed two days.</p>
+<p>"There was some good learning on the wet,” Mekies said. “Unfortunately, it didn't end up in the right way, but what is important [is] that Isack is okay and we'll try our best to repair the car and to see what's coming next.</p><div class="ms-ap-native " data-msnt-label="Advertisement"><div id="ads_6122441_MST_global_Native_native_1_1770093040" class="ms-ap" data-id="20" data-ad-unit-id="/6122441/MST/global/Native/native_1" data-dfp-code="MST/global/Native" data-sizes="fluid,1x1" data-width="1" data-height="1" data-dfp-attrs="{&quot;ms_native&quot;:&quot;1&quot;,&quot;ms_banner_name&quot;:&quot;native_1&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;native&quot;}" data-msnt-label="Advertisement"></div></div>
+<p>"It was a very tricky condition this afternoon, so very unfortunate that it finished that way, but it's part of the game. Again, very tricky, a lot of work to do on many aspects and these sorts of things can happen. These difficulties today came after a very, very positive day yesterday in terms of the number of laps Isack could complete in the car and in terms of his learning and development and feedback to the engineers.</p>
+<p>"It's something we are trying to analyse now and hopefully we get some answer a bit later on. The priority right now is to assess the damage on the car and to see what it gives us in terms of opportunities to run in the next day. We only have one day left, so we have to make sure we place that card carefully and it's an analysis that will take still a few hours."</p><div class="ms-apb ms-apb-inarticle ms-apb-inarticle-after-preview-without-sidebar " data-msnt-label="Advertisement"><div id="ads_6122441_MST_global_Rectangle_rectangle_1_1770093040" class="ms-ap" data-id="4" data-ad-unit-id="/6122441/MST/global/Rectangle/rectangle_1" style="width:300px;min-height:250px;" data-dfp-code="MST/global/Rectangle" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;rectangle_1&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;inarticle-after-preview-without-sidebar&quot;}" data-msnt-label="Advertisement"></div></div>
+<section class="" contenteditable="false" draggable="true" data-widget="image" data-width="1200" data-height="815" data-link="" data-id="72159739" data-title="Laurent Mekies, Red Bull Racing Team Team Principal " data-author="Red Bull Content Pool" data-custom="false" data-src="//cdn.motorsport.com/images/mgl/YXypvxj6/s8/laurent-mekies-red-bull-racing.jpg" data-show-title="true" data-show-author="true"><picture> <source srcset="https://cdn.motorsport.com/images/mgl/YXypvxj6/s200/laurent-mekies-red-bull-racing.webp 200w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s300/laurent-mekies-red-bull-racing.webp 300w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s400/laurent-mekies-red-bull-racing.webp 400w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s500/laurent-mekies-red-bull-racing.webp 500w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s600/laurent-mekies-red-bull-racing.webp 600w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s700/laurent-mekies-red-bull-racing.webp 700w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s800/laurent-mekies-red-bull-racing.webp 800w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s900/laurent-mekies-red-bull-racing.webp 900w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s1000/laurent-mekies-red-bull-racing.webp 1000w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s1100/laurent-mekies-red-bull-racing.webp 1100w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s1200/laurent-mekies-red-bull-racing.webp 1200w" type="image/webp" sizes="(min-width: 650px) 700px"> <source srcset="https://cdn.motorsport.com/images/mgl/YXypvxj6/s200/laurent-mekies-red-bull-racing.jpg 200w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s300/laurent-mekies-red-bull-racing.jpg 300w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s400/laurent-mekies-red-bull-racing.jpg 400w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s500/laurent-mekies-red-bull-racing.jpg 500w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s600/laurent-mekies-red-bull-racing.jpg 600w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s700/laurent-mekies-red-bull-racing.jpg 700w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s800/laurent-mekies-red-bull-racing.jpg 800w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s900/laurent-mekies-red-bull-racing.jpg 900w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s1000/laurent-mekies-red-bull-racing.jpg 1000w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s1100/laurent-mekies-red-bull-racing.jpg 1100w, https://cdn.motorsport.com/images/mgl/YXypvxj6/s1200/laurent-mekies-red-bull-racing.jpg 1200w" type="image/jpeg" sizes="(min-width: 650px) 700px"> <img draggable="false" src="https://cdn.motorsport.com/images/mgl/YXypvxj6/s1000/laurent-mekies-red-bull-racing.jpg" alt="Laurent Mekies, Red Bull Racing Team Team Principal " width="1200" height="800" loading="lazy"> </picture>
+<p class="title">Laurent Mekies, Red Bull Racing Team Team Principal</p>
+<p class="photographer">Photo by: Red Bull Content Pool</p>
+</section>
+<p>Mekies hailed the Milton Keynes squad for its otherwise productive start to the 2026 pre-season, facing the huge task of bedding in its Red Bull Powertrains power units, which it developed together with Ford.</p>
+<p>"We knew it would be a very special moment to be here for the first time with RB22, with our own power unit," the Frenchman explained. "The last few months and weeks have been incredibly hectic to be ready, but ultimately we were ready on Monday morning to run and I can only take that opportunity to say a big thank you and well done to everybody back in Milton Keynes chassis and power unit side, because it was incredible to see the car going out at a few minutes past nine on Monday morning with our own power unit.</p><div class="ms-apb ms-apb-inarticle ms-apb-inarticle-after-preview-without-sidebar " data-msnt-label="Advertisement"><div id="ads_6122441_MST_global_Rectangle_rectangle_2_1770093040" class="ms-ap" data-id="4" data-ad-unit-id="/6122441/MST/global/Rectangle/rectangle_2" style="width:300px;min-height:250px;" data-dfp-code="MST/global/Rectangle" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;rectangle_2&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;inarticle-after-preview-without-sidebar&quot;}" data-msnt-label="Advertisement"></div></div>
+<p>"Of course, it's very early days and of course, nothing is perfect, but we could run, we could start to learn, work as one team. So that was a huge satisfaction. It doesn't change the size of the journey in front of us, but certainly it's a first moment that everybody in MK should be proud of."</p>
+<h2>Photos from&nbsp;Barcelona shakedown</h2>
+<div class="article-fullwidth-gallery article-fullwidth-gallery-11500 article-fullwidth-gallery--slide" data-gallery-type="regular" data-id="11500">
+    <div class="article-fullwidth-gallery_items">
+                                    <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158806" class="article-fullwidth-gallery_item current" data-name="gal-11500-franco-colapinto-alpine-72158806">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158806" data-detail-url="/f1/photos/franco-colapinto-alpine-72158806/72158806/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s200/franco-colapinto-alpine.webp 200w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s300/franco-colapinto-alpine.webp 300w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s400/franco-colapinto-alpine.webp 400w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s500/franco-colapinto-alpine.webp 500w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s600/franco-colapinto-alpine.webp 600w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s700/franco-colapinto-alpine.webp 700w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s800/franco-colapinto-alpine.webp 800w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s900/franco-colapinto-alpine.webp 900w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s1000/franco-colapinto-alpine.webp 1000w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s1100/franco-colapinto-alpine.webp 1100w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s1200/franco-colapinto-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s200/franco-colapinto-alpine.jpg 200w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s300/franco-colapinto-alpine.jpg 300w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s400/franco-colapinto-alpine.jpg 400w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s500/franco-colapinto-alpine.jpg 500w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s600/franco-colapinto-alpine.jpg 600w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s700/franco-colapinto-alpine.jpg 700w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s800/franco-colapinto-alpine.jpg 800w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s900/franco-colapinto-alpine.jpg 900w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s1000/franco-colapinto-alpine.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s1100/franco-colapinto-alpine.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/2jEDlLE0/s1200/franco-colapinto-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/2jEDlLE0/s700/franco-colapinto-alpine.jpg" alt="Franco Colapinto, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161114" class="article-fullwidth-gallery_item" data-name="gal-11500-ferrari-motorhome-72161114">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161114" data-detail-url="/f1/photos/ferrari-motorhome-72161114/72161114/">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s200/ferrari-motorhome.webp 200w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s300/ferrari-motorhome.webp 300w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s400/ferrari-motorhome.webp 400w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s500/ferrari-motorhome.webp 500w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s600/ferrari-motorhome.webp 600w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s700/ferrari-motorhome.webp 700w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s800/ferrari-motorhome.webp 800w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s900/ferrari-motorhome.webp 900w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s1000/ferrari-motorhome.webp 1000w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s1100/ferrari-motorhome.webp 1100w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s1200/ferrari-motorhome.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s200/ferrari-motorhome.jpg 200w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s300/ferrari-motorhome.jpg 300w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s400/ferrari-motorhome.jpg 400w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s500/ferrari-motorhome.jpg 500w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s600/ferrari-motorhome.jpg 600w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s700/ferrari-motorhome.jpg 700w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s800/ferrari-motorhome.jpg 800w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s900/ferrari-motorhome.jpg 900w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s1000/ferrari-motorhome.jpg 1000w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s1100/ferrari-motorhome.jpg 1100w, https://cdn-7.motorsport.com/images/mgl/2jEDlaq0/s1200/ferrari-motorhome.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/2jEDlaq0/s700/ferrari-motorhome.jpg" alt="Ferrari motorhome">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163056" class="article-fullwidth-gallery_item" data-name="gal-11500-liam-lawson-racing-bulls--72163056">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163056" data-detail-url="/f1/photos/liam-lawson-racing-bulls--72163056/72163056/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/24QedxPY/s200/liam-lawson-racing-bulls.webp 200w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s300/liam-lawson-racing-bulls.webp 300w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s400/liam-lawson-racing-bulls.webp 400w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s500/liam-lawson-racing-bulls.webp 500w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s600/liam-lawson-racing-bulls.webp 600w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s700/liam-lawson-racing-bulls.webp 700w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s800/liam-lawson-racing-bulls.webp 800w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s900/liam-lawson-racing-bulls.webp 900w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s1000/liam-lawson-racing-bulls.webp 1000w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s1100/liam-lawson-racing-bulls.webp 1100w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s1200/liam-lawson-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/24QedxPY/s200/liam-lawson-racing-bulls.jpg 200w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s300/liam-lawson-racing-bulls.jpg 300w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s400/liam-lawson-racing-bulls.jpg 400w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s500/liam-lawson-racing-bulls.jpg 500w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s600/liam-lawson-racing-bulls.jpg 600w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s700/liam-lawson-racing-bulls.jpg 700w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s800/liam-lawson-racing-bulls.jpg 800w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s900/liam-lawson-racing-bulls.jpg 900w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s1000/liam-lawson-racing-bulls.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s1100/liam-lawson-racing-bulls.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/24QedxPY/s1200/liam-lawson-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/24QedxPY/s700/liam-lawson-racing-bulls.jpg" alt="Liam Lawson, Racing Bulls ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72159741" class="article-fullwidth-gallery_item" data-name="gal-11500-laurent-mekies-red-bull-racing-team-team-principal--72159741">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72159741" data-detail-url="/f1/photos/laurent-mekies-red-bull-racing-team-team-principal--72159741/72159741/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s200/laurent-mekies-red-bull-racing.webp 200w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s300/laurent-mekies-red-bull-racing.webp 300w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s400/laurent-mekies-red-bull-racing.webp 400w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s500/laurent-mekies-red-bull-racing.webp 500w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s600/laurent-mekies-red-bull-racing.webp 600w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s700/laurent-mekies-red-bull-racing.webp 700w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s800/laurent-mekies-red-bull-racing.webp 800w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s900/laurent-mekies-red-bull-racing.webp 900w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s1000/laurent-mekies-red-bull-racing.webp 1000w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s1100/laurent-mekies-red-bull-racing.webp 1100w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s1200/laurent-mekies-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s200/laurent-mekies-red-bull-racing.jpg 200w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s300/laurent-mekies-red-bull-racing.jpg 300w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s400/laurent-mekies-red-bull-racing.jpg 400w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s500/laurent-mekies-red-bull-racing.jpg 500w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s600/laurent-mekies-red-bull-racing.jpg 600w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s700/laurent-mekies-red-bull-racing.jpg 700w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s800/laurent-mekies-red-bull-racing.jpg 800w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s900/laurent-mekies-red-bull-racing.jpg 900w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s1000/laurent-mekies-red-bull-racing.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s1100/laurent-mekies-red-bull-racing.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/6b8jEke2/s1200/laurent-mekies-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/6b8jEke2/s700/laurent-mekies-red-bull-racing.jpg" alt="Laurent Mekies, Red Bull Racing Team Team Principal, Ben Waterhouse, Red Bull Racing Head of Performance Engineering">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160008" class="article-fullwidth-gallery_item" data-name="gal-11500-charles-leclerc-ferraro">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160008" data-detail-url="/f1/photos/charles-leclerc-ferraro/72160008/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s200/charles-leclerc-ferraro.webp 200w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s300/charles-leclerc-ferraro.webp 300w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s400/charles-leclerc-ferraro.webp 400w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s500/charles-leclerc-ferraro.webp 500w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s600/charles-leclerc-ferraro.webp 600w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s700/charles-leclerc-ferraro.webp 700w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s800/charles-leclerc-ferraro.webp 800w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s900/charles-leclerc-ferraro.webp 900w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s1000/charles-leclerc-ferraro.webp 1000w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s1100/charles-leclerc-ferraro.webp 1100w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s1200/charles-leclerc-ferraro.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s200/charles-leclerc-ferraro.jpg 200w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s300/charles-leclerc-ferraro.jpg 300w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s400/charles-leclerc-ferraro.jpg 400w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s500/charles-leclerc-ferraro.jpg 500w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s600/charles-leclerc-ferraro.jpg 600w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s700/charles-leclerc-ferraro.jpg 700w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s800/charles-leclerc-ferraro.jpg 800w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s900/charles-leclerc-ferraro.jpg 900w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s1000/charles-leclerc-ferraro.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s1100/charles-leclerc-ferraro.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/Y9lLXQb2/s1200/charles-leclerc-ferraro.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/Y9lLXQb2/s700/charles-leclerc-ferraro.jpg" alt="Charles Leclerc, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72159743" class="article-fullwidth-gallery_item" data-name="gal-11500-isack-hadjar-red-bull-racing-72159743">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72159743" data-detail-url="/f1/photos/isack-hadjar-red-bull-racing-72159743/72159743/">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-7.motorsport.com/images/mgl/01QdMbx0/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/01QdMbx0/s700/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing
+">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158429" class="article-fullwidth-gallery_item" data-name="gal-11500-andrea-kimi-antonelli-mercedes-w17--72158429">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158429" data-detail-url="/f1/photos/andrea-kimi-antonelli-mercedes-w17--72158429/72158429/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s200/andrea-kimi-antonelli-mercedes.webp 200w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s300/andrea-kimi-antonelli-mercedes.webp 300w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s400/andrea-kimi-antonelli-mercedes.webp 400w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s500/andrea-kimi-antonelli-mercedes.webp 500w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s600/andrea-kimi-antonelli-mercedes.webp 600w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s700/andrea-kimi-antonelli-mercedes.webp 700w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s800/andrea-kimi-antonelli-mercedes.webp 800w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s900/andrea-kimi-antonelli-mercedes.webp 900w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s1000/andrea-kimi-antonelli-mercedes.webp 1000w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s1100/andrea-kimi-antonelli-mercedes.webp 1100w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s1200/andrea-kimi-antonelli-mercedes.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s200/andrea-kimi-antonelli-mercedes.jpg 200w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s300/andrea-kimi-antonelli-mercedes.jpg 300w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s400/andrea-kimi-antonelli-mercedes.jpg 400w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s500/andrea-kimi-antonelli-mercedes.jpg 500w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s600/andrea-kimi-antonelli-mercedes.jpg 600w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s700/andrea-kimi-antonelli-mercedes.jpg 700w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s800/andrea-kimi-antonelli-mercedes.jpg 800w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s900/andrea-kimi-antonelli-mercedes.jpg 900w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s1000/andrea-kimi-antonelli-mercedes.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s1100/andrea-kimi-antonelli-mercedes.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/0rVxl5W0/s1200/andrea-kimi-antonelli-mercedes.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/0rVxl5W0/s700/andrea-kimi-antonelli-mercedes.jpg" alt="Andrea Kimi Antonelli, Mercedes W17  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72164237" class="article-fullwidth-gallery_item" data-name="gal-11500-sergio-perez-valtteri-bottas-cadillac--72164237">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72164237" data-detail-url="/f1/photos/sergio-perez-valtteri-bottas-cadillac--72164237/72164237/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s200/sergio-perez-valtteri-bottas-c.webp 200w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s300/sergio-perez-valtteri-bottas-c.webp 300w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s400/sergio-perez-valtteri-bottas-c.webp 400w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s500/sergio-perez-valtteri-bottas-c.webp 500w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s600/sergio-perez-valtteri-bottas-c.webp 600w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s700/sergio-perez-valtteri-bottas-c.webp 700w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s800/sergio-perez-valtteri-bottas-c.webp 800w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s900/sergio-perez-valtteri-bottas-c.webp 900w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s1000/sergio-perez-valtteri-bottas-c.webp 1000w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s1100/sergio-perez-valtteri-bottas-c.webp 1100w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s1200/sergio-perez-valtteri-bottas-c.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s200/sergio-perez-valtteri-bottas-c.jpg 200w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s300/sergio-perez-valtteri-bottas-c.jpg 300w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s400/sergio-perez-valtteri-bottas-c.jpg 400w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s500/sergio-perez-valtteri-bottas-c.jpg 500w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s600/sergio-perez-valtteri-bottas-c.jpg 600w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s700/sergio-perez-valtteri-bottas-c.jpg 700w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s800/sergio-perez-valtteri-bottas-c.jpg 800w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s900/sergio-perez-valtteri-bottas-c.jpg 900w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s1000/sergio-perez-valtteri-bottas-c.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s1100/sergio-perez-valtteri-bottas-c.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/YMX37bn2/s1200/sergio-perez-valtteri-bottas-c.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/YMX37bn2/s700/sergio-perez-valtteri-bottas-c.jpg" alt="Sergio Perez, Valtteri Bottas, Cadillac ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158803" class="article-fullwidth-gallery_item" data-name="gal-11500-franco-colapinto-alpine-72158803">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158803" data-detail-url="/f1/photos/franco-colapinto-alpine-72158803/72158803/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/2y7APno6/s200/franco-colapinto-alpine.webp 200w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s300/franco-colapinto-alpine.webp 300w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s400/franco-colapinto-alpine.webp 400w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s500/franco-colapinto-alpine.webp 500w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s600/franco-colapinto-alpine.webp 600w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s700/franco-colapinto-alpine.webp 700w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s800/franco-colapinto-alpine.webp 800w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s900/franco-colapinto-alpine.webp 900w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s1000/franco-colapinto-alpine.webp 1000w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s1100/franco-colapinto-alpine.webp 1100w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s1200/franco-colapinto-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/2y7APno6/s200/franco-colapinto-alpine.jpg 200w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s300/franco-colapinto-alpine.jpg 300w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s400/franco-colapinto-alpine.jpg 400w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s500/franco-colapinto-alpine.jpg 500w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s600/franco-colapinto-alpine.jpg 600w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s700/franco-colapinto-alpine.jpg 700w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s800/franco-colapinto-alpine.jpg 800w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s900/franco-colapinto-alpine.jpg 900w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s1000/franco-colapinto-alpine.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s1100/franco-colapinto-alpine.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/2y7APno6/s1200/franco-colapinto-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-3.motorsport.com/images/mgl/2y7APno6/s700/franco-colapinto-alpine.jpg" alt="Franco Colapinto, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160255" class="article-fullwidth-gallery_item" data-name="gal-11500-isack-hadjar-red-bull-racing--72160255">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160255" data-detail-url="/f1/photos/isack-hadjar-red-bull-racing--72160255/72160255/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/25d3GvJ0/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/25d3GvJ0/s700/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163027" class="article-fullwidth-gallery_item" data-name="gal-11500-esteban-ocon-haas-f1-team-72163027">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163027" data-detail-url="/f1/photos/esteban-ocon-haas-f1-team-72163027/72163027/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s200/esteban-ocon-haas-f1-team.webp 200w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s300/esteban-ocon-haas-f1-team.webp 300w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s400/esteban-ocon-haas-f1-team.webp 400w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s500/esteban-ocon-haas-f1-team.webp 500w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s600/esteban-ocon-haas-f1-team.webp 600w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s700/esteban-ocon-haas-f1-team.webp 700w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s800/esteban-ocon-haas-f1-team.webp 800w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s900/esteban-ocon-haas-f1-team.webp 900w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s1000/esteban-ocon-haas-f1-team.webp 1000w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s1100/esteban-ocon-haas-f1-team.webp 1100w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s1200/esteban-ocon-haas-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s200/esteban-ocon-haas-f1-team.jpg 200w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s300/esteban-ocon-haas-f1-team.jpg 300w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s400/esteban-ocon-haas-f1-team.jpg 400w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s500/esteban-ocon-haas-f1-team.jpg 500w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s600/esteban-ocon-haas-f1-team.jpg 600w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s700/esteban-ocon-haas-f1-team.jpg 700w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s800/esteban-ocon-haas-f1-team.jpg 800w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s900/esteban-ocon-haas-f1-team.jpg 900w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s1000/esteban-ocon-haas-f1-team.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s1100/esteban-ocon-haas-f1-team.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/6Al7yrkY/s1200/esteban-ocon-haas-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/mgl/6Al7yrkY/s700/esteban-ocon-haas-f1-team.jpg" alt="Esteban Ocon, Haas F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161233" class="article-fullwidth-gallery_item" data-name="gal-11500-max-verstappen-red-bull-racing-72161233">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161233" data-detail-url="/f1/photos/max-verstappen-red-bull-racing-72161233/72161233/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/2GdwpbzY/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/2GdwpbzY/s700/max-verstappen-red-bull-racing.jpg" alt="Max Verstappen, Red Bull Racing">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161113" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari--72161113">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161113" data-detail-url="/f1/photos/lewis-hamilton-ferrari--72161113/72161113/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/0R7wJao2/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/0R7wJao2/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162913" class="article-fullwidth-gallery_item" data-name="gal-11500-oliver-bearman-haas-f1-team--72162913">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162913" data-detail-url="/f1/photos/oliver-bearman-haas-f1-team--72162913/72162913/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s200/oliver-bearman-haas-f1-team.webp 200w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s300/oliver-bearman-haas-f1-team.webp 300w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s400/oliver-bearman-haas-f1-team.webp 400w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s500/oliver-bearman-haas-f1-team.webp 500w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s600/oliver-bearman-haas-f1-team.webp 600w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s700/oliver-bearman-haas-f1-team.webp 700w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s800/oliver-bearman-haas-f1-team.webp 800w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s900/oliver-bearman-haas-f1-team.webp 900w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s1000/oliver-bearman-haas-f1-team.webp 1000w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s1100/oliver-bearman-haas-f1-team.webp 1100w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s1200/oliver-bearman-haas-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s200/oliver-bearman-haas-f1-team.jpg 200w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s300/oliver-bearman-haas-f1-team.jpg 300w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s400/oliver-bearman-haas-f1-team.jpg 400w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s500/oliver-bearman-haas-f1-team.jpg 500w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s600/oliver-bearman-haas-f1-team.jpg 600w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s700/oliver-bearman-haas-f1-team.jpg 700w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s800/oliver-bearman-haas-f1-team.jpg 800w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s900/oliver-bearman-haas-f1-team.jpg 900w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s1000/oliver-bearman-haas-f1-team.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s1100/oliver-bearman-haas-f1-team.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/2eZgyK1Y/s1200/oliver-bearman-haas-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/2eZgyK1Y/s700/oliver-bearman-haas-f1-team.jpg" alt="Oliver Bearman, Haas F1 Team ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161188" class="article-fullwidth-gallery_item" data-name="gal-11500-gabriel-bortoleto-audi-72161188">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161188" data-detail-url="/f1/photos/gabriel-bortoleto-audi-72161188/72161188/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s200/gabriel-bortoleto-audi.webp 200w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s300/gabriel-bortoleto-audi.webp 300w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s400/gabriel-bortoleto-audi.webp 400w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s500/gabriel-bortoleto-audi.webp 500w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s600/gabriel-bortoleto-audi.webp 600w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s700/gabriel-bortoleto-audi.webp 700w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s800/gabriel-bortoleto-audi.webp 800w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s900/gabriel-bortoleto-audi.webp 900w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s1000/gabriel-bortoleto-audi.webp 1000w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s1100/gabriel-bortoleto-audi.webp 1100w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s1200/gabriel-bortoleto-audi.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s200/gabriel-bortoleto-audi.jpg 200w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s300/gabriel-bortoleto-audi.jpg 300w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s400/gabriel-bortoleto-audi.jpg 400w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s500/gabriel-bortoleto-audi.jpg 500w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s600/gabriel-bortoleto-audi.jpg 600w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s700/gabriel-bortoleto-audi.jpg 700w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s800/gabriel-bortoleto-audi.jpg 800w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s900/gabriel-bortoleto-audi.jpg 900w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s1000/gabriel-bortoleto-audi.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s1100/gabriel-bortoleto-audi.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/27NQLwE0/s1200/gabriel-bortoleto-audi.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/27NQLwE0/s700/gabriel-bortoleto-audi.jpg" alt="Gabriel Bortoleto, Audi">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161870" class="article-fullwidth-gallery_item" data-name="gal-11500-lando-norris-mclaren-72161870">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161870" data-detail-url="/f1/photos/lando-norris-mclaren-72161870/72161870/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s200/lando-norris-mclaren.webp 200w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s300/lando-norris-mclaren.webp 300w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s400/lando-norris-mclaren.webp 400w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s500/lando-norris-mclaren.webp 500w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s600/lando-norris-mclaren.webp 600w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s700/lando-norris-mclaren.webp 700w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s800/lando-norris-mclaren.webp 800w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s900/lando-norris-mclaren.webp 900w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s1000/lando-norris-mclaren.webp 1000w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s1100/lando-norris-mclaren.webp 1100w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s1200/lando-norris-mclaren.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s200/lando-norris-mclaren.jpg 200w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s300/lando-norris-mclaren.jpg 300w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s400/lando-norris-mclaren.jpg 400w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s500/lando-norris-mclaren.jpg 500w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s600/lando-norris-mclaren.jpg 600w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s700/lando-norris-mclaren.jpg 700w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s800/lando-norris-mclaren.jpg 800w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s900/lando-norris-mclaren.jpg 900w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s1000/lando-norris-mclaren.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s1100/lando-norris-mclaren.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/27NQLEK0/s1200/lando-norris-mclaren.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/27NQLEK0/s700/lando-norris-mclaren.jpg" alt="Lando Norris, Mclaren">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162730" class="article-fullwidth-gallery_item" data-name="gal-11500-arvid-lindblad-racing-bulls--72162730">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162730" data-detail-url="/f1/photos/arvid-lindblad-racing-bulls--72162730/72162730/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s200/arvid-lindblad-racing-bulls.webp 200w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s300/arvid-lindblad-racing-bulls.webp 300w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s400/arvid-lindblad-racing-bulls.webp 400w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s500/arvid-lindblad-racing-bulls.webp 500w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s600/arvid-lindblad-racing-bulls.webp 600w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s700/arvid-lindblad-racing-bulls.webp 700w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s800/arvid-lindblad-racing-bulls.webp 800w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s900/arvid-lindblad-racing-bulls.webp 900w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s1000/arvid-lindblad-racing-bulls.webp 1000w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s1100/arvid-lindblad-racing-bulls.webp 1100w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s1200/arvid-lindblad-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s200/arvid-lindblad-racing-bulls.jpg 200w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s300/arvid-lindblad-racing-bulls.jpg 300w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s400/arvid-lindblad-racing-bulls.jpg 400w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s500/arvid-lindblad-racing-bulls.jpg 500w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s600/arvid-lindblad-racing-bulls.jpg 600w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s700/arvid-lindblad-racing-bulls.jpg 700w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s800/arvid-lindblad-racing-bulls.jpg 800w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s900/arvid-lindblad-racing-bulls.jpg 900w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s1000/arvid-lindblad-racing-bulls.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s1100/arvid-lindblad-racing-bulls.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/YMX3Kwl2/s1200/arvid-lindblad-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-3.motorsport.com/images/mgl/YMX3Kwl2/s700/arvid-lindblad-racing-bulls.jpg" alt="Arvid Lindblad, Racing Bulls ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72159742" class="article-fullwidth-gallery_item" data-name="gal-11500-isack-hadjar-red-bull-racing-72159742">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72159742" data-detail-url="/f1/photos/isack-hadjar-red-bull-racing-72159742/72159742/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/YpbPlZJ0/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/YpbPlZJ0/s700/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing
+">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158805" class="article-fullwidth-gallery_item" data-name="gal-11500-franco-colapinto-alpine-72158805">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158805" data-detail-url="/f1/photos/franco-colapinto-alpine-72158805/72158805/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s200/franco-colapinto-alpine.webp 200w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s300/franco-colapinto-alpine.webp 300w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s400/franco-colapinto-alpine.webp 400w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s500/franco-colapinto-alpine.webp 500w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s600/franco-colapinto-alpine.webp 600w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s700/franco-colapinto-alpine.webp 700w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s800/franco-colapinto-alpine.webp 800w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s900/franco-colapinto-alpine.webp 900w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s1000/franco-colapinto-alpine.webp 1000w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s1100/franco-colapinto-alpine.webp 1100w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s1200/franco-colapinto-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s200/franco-colapinto-alpine.jpg 200w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s300/franco-colapinto-alpine.jpg 300w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s400/franco-colapinto-alpine.jpg 400w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s500/franco-colapinto-alpine.jpg 500w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s600/franco-colapinto-alpine.jpg 600w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s700/franco-colapinto-alpine.jpg 700w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s800/franco-colapinto-alpine.jpg 800w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s900/franco-colapinto-alpine.jpg 900w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s1000/franco-colapinto-alpine.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s1100/franco-colapinto-alpine.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/Y9lLXm72/s1200/franco-colapinto-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/Y9lLXm72/s700/franco-colapinto-alpine.jpg" alt="Franco Colapinto, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162230" class="article-fullwidth-gallery_item" data-name="gal-11500-lando-norris-mclaren--72162230">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162230" data-detail-url="/f1/photos/lando-norris-mclaren--72162230/72162230/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s200/lando-norris-mclaren.webp 200w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s300/lando-norris-mclaren.webp 300w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s400/lando-norris-mclaren.webp 400w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s500/lando-norris-mclaren.webp 500w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s600/lando-norris-mclaren.webp 600w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s700/lando-norris-mclaren.webp 700w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s800/lando-norris-mclaren.webp 800w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s900/lando-norris-mclaren.webp 900w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s1000/lando-norris-mclaren.webp 1000w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s1100/lando-norris-mclaren.webp 1100w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s1200/lando-norris-mclaren.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s200/lando-norris-mclaren.jpg 200w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s300/lando-norris-mclaren.jpg 300w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s400/lando-norris-mclaren.jpg 400w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s500/lando-norris-mclaren.jpg 500w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s600/lando-norris-mclaren.jpg 600w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s700/lando-norris-mclaren.jpg 700w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s800/lando-norris-mclaren.jpg 800w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s900/lando-norris-mclaren.jpg 900w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s1000/lando-norris-mclaren.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s1100/lando-norris-mclaren.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/01QdMmq0/s1200/lando-norris-mclaren.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/01QdMmq0/s700/lando-norris-mclaren.jpg" alt="Lando Norris, McLaren ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163373" class="article-fullwidth-gallery_item" data-name="gal-11500-george-russell-mercedes--72163373">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163373" data-detail-url="/f1/photos/george-russell-mercedes--72163373/72163373/">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s200/george-russell-mercedes.webp 200w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s300/george-russell-mercedes.webp 300w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s400/george-russell-mercedes.webp 400w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s500/george-russell-mercedes.webp 500w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s600/george-russell-mercedes.webp 600w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s700/george-russell-mercedes.webp 700w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s800/george-russell-mercedes.webp 800w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s900/george-russell-mercedes.webp 900w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s1000/george-russell-mercedes.webp 1000w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s1100/george-russell-mercedes.webp 1100w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s1200/george-russell-mercedes.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s200/george-russell-mercedes.jpg 200w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s300/george-russell-mercedes.jpg 300w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s400/george-russell-mercedes.jpg 400w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s500/george-russell-mercedes.jpg 500w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s600/george-russell-mercedes.jpg 600w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s700/george-russell-mercedes.jpg 700w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s800/george-russell-mercedes.jpg 800w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s900/george-russell-mercedes.jpg 900w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s1000/george-russell-mercedes.jpg 1000w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s1100/george-russell-mercedes.jpg 1100w, https://cdn-4.motorsport.com/images/mgl/Y9lL5Lq2/s1200/george-russell-mercedes.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/Y9lL5Lq2/s700/george-russell-mercedes.jpg" alt="George Russell, Mercedes ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161184" class="article-fullwidth-gallery_item" data-name="gal-11500-helmet-of-gabriel-bortoleto-audi">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161184" data-detail-url="/f1/photos/helmet-of-gabriel-bortoleto-audi/72161184/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s200/helmet-of-gabriel-bortoleto-au.webp 200w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s300/helmet-of-gabriel-bortoleto-au.webp 300w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s400/helmet-of-gabriel-bortoleto-au.webp 400w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s500/helmet-of-gabriel-bortoleto-au.webp 500w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s600/helmet-of-gabriel-bortoleto-au.webp 600w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s700/helmet-of-gabriel-bortoleto-au.webp 700w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s800/helmet-of-gabriel-bortoleto-au.webp 800w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s900/helmet-of-gabriel-bortoleto-au.webp 900w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s1000/helmet-of-gabriel-bortoleto-au.webp 1000w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s1100/helmet-of-gabriel-bortoleto-au.webp 1100w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s1200/helmet-of-gabriel-bortoleto-au.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s200/helmet-of-gabriel-bortoleto-au.jpg 200w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s300/helmet-of-gabriel-bortoleto-au.jpg 300w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s400/helmet-of-gabriel-bortoleto-au.jpg 400w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s500/helmet-of-gabriel-bortoleto-au.jpg 500w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s600/helmet-of-gabriel-bortoleto-au.jpg 600w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s700/helmet-of-gabriel-bortoleto-au.jpg 700w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s800/helmet-of-gabriel-bortoleto-au.jpg 800w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s900/helmet-of-gabriel-bortoleto-au.jpg 900w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s1000/helmet-of-gabriel-bortoleto-au.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s1100/helmet-of-gabriel-bortoleto-au.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/6x7ZlVmY/s1200/helmet-of-gabriel-bortoleto-au.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/6x7ZlVmY/s700/helmet-of-gabriel-bortoleto-au.jpg" alt="Helmet of Gabriel Bortoleto, Audi">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163031" class="article-fullwidth-gallery_item" data-name="gal-11500-laura-mueller-race-engineer-haas-f1-team">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163031" data-detail-url="/f1/photos/laura-mueller-race-engineer-haas-f1-team/72163031/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s200/laura-mueller-race-engineer-ha.webp 200w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s300/laura-mueller-race-engineer-ha.webp 300w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s400/laura-mueller-race-engineer-ha.webp 400w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s500/laura-mueller-race-engineer-ha.webp 500w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s600/laura-mueller-race-engineer-ha.webp 600w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s700/laura-mueller-race-engineer-ha.webp 700w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s800/laura-mueller-race-engineer-ha.webp 800w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s900/laura-mueller-race-engineer-ha.webp 900w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s1000/laura-mueller-race-engineer-ha.webp 1000w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s1100/laura-mueller-race-engineer-ha.webp 1100w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s1200/laura-mueller-race-engineer-ha.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s200/laura-mueller-race-engineer-ha.jpg 200w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s300/laura-mueller-race-engineer-ha.jpg 300w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s400/laura-mueller-race-engineer-ha.jpg 400w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s500/laura-mueller-race-engineer-ha.jpg 500w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s600/laura-mueller-race-engineer-ha.jpg 600w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s700/laura-mueller-race-engineer-ha.jpg 700w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s800/laura-mueller-race-engineer-ha.jpg 800w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s900/laura-mueller-race-engineer-ha.jpg 900w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s1000/laura-mueller-race-engineer-ha.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s1100/laura-mueller-race-engineer-ha.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/YP7rdvj2/s1200/laura-mueller-race-engineer-ha.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/YP7rdvj2/s700/laura-mueller-race-engineer-ha.jpg" alt="Laura Mueller, Race Engineer Haas F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160010" class="article-fullwidth-gallery_item" data-name="gal-11500-charles-leclerc-ferraro-72160010">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160010" data-detail-url="/f1/photos/charles-leclerc-ferraro-72160010/72160010/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s200/charles-leclerc-ferraro.webp 200w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s300/charles-leclerc-ferraro.webp 300w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s400/charles-leclerc-ferraro.webp 400w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s500/charles-leclerc-ferraro.webp 500w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s600/charles-leclerc-ferraro.webp 600w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s700/charles-leclerc-ferraro.webp 700w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s800/charles-leclerc-ferraro.webp 800w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s900/charles-leclerc-ferraro.webp 900w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s1000/charles-leclerc-ferraro.webp 1000w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s1100/charles-leclerc-ferraro.webp 1100w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s1200/charles-leclerc-ferraro.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s200/charles-leclerc-ferraro.jpg 200w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s300/charles-leclerc-ferraro.jpg 300w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s400/charles-leclerc-ferraro.jpg 400w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s500/charles-leclerc-ferraro.jpg 500w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s600/charles-leclerc-ferraro.jpg 600w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s700/charles-leclerc-ferraro.jpg 700w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s800/charles-leclerc-ferraro.jpg 800w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s900/charles-leclerc-ferraro.jpg 900w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s1000/charles-leclerc-ferraro.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s1100/charles-leclerc-ferraro.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/2y7APNy6/s1200/charles-leclerc-ferraro.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/2y7APNy6/s700/charles-leclerc-ferraro.jpg" alt="Charles Leclerc, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160256" class="article-fullwidth-gallery_item" data-name="gal-11500-max-verstappen-red-bull-racing--72160256">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160256" data-detail-url="/f1/photos/max-verstappen-red-bull-racing--72160256/72160256/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/2jEDl9q0/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/2jEDl9q0/s700/max-verstappen-red-bull-racing.jpg" alt="Max Verstappen, Red Bull Racing  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158586" class="article-fullwidth-gallery_item" data-name="gal-11500-andrea-kimi-antonelli-mercedes-w17-72158586">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158586" data-detail-url="/f1/photos/andrea-kimi-antonelli-mercedes-w17-72158586/72158586/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s200/andrea-kimi-antonelli-mercedes.webp 200w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s300/andrea-kimi-antonelli-mercedes.webp 300w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s400/andrea-kimi-antonelli-mercedes.webp 400w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s500/andrea-kimi-antonelli-mercedes.webp 500w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s600/andrea-kimi-antonelli-mercedes.webp 600w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s700/andrea-kimi-antonelli-mercedes.webp 700w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s800/andrea-kimi-antonelli-mercedes.webp 800w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s900/andrea-kimi-antonelli-mercedes.webp 900w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s1000/andrea-kimi-antonelli-mercedes.webp 1000w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s1100/andrea-kimi-antonelli-mercedes.webp 1100w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s1200/andrea-kimi-antonelli-mercedes.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s200/andrea-kimi-antonelli-mercedes.jpg 200w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s300/andrea-kimi-antonelli-mercedes.jpg 300w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s400/andrea-kimi-antonelli-mercedes.jpg 400w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s500/andrea-kimi-antonelli-mercedes.jpg 500w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s600/andrea-kimi-antonelli-mercedes.jpg 600w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s700/andrea-kimi-antonelli-mercedes.jpg 700w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s800/andrea-kimi-antonelli-mercedes.jpg 800w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s900/andrea-kimi-antonelli-mercedes.jpg 900w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s1000/andrea-kimi-antonelli-mercedes.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s1100/andrea-kimi-antonelli-mercedes.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/2jEDlzE0/s1200/andrea-kimi-antonelli-mercedes.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/2jEDlzE0/s700/andrea-kimi-antonelli-mercedes.jpg" alt="Andrea Kimi Antonelli, Mercedes W17">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161219" class="article-fullwidth-gallery_item" data-name="gal-11500-liam-lawson-racing-bulls--72161219">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161219" data-detail-url="/f1/photos/liam-lawson-racing-bulls--72161219/72161219/">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s200/liam-lawson-racing-bulls.webp 200w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s300/liam-lawson-racing-bulls.webp 300w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s400/liam-lawson-racing-bulls.webp 400w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s500/liam-lawson-racing-bulls.webp 500w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s600/liam-lawson-racing-bulls.webp 600w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s700/liam-lawson-racing-bulls.webp 700w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s800/liam-lawson-racing-bulls.webp 800w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s900/liam-lawson-racing-bulls.webp 900w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s1000/liam-lawson-racing-bulls.webp 1000w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s1100/liam-lawson-racing-bulls.webp 1100w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s1200/liam-lawson-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s200/liam-lawson-racing-bulls.jpg 200w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s300/liam-lawson-racing-bulls.jpg 300w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s400/liam-lawson-racing-bulls.jpg 400w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s500/liam-lawson-racing-bulls.jpg 500w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s600/liam-lawson-racing-bulls.jpg 600w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s700/liam-lawson-racing-bulls.jpg 700w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s800/liam-lawson-racing-bulls.jpg 800w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s900/liam-lawson-racing-bulls.jpg 900w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s1000/liam-lawson-racing-bulls.jpg 1000w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s1100/liam-lawson-racing-bulls.jpg 1100w, https://cdn-4.motorsport.com/images/mgl/2wlEQdKY/s1200/liam-lawson-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/2wlEQdKY/s700/liam-lawson-racing-bulls.jpg" alt="Liam Lawson, Racing Bulls  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162550" class="article-fullwidth-gallery_item" data-name="gal-11500-lando-norris-mclaren-mcl40--72162550">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162550" data-detail-url="/f1/photos/lando-norris-mclaren-mcl40--72162550/72162550/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s200/lando-norris-mclaren-mcl40.webp 200w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s300/lando-norris-mclaren-mcl40.webp 300w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s400/lando-norris-mclaren-mcl40.webp 400w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s500/lando-norris-mclaren-mcl40.webp 500w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s600/lando-norris-mclaren-mcl40.webp 600w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s700/lando-norris-mclaren-mcl40.webp 700w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s800/lando-norris-mclaren-mcl40.webp 800w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s900/lando-norris-mclaren-mcl40.webp 900w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s1000/lando-norris-mclaren-mcl40.webp 1000w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s1100/lando-norris-mclaren-mcl40.webp 1100w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s1200/lando-norris-mclaren-mcl40.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s200/lando-norris-mclaren-mcl40.jpg 200w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s300/lando-norris-mclaren-mcl40.jpg 300w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s400/lando-norris-mclaren-mcl40.jpg 400w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s500/lando-norris-mclaren-mcl40.jpg 500w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s600/lando-norris-mclaren-mcl40.jpg 600w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s700/lando-norris-mclaren-mcl40.jpg 700w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s800/lando-norris-mclaren-mcl40.jpg 800w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s900/lando-norris-mclaren-mcl40.jpg 900w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s1000/lando-norris-mclaren-mcl40.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s1100/lando-norris-mclaren-mcl40.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/0o5PlzwY/s1200/lando-norris-mclaren-mcl40.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/0o5PlzwY/s700/lando-norris-mclaren-mcl40.jpg" alt="Lando Norris, McLaren MCL40 ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160009" class="article-fullwidth-gallery_item" data-name="gal-11500-charles-leclerc-ferraro-72160009">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160009" data-detail-url="/f1/photos/charles-leclerc-ferraro-72160009/72160009/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s200/charles-leclerc-ferraro.webp 200w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s300/charles-leclerc-ferraro.webp 300w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s400/charles-leclerc-ferraro.webp 400w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s500/charles-leclerc-ferraro.webp 500w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s600/charles-leclerc-ferraro.webp 600w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s700/charles-leclerc-ferraro.webp 700w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s800/charles-leclerc-ferraro.webp 800w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s900/charles-leclerc-ferraro.webp 900w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s1000/charles-leclerc-ferraro.webp 1000w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s1100/charles-leclerc-ferraro.webp 1100w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s1200/charles-leclerc-ferraro.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s200/charles-leclerc-ferraro.jpg 200w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s300/charles-leclerc-ferraro.jpg 300w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s400/charles-leclerc-ferraro.jpg 400w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s500/charles-leclerc-ferraro.jpg 500w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s600/charles-leclerc-ferraro.jpg 600w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s700/charles-leclerc-ferraro.jpg 700w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s800/charles-leclerc-ferraro.jpg 800w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s900/charles-leclerc-ferraro.jpg 900w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s1000/charles-leclerc-ferraro.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s1100/charles-leclerc-ferraro.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/0R7wJmo2/s1200/charles-leclerc-ferraro.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/0R7wJmo2/s700/charles-leclerc-ferraro.jpg" alt="Charles Leclerc, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161220" class="article-fullwidth-gallery_item" data-name="gal-11500-liam-lawson-racing-bulls--72161220">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161220" data-detail-url="/f1/photos/liam-lawson-racing-bulls--72161220/72161220/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s200/liam-lawson-racing-bulls.webp 200w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s300/liam-lawson-racing-bulls.webp 300w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s400/liam-lawson-racing-bulls.webp 400w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s500/liam-lawson-racing-bulls.webp 500w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s600/liam-lawson-racing-bulls.webp 600w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s700/liam-lawson-racing-bulls.webp 700w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s800/liam-lawson-racing-bulls.webp 800w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s900/liam-lawson-racing-bulls.webp 900w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s1000/liam-lawson-racing-bulls.webp 1000w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s1100/liam-lawson-racing-bulls.webp 1100w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s1200/liam-lawson-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s200/liam-lawson-racing-bulls.jpg 200w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s300/liam-lawson-racing-bulls.jpg 300w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s400/liam-lawson-racing-bulls.jpg 400w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s500/liam-lawson-racing-bulls.jpg 500w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s600/liam-lawson-racing-bulls.jpg 600w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s700/liam-lawson-racing-bulls.jpg 700w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s800/liam-lawson-racing-bulls.jpg 800w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s900/liam-lawson-racing-bulls.jpg 900w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s1000/liam-lawson-racing-bulls.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s1100/liam-lawson-racing-bulls.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/0qgPlxQY/s1200/liam-lawson-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-7.motorsport.com/images/mgl/0qgPlxQY/s700/liam-lawson-racing-bulls.jpg" alt="Liam Lawson, Racing Bulls  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163079" class="article-fullwidth-gallery_item" data-name="gal-11500-nico-hulkenberg-audi-f1-team--72163079">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163079" data-detail-url="/f1/photos/nico-hulkenberg-audi-f1-team--72163079/72163079/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/6grBRllY/s200/nico-hulkenberg-audi-f1-team.webp 200w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s300/nico-hulkenberg-audi-f1-team.webp 300w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s400/nico-hulkenberg-audi-f1-team.webp 400w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s500/nico-hulkenberg-audi-f1-team.webp 500w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s600/nico-hulkenberg-audi-f1-team.webp 600w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s700/nico-hulkenberg-audi-f1-team.webp 700w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s800/nico-hulkenberg-audi-f1-team.webp 800w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s900/nico-hulkenberg-audi-f1-team.webp 900w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s1000/nico-hulkenberg-audi-f1-team.webp 1000w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s1100/nico-hulkenberg-audi-f1-team.webp 1100w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s1200/nico-hulkenberg-audi-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/6grBRllY/s200/nico-hulkenberg-audi-f1-team.jpg 200w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s300/nico-hulkenberg-audi-f1-team.jpg 300w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s400/nico-hulkenberg-audi-f1-team.jpg 400w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s500/nico-hulkenberg-audi-f1-team.jpg 500w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s600/nico-hulkenberg-audi-f1-team.jpg 600w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s700/nico-hulkenberg-audi-f1-team.jpg 700w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s800/nico-hulkenberg-audi-f1-team.jpg 800w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s900/nico-hulkenberg-audi-f1-team.jpg 900w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s1000/nico-hulkenberg-audi-f1-team.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s1100/nico-hulkenberg-audi-f1-team.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/6grBRllY/s1200/nico-hulkenberg-audi-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/mgl/6grBRllY/s700/nico-hulkenberg-audi-f1-team.jpg" alt="Nico Hulkenberg, Audi F1 Team ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72159739" class="article-fullwidth-gallery_item" data-name="gal-11500-laurent-mekies-red-bull-racing-team-team-principal-">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72159739" data-detail-url="/f1/photos/laurent-mekies-red-bull-racing-team-team-principal-/72159739/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s200/laurent-mekies-red-bull-racing.webp 200w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s300/laurent-mekies-red-bull-racing.webp 300w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s400/laurent-mekies-red-bull-racing.webp 400w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s500/laurent-mekies-red-bull-racing.webp 500w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s600/laurent-mekies-red-bull-racing.webp 600w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s700/laurent-mekies-red-bull-racing.webp 700w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s800/laurent-mekies-red-bull-racing.webp 800w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s900/laurent-mekies-red-bull-racing.webp 900w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s1000/laurent-mekies-red-bull-racing.webp 1000w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s1100/laurent-mekies-red-bull-racing.webp 1100w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s1200/laurent-mekies-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s200/laurent-mekies-red-bull-racing.jpg 200w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s300/laurent-mekies-red-bull-racing.jpg 300w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s400/laurent-mekies-red-bull-racing.jpg 400w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s500/laurent-mekies-red-bull-racing.jpg 500w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s600/laurent-mekies-red-bull-racing.jpg 600w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s700/laurent-mekies-red-bull-racing.jpg 700w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s800/laurent-mekies-red-bull-racing.jpg 800w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s900/laurent-mekies-red-bull-racing.jpg 900w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s1000/laurent-mekies-red-bull-racing.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s1100/laurent-mekies-red-bull-racing.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/YXypvxj6/s1200/laurent-mekies-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/YXypvxj6/s700/laurent-mekies-red-bull-racing.jpg" alt="Laurent Mekies, Red Bull Racing Team Team Principal ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160917" class="article-fullwidth-gallery_item" data-name="gal-11500-oliver-bearman-haas-72160917">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160917" data-detail-url="/f1/photos/oliver-bearman-haas-72160917/72160917/">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/mgl/24QedmgY/s200/oliver-bearman-haas.webp 200w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s300/oliver-bearman-haas.webp 300w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s400/oliver-bearman-haas.webp 400w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s500/oliver-bearman-haas.webp 500w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s600/oliver-bearman-haas.webp 600w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s700/oliver-bearman-haas.webp 700w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s800/oliver-bearman-haas.webp 800w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s900/oliver-bearman-haas.webp 900w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s1000/oliver-bearman-haas.webp 1000w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s1100/oliver-bearman-haas.webp 1100w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s1200/oliver-bearman-haas.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/mgl/24QedmgY/s200/oliver-bearman-haas.jpg 200w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s300/oliver-bearman-haas.jpg 300w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s400/oliver-bearman-haas.jpg 400w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s500/oliver-bearman-haas.jpg 500w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s600/oliver-bearman-haas.jpg 600w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s700/oliver-bearman-haas.jpg 700w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s800/oliver-bearman-haas.jpg 800w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s900/oliver-bearman-haas.jpg 900w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s1000/oliver-bearman-haas.jpg 1000w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s1100/oliver-bearman-haas.jpg 1100w, https://cdn-7.motorsport.com/images/mgl/24QedmgY/s1200/oliver-bearman-haas.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/24QedmgY/s700/oliver-bearman-haas.jpg" alt="Oliver Bearman, Haas">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161221" class="article-fullwidth-gallery_item" data-name="gal-11500-liam-lawson-racing-bulls--72161221">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161221" data-detail-url="/f1/photos/liam-lawson-racing-bulls--72161221/72161221/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s200/liam-lawson-racing-bulls.webp 200w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s300/liam-lawson-racing-bulls.webp 300w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s400/liam-lawson-racing-bulls.webp 400w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s500/liam-lawson-racing-bulls.webp 500w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s600/liam-lawson-racing-bulls.webp 600w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s700/liam-lawson-racing-bulls.webp 700w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s800/liam-lawson-racing-bulls.webp 800w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s900/liam-lawson-racing-bulls.webp 900w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s1000/liam-lawson-racing-bulls.webp 1000w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s1100/liam-lawson-racing-bulls.webp 1100w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s1200/liam-lawson-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s200/liam-lawson-racing-bulls.jpg 200w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s300/liam-lawson-racing-bulls.jpg 300w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s400/liam-lawson-racing-bulls.jpg 400w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s500/liam-lawson-racing-bulls.jpg 500w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s600/liam-lawson-racing-bulls.jpg 600w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s700/liam-lawson-racing-bulls.jpg 700w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s800/liam-lawson-racing-bulls.jpg 800w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s900/liam-lawson-racing-bulls.jpg 900w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s1000/liam-lawson-racing-bulls.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s1100/liam-lawson-racing-bulls.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/2eZgyDpY/s1200/liam-lawson-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/2eZgyDpY/s700/liam-lawson-racing-bulls.jpg" alt="Liam Lawson, Racing Bulls  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158804" class="article-fullwidth-gallery_item" data-name="gal-11500-franco-colapinto-alpine-72158804">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158804" data-detail-url="/f1/photos/franco-colapinto-alpine-72158804/72158804/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s200/franco-colapinto-alpine.webp 200w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s300/franco-colapinto-alpine.webp 300w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s400/franco-colapinto-alpine.webp 400w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s500/franco-colapinto-alpine.webp 500w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s600/franco-colapinto-alpine.webp 600w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s700/franco-colapinto-alpine.webp 700w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s800/franco-colapinto-alpine.webp 800w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s900/franco-colapinto-alpine.webp 900w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s1000/franco-colapinto-alpine.webp 1000w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s1100/franco-colapinto-alpine.webp 1100w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s1200/franco-colapinto-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s200/franco-colapinto-alpine.jpg 200w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s300/franco-colapinto-alpine.jpg 300w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s400/franco-colapinto-alpine.jpg 400w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s500/franco-colapinto-alpine.jpg 500w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s600/franco-colapinto-alpine.jpg 600w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s700/franco-colapinto-alpine.jpg 700w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s800/franco-colapinto-alpine.jpg 800w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s900/franco-colapinto-alpine.jpg 900w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s1000/franco-colapinto-alpine.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s1100/franco-colapinto-alpine.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/0R7wJPr2/s1200/franco-colapinto-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/0R7wJPr2/s700/franco-colapinto-alpine.jpg" alt="Franco Colapinto, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160254" class="article-fullwidth-gallery_item" data-name="gal-11500-isack-hadjar-red-bull-racing--72160254">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160254" data-detail-url="/f1/photos/isack-hadjar-red-bull-racing--72160254/72160254/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/6Vy74qnY/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/6Vy74qnY/s700/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161110" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari--72161110">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161110" data-detail-url="/f1/photos/lewis-hamilton-ferrari--72161110/72161110/">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-7.motorsport.com/images/mgl/6DGqjWwY/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/mgl/6DGqjWwY/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158585" class="article-fullwidth-gallery_item" data-name="gal-11500-andrea-kimi-antonelli-mercedes-w17-72158585">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158585" data-detail-url="/f1/photos/andrea-kimi-antonelli-mercedes-w17-72158585/72158585/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s200/andrea-kimi-antonelli-mercedes.webp 200w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s300/andrea-kimi-antonelli-mercedes.webp 300w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s400/andrea-kimi-antonelli-mercedes.webp 400w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s500/andrea-kimi-antonelli-mercedes.webp 500w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s600/andrea-kimi-antonelli-mercedes.webp 600w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s700/andrea-kimi-antonelli-mercedes.webp 700w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s800/andrea-kimi-antonelli-mercedes.webp 800w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s900/andrea-kimi-antonelli-mercedes.webp 900w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s1000/andrea-kimi-antonelli-mercedes.webp 1000w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s1100/andrea-kimi-antonelli-mercedes.webp 1100w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s1200/andrea-kimi-antonelli-mercedes.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s200/andrea-kimi-antonelli-mercedes.jpg 200w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s300/andrea-kimi-antonelli-mercedes.jpg 300w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s400/andrea-kimi-antonelli-mercedes.jpg 400w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s500/andrea-kimi-antonelli-mercedes.jpg 500w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s600/andrea-kimi-antonelli-mercedes.jpg 600w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s700/andrea-kimi-antonelli-mercedes.jpg 700w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s800/andrea-kimi-antonelli-mercedes.jpg 800w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s900/andrea-kimi-antonelli-mercedes.jpg 900w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s1000/andrea-kimi-antonelli-mercedes.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s1100/andrea-kimi-antonelli-mercedes.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/0R7wJjr2/s1200/andrea-kimi-antonelli-mercedes.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/0R7wJjr2/s700/andrea-kimi-antonelli-mercedes.jpg" alt="Andrea Kimi Antonelli, Mercedes W17">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160869" class="article-fullwidth-gallery_item" data-name="gal-11500-max-verstappen-red-bull-racing-72160869">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160869" data-detail-url="/f1/photos/max-verstappen-red-bull-racing-72160869/72160869/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/6lmdlz10/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/6lmdlz10/s700/max-verstappen-red-bull-racing.jpg" alt="Max Verstappen, Red Bull Racing">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161191" class="article-fullwidth-gallery_item" data-name="gal-11500-audi-r26-in-the-pitlane">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161191" data-detail-url="/f1/photos/audi-r26-in-the-pitlane/72161191/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s200/audi-r26-in-the-pitlane.webp 200w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s300/audi-r26-in-the-pitlane.webp 300w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s400/audi-r26-in-the-pitlane.webp 400w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s500/audi-r26-in-the-pitlane.webp 500w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s600/audi-r26-in-the-pitlane.webp 600w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s700/audi-r26-in-the-pitlane.webp 700w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s800/audi-r26-in-the-pitlane.webp 800w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s900/audi-r26-in-the-pitlane.webp 900w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s1000/audi-r26-in-the-pitlane.webp 1000w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s1100/audi-r26-in-the-pitlane.webp 1100w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s1200/audi-r26-in-the-pitlane.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s200/audi-r26-in-the-pitlane.jpg 200w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s300/audi-r26-in-the-pitlane.jpg 300w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s400/audi-r26-in-the-pitlane.jpg 400w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s500/audi-r26-in-the-pitlane.jpg 500w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s600/audi-r26-in-the-pitlane.jpg 600w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s700/audi-r26-in-the-pitlane.jpg 700w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s800/audi-r26-in-the-pitlane.jpg 800w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s900/audi-r26-in-the-pitlane.jpg 900w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s1000/audi-r26-in-the-pitlane.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s1100/audi-r26-in-the-pitlane.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/YN7wpae6/s1200/audi-r26-in-the-pitlane.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/YN7wpae6/s700/audi-r26-in-the-pitlane.jpg" alt="Audi R26 in the pitlane">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72158022" class="article-fullwidth-gallery_item" data-name="gal-11500-esteban-ocon-haas">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72158022" data-detail-url="/f1/photos/esteban-ocon-haas/72158022/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s200/esteban-ocon-haas.webp 200w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s300/esteban-ocon-haas.webp 300w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s400/esteban-ocon-haas.webp 400w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s500/esteban-ocon-haas.webp 500w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s600/esteban-ocon-haas.webp 600w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s700/esteban-ocon-haas.webp 700w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s800/esteban-ocon-haas.webp 800w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s900/esteban-ocon-haas.webp 900w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s1000/esteban-ocon-haas.webp 1000w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s1100/esteban-ocon-haas.webp 1100w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s1200/esteban-ocon-haas.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s200/esteban-ocon-haas.jpg 200w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s300/esteban-ocon-haas.jpg 300w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s400/esteban-ocon-haas.jpg 400w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s500/esteban-ocon-haas.jpg 500w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s600/esteban-ocon-haas.jpg 600w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s700/esteban-ocon-haas.jpg 700w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s800/esteban-ocon-haas.jpg 800w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s900/esteban-ocon-haas.jpg 900w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s1000/esteban-ocon-haas.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s1100/esteban-ocon-haas.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/YN7wpQb6/s1200/esteban-ocon-haas.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/YN7wpQb6/s700/esteban-ocon-haas.jpg" alt="Esteban Ocon, Haas">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161218" class="article-fullwidth-gallery_item" data-name="gal-11500-liam-lawson-racing-bulls--72161218">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161218" data-detail-url="/f1/photos/liam-lawson-racing-bulls--72161218/72161218/">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s200/liam-lawson-racing-bulls.webp 200w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s300/liam-lawson-racing-bulls.webp 300w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s400/liam-lawson-racing-bulls.webp 400w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s500/liam-lawson-racing-bulls.webp 500w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s600/liam-lawson-racing-bulls.webp 600w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s700/liam-lawson-racing-bulls.webp 700w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s800/liam-lawson-racing-bulls.webp 800w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s900/liam-lawson-racing-bulls.webp 900w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s1000/liam-lawson-racing-bulls.webp 1000w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s1100/liam-lawson-racing-bulls.webp 1100w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s1200/liam-lawson-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s200/liam-lawson-racing-bulls.jpg 200w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s300/liam-lawson-racing-bulls.jpg 300w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s400/liam-lawson-racing-bulls.jpg 400w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s500/liam-lawson-racing-bulls.jpg 500w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s600/liam-lawson-racing-bulls.jpg 600w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s700/liam-lawson-racing-bulls.jpg 700w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s800/liam-lawson-racing-bulls.jpg 800w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s900/liam-lawson-racing-bulls.jpg 900w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s1000/liam-lawson-racing-bulls.jpg 1000w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s1100/liam-lawson-racing-bulls.jpg 1100w, https://cdn-4.motorsport.com/images/mgl/2dE7DZ7Y/s1200/liam-lawson-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/2dE7DZ7Y/s700/liam-lawson-racing-bulls.jpg" alt="Liam Lawson, Racing Bulls  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161357" class="article-fullwidth-gallery_item" data-name="gal-11500-charles-leclerc-ferrari-72161357">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161357" data-detail-url="/f1/photos/charles-leclerc-ferrari-72161357/72161357/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/24QedPgY/s200/charles-leclerc-ferrari.webp 200w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s300/charles-leclerc-ferrari.webp 300w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s400/charles-leclerc-ferrari.webp 400w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s500/charles-leclerc-ferrari.webp 500w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s600/charles-leclerc-ferrari.webp 600w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s700/charles-leclerc-ferrari.webp 700w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s800/charles-leclerc-ferrari.webp 800w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s900/charles-leclerc-ferrari.webp 900w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s1000/charles-leclerc-ferrari.webp 1000w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s1100/charles-leclerc-ferrari.webp 1100w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s1200/charles-leclerc-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/24QedPgY/s200/charles-leclerc-ferrari.jpg 200w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s300/charles-leclerc-ferrari.jpg 300w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s400/charles-leclerc-ferrari.jpg 400w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s500/charles-leclerc-ferrari.jpg 500w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s600/charles-leclerc-ferrari.jpg 600w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s700/charles-leclerc-ferrari.jpg 700w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s800/charles-leclerc-ferrari.jpg 800w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s900/charles-leclerc-ferrari.jpg 900w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s1000/charles-leclerc-ferrari.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s1100/charles-leclerc-ferrari.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/24QedPgY/s1200/charles-leclerc-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/24QedPgY/s700/charles-leclerc-ferrari.jpg" alt="Charles Leclerc, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72159740" class="article-fullwidth-gallery_item" data-name="gal-11500-isack-hadjar-red-bull-racing-72159740">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72159740" data-detail-url="/f1/photos/isack-hadjar-red-bull-racing-72159740/72159740/">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/mgl/6O79pR56/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/mgl/6O79pR56/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-7.motorsport.com/images/mgl/6O79pR56/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/6O79pR56/s700/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing
+">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160963" class="article-fullwidth-gallery_item" data-name="gal-11500-sergio-perez-cadillac-f1-team">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160963" data-detail-url="/f1/photos/sergio-perez-cadillac-f1-team/72160963/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s200/sergio-perez-cadillac-f1-team.webp 200w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s300/sergio-perez-cadillac-f1-team.webp 300w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s400/sergio-perez-cadillac-f1-team.webp 400w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s500/sergio-perez-cadillac-f1-team.webp 500w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s600/sergio-perez-cadillac-f1-team.webp 600w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s700/sergio-perez-cadillac-f1-team.webp 700w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s800/sergio-perez-cadillac-f1-team.webp 800w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s900/sergio-perez-cadillac-f1-team.webp 900w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s1000/sergio-perez-cadillac-f1-team.webp 1000w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s1100/sergio-perez-cadillac-f1-team.webp 1100w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s1200/sergio-perez-cadillac-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s200/sergio-perez-cadillac-f1-team.jpg 200w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s300/sergio-perez-cadillac-f1-team.jpg 300w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s400/sergio-perez-cadillac-f1-team.jpg 400w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s500/sergio-perez-cadillac-f1-team.jpg 500w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s600/sergio-perez-cadillac-f1-team.jpg 600w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s700/sergio-perez-cadillac-f1-team.jpg 700w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s800/sergio-perez-cadillac-f1-team.jpg 800w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s900/sergio-perez-cadillac-f1-team.jpg 900w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s1000/sergio-perez-cadillac-f1-team.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s1100/sergio-perez-cadillac-f1-team.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/0arKBaN2/s1200/sergio-perez-cadillac-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/mgl/0arKBaN2/s700/sergio-perez-cadillac-f1-team.jpg" alt="Sergio Perez, Cadillac F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160868" class="article-fullwidth-gallery_item" data-name="gal-11500-max-verstappen-red-bull-racing-72160868">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160868" data-detail-url="/f1/photos/max-verstappen-red-bull-racing-72160868/72160868/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/6Al7yQGY/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/mgl/6Al7yQGY/s700/max-verstappen-red-bull-racing.jpg" alt="Max Verstappen, Red Bull Racing">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161243" class="article-fullwidth-gallery_item" data-name="gal-11500-oliver-bearman-haas-f1-team-72161243">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161243" data-detail-url="/f1/photos/oliver-bearman-haas-f1-team-72161243/72161243/">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s200/oliver-bearman-haas-f1-team.webp 200w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s300/oliver-bearman-haas-f1-team.webp 300w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s400/oliver-bearman-haas-f1-team.webp 400w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s500/oliver-bearman-haas-f1-team.webp 500w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s600/oliver-bearman-haas-f1-team.webp 600w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s700/oliver-bearman-haas-f1-team.webp 700w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s800/oliver-bearman-haas-f1-team.webp 800w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s900/oliver-bearman-haas-f1-team.webp 900w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s1000/oliver-bearman-haas-f1-team.webp 1000w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s1100/oliver-bearman-haas-f1-team.webp 1100w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s1200/oliver-bearman-haas-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s200/oliver-bearman-haas-f1-team.jpg 200w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s300/oliver-bearman-haas-f1-team.jpg 300w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s400/oliver-bearman-haas-f1-team.jpg 400w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s500/oliver-bearman-haas-f1-team.jpg 500w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s600/oliver-bearman-haas-f1-team.jpg 600w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s700/oliver-bearman-haas-f1-team.jpg 700w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s800/oliver-bearman-haas-f1-team.jpg 800w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s900/oliver-bearman-haas-f1-team.jpg 900w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s1000/oliver-bearman-haas-f1-team.jpg 1000w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s1100/oliver-bearman-haas-f1-team.jpg 1100w, https://cdn-4.motorsport.com/images/mgl/6Al7yjGY/s1200/oliver-bearman-haas-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-3.motorsport.com/images/mgl/6Al7yjGY/s700/oliver-bearman-haas-f1-team.jpg" alt="Oliver Bearman, Haas F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163370" class="article-fullwidth-gallery_item" data-name="gal-11500-george-russell-mercedes--72163370">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163370" data-detail-url="/f1/photos/george-russell-mercedes--72163370/72163370/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s200/george-russell-mercedes.webp 200w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s300/george-russell-mercedes.webp 300w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s400/george-russell-mercedes.webp 400w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s500/george-russell-mercedes.webp 500w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s600/george-russell-mercedes.webp 600w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s700/george-russell-mercedes.webp 700w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s800/george-russell-mercedes.webp 800w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s900/george-russell-mercedes.webp 900w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s1000/george-russell-mercedes.webp 1000w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s1100/george-russell-mercedes.webp 1100w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s1200/george-russell-mercedes.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s200/george-russell-mercedes.jpg 200w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s300/george-russell-mercedes.jpg 300w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s400/george-russell-mercedes.jpg 400w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s500/george-russell-mercedes.jpg 500w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s600/george-russell-mercedes.jpg 600w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s700/george-russell-mercedes.jpg 700w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s800/george-russell-mercedes.jpg 800w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s900/george-russell-mercedes.jpg 900w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s1000/george-russell-mercedes.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s1100/george-russell-mercedes.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/0ZqAbAR6/s1200/george-russell-mercedes.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/0ZqAbAR6/s700/george-russell-mercedes.jpg" alt="George Russell, Mercedes ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160867" class="article-fullwidth-gallery_item" data-name="gal-11500-max-verstappen-red-bull-racing-72160867">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160867" data-detail-url="/f1/photos/max-verstappen-red-bull-racing-72160867/72160867/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-3.motorsport.com/images/mgl/2Qe8pam2/s700/max-verstappen-red-bull-racing.jpg" alt="Max Verstappen, Red Bull Racing">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161342" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari-72161342">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161342" data-detail-url="/f1/photos/lewis-hamilton-ferrari-72161342/72161342/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/YWKwvo5Y/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161187" class="article-fullwidth-gallery_item" data-name="gal-11500-mattia-binotto-audi">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161187" data-detail-url="/f1/photos/mattia-binotto-audi/72161187/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/63Qmp772/s200/mattia-binotto-audi.webp 200w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s300/mattia-binotto-audi.webp 300w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s400/mattia-binotto-audi.webp 400w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s500/mattia-binotto-audi.webp 500w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s600/mattia-binotto-audi.webp 600w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s700/mattia-binotto-audi.webp 700w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s800/mattia-binotto-audi.webp 800w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s900/mattia-binotto-audi.webp 900w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s1000/mattia-binotto-audi.webp 1000w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s1100/mattia-binotto-audi.webp 1100w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s1200/mattia-binotto-audi.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/63Qmp772/s200/mattia-binotto-audi.jpg 200w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s300/mattia-binotto-audi.jpg 300w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s400/mattia-binotto-audi.jpg 400w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s500/mattia-binotto-audi.jpg 500w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s600/mattia-binotto-audi.jpg 600w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s700/mattia-binotto-audi.jpg 700w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s800/mattia-binotto-audi.jpg 800w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s900/mattia-binotto-audi.jpg 900w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s1000/mattia-binotto-audi.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s1100/mattia-binotto-audi.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/63Qmp772/s1200/mattia-binotto-audi.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/63Qmp772/s700/mattia-binotto-audi.jpg" alt="Mattia Binotto, Audi">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160988" class="article-fullwidth-gallery_item" data-name="gal-11500-charles-leclerc-ferrari-72160988">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160988" data-detail-url="/f1/photos/charles-leclerc-ferrari-72160988/72160988/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s200/charles-leclerc-ferrari.webp 200w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s300/charles-leclerc-ferrari.webp 300w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s400/charles-leclerc-ferrari.webp 400w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s500/charles-leclerc-ferrari.webp 500w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s600/charles-leclerc-ferrari.webp 600w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s700/charles-leclerc-ferrari.webp 700w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s800/charles-leclerc-ferrari.webp 800w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s900/charles-leclerc-ferrari.webp 900w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s1000/charles-leclerc-ferrari.webp 1000w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s1100/charles-leclerc-ferrari.webp 1100w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s1200/charles-leclerc-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s200/charles-leclerc-ferrari.jpg 200w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s300/charles-leclerc-ferrari.jpg 300w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s400/charles-leclerc-ferrari.jpg 400w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s500/charles-leclerc-ferrari.jpg 500w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s600/charles-leclerc-ferrari.jpg 600w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s700/charles-leclerc-ferrari.jpg 700w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s800/charles-leclerc-ferrari.jpg 800w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s900/charles-leclerc-ferrari.jpg 900w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s1000/charles-leclerc-ferrari.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s1100/charles-leclerc-ferrari.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/0rVxlDO0/s1200/charles-leclerc-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/0rVxlDO0/s700/charles-leclerc-ferrari.jpg" alt="Charles Leclerc, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72164211" class="article-fullwidth-gallery_item" data-name="gal-11500-oscar-piastri-mclaren-72164211">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72164211" data-detail-url="/f1/photos/oscar-piastri-mclaren-72164211/72164211/">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s200/oscar-piastri-mclaren.webp 200w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s300/oscar-piastri-mclaren.webp 300w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s400/oscar-piastri-mclaren.webp 400w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s500/oscar-piastri-mclaren.webp 500w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s600/oscar-piastri-mclaren.webp 600w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s700/oscar-piastri-mclaren.webp 700w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s800/oscar-piastri-mclaren.webp 800w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s900/oscar-piastri-mclaren.webp 900w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s1000/oscar-piastri-mclaren.webp 1000w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s1100/oscar-piastri-mclaren.webp 1100w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s1200/oscar-piastri-mclaren.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s200/oscar-piastri-mclaren.jpg 200w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s300/oscar-piastri-mclaren.jpg 300w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s400/oscar-piastri-mclaren.jpg 400w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s500/oscar-piastri-mclaren.jpg 500w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s600/oscar-piastri-mclaren.jpg 600w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s700/oscar-piastri-mclaren.jpg 700w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s800/oscar-piastri-mclaren.jpg 800w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s900/oscar-piastri-mclaren.jpg 900w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s1000/oscar-piastri-mclaren.jpg 1000w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s1100/oscar-piastri-mclaren.jpg 1100w, https://cdn-4.motorsport.com/images/mgl/63QmZaJ2/s1200/oscar-piastri-mclaren.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-3.motorsport.com/images/mgl/63QmZaJ2/s700/oscar-piastri-mclaren.jpg" alt="Oscar Piastri, McLaren">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162278" class="article-fullwidth-gallery_item" data-name="gal-11500-franco-colapinto-alpine-72162278">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162278" data-detail-url="/f1/photos/franco-colapinto-alpine-72162278/72162278/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s200/franco-colapinto-alpine.webp 200w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s300/franco-colapinto-alpine.webp 300w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s400/franco-colapinto-alpine.webp 400w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s500/franco-colapinto-alpine.webp 500w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s600/franco-colapinto-alpine.webp 600w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s700/franco-colapinto-alpine.webp 700w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s800/franco-colapinto-alpine.webp 800w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s900/franco-colapinto-alpine.webp 900w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s1000/franco-colapinto-alpine.webp 1000w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s1100/franco-colapinto-alpine.webp 1100w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s1200/franco-colapinto-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s200/franco-colapinto-alpine.jpg 200w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s300/franco-colapinto-alpine.jpg 300w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s400/franco-colapinto-alpine.jpg 400w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s500/franco-colapinto-alpine.jpg 500w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s600/franco-colapinto-alpine.jpg 600w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s700/franco-colapinto-alpine.jpg 700w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s800/franco-colapinto-alpine.jpg 800w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s900/franco-colapinto-alpine.jpg 900w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s1000/franco-colapinto-alpine.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s1100/franco-colapinto-alpine.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/6x7ZlR7Y/s1200/franco-colapinto-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/6x7ZlR7Y/s700/franco-colapinto-alpine.jpg" alt="Franco Colapinto, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72166138" class="article-fullwidth-gallery_item" data-name="gal-11500-gabriel-bortoleto-audi-f1-team-72166138">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72166138" data-detail-url="/f1/photos/gabriel-bortoleto-audi-f1-team-72166138/72166138/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s200/gabriel-bortoleto-audi-f1-team.webp 200w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s300/gabriel-bortoleto-audi-f1-team.webp 300w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s400/gabriel-bortoleto-audi-f1-team.webp 400w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s500/gabriel-bortoleto-audi-f1-team.webp 500w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s600/gabriel-bortoleto-audi-f1-team.webp 600w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s700/gabriel-bortoleto-audi-f1-team.webp 700w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s800/gabriel-bortoleto-audi-f1-team.webp 800w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s900/gabriel-bortoleto-audi-f1-team.webp 900w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s1000/gabriel-bortoleto-audi-f1-team.webp 1000w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s1100/gabriel-bortoleto-audi-f1-team.webp 1100w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s1200/gabriel-bortoleto-audi-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s200/gabriel-bortoleto-audi-f1-team.jpg 200w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s300/gabriel-bortoleto-audi-f1-team.jpg 300w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s400/gabriel-bortoleto-audi-f1-team.jpg 400w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s500/gabriel-bortoleto-audi-f1-team.jpg 500w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s600/gabriel-bortoleto-audi-f1-team.jpg 600w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s700/gabriel-bortoleto-audi-f1-team.jpg 700w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s800/gabriel-bortoleto-audi-f1-team.jpg 800w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s900/gabriel-bortoleto-audi-f1-team.jpg 900w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s1000/gabriel-bortoleto-audi-f1-team.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s1100/gabriel-bortoleto-audi-f1-team.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/0ZqAbRL6/s1200/gabriel-bortoleto-audi-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-7.motorsport.com/images/mgl/0ZqAbRL6/s700/gabriel-bortoleto-audi-f1-team.jpg" alt="Gabriel Bortoleto, Audi F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161109" class="article-fullwidth-gallery_item" data-name="gal-11500-charles-leclerc-ferrari--72161109">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161109" data-detail-url="/f1/photos/charles-leclerc-ferrari--72161109/72161109/">
+                        <source type="image/webp" srcset="https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s200/charles-leclerc-ferrari.webp 200w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s300/charles-leclerc-ferrari.webp 300w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s400/charles-leclerc-ferrari.webp 400w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s500/charles-leclerc-ferrari.webp 500w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s600/charles-leclerc-ferrari.webp 600w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s700/charles-leclerc-ferrari.webp 700w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s800/charles-leclerc-ferrari.webp 800w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s900/charles-leclerc-ferrari.webp 900w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s1000/charles-leclerc-ferrari.webp 1000w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s1100/charles-leclerc-ferrari.webp 1100w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s1200/charles-leclerc-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s200/charles-leclerc-ferrari.jpg 200w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s300/charles-leclerc-ferrari.jpg 300w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s400/charles-leclerc-ferrari.jpg 400w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s500/charles-leclerc-ferrari.jpg 500w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s600/charles-leclerc-ferrari.jpg 600w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s700/charles-leclerc-ferrari.jpg 700w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s800/charles-leclerc-ferrari.jpg 800w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s900/charles-leclerc-ferrari.jpg 900w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s1000/charles-leclerc-ferrari.jpg 1000w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s1100/charles-leclerc-ferrari.jpg 1100w, https://cdn-1.motorsport.com/images/mgl/0ZqAvaN6/s1200/charles-leclerc-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/0ZqAvaN6/s700/charles-leclerc-ferrari.jpg" alt="Charles Leclerc, Ferrari ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161343" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari-72161343">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161343" data-detail-url="/f1/photos/lewis-hamilton-ferrari-72161343/72161343/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/YP7rdwe2/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/YP7rdwe2/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161915" class="article-fullwidth-gallery_item" data-name="gal-11500-oliver-bearman-haas-72161915">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161915" data-detail-url="/f1/photos/oliver-bearman-haas-72161915/72161915/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s200/oliver-bearman-haas.webp 200w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s300/oliver-bearman-haas.webp 300w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s400/oliver-bearman-haas.webp 400w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s500/oliver-bearman-haas.webp 500w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s600/oliver-bearman-haas.webp 600w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s700/oliver-bearman-haas.webp 700w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s800/oliver-bearman-haas.webp 800w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s900/oliver-bearman-haas.webp 900w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s1000/oliver-bearman-haas.webp 1000w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s1100/oliver-bearman-haas.webp 1100w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s1200/oliver-bearman-haas.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s200/oliver-bearman-haas.jpg 200w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s300/oliver-bearman-haas.jpg 300w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s400/oliver-bearman-haas.jpg 400w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s500/oliver-bearman-haas.jpg 500w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s600/oliver-bearman-haas.jpg 600w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s700/oliver-bearman-haas.jpg 700w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s800/oliver-bearman-haas.jpg 800w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s900/oliver-bearman-haas.jpg 900w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s1000/oliver-bearman-haas.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s1100/oliver-bearman-haas.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/YN7wpgm6/s1200/oliver-bearman-haas.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/YN7wpgm6/s700/oliver-bearman-haas.jpg" alt="Oliver Bearman, Haas">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162279" class="article-fullwidth-gallery_item" data-name="gal-11500-pierre-gasly-alpine-72162279">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162279" data-detail-url="/f1/photos/pierre-gasly-alpine-72162279/72162279/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s200/pierre-gasly-alpine.webp 200w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s300/pierre-gasly-alpine.webp 300w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s400/pierre-gasly-alpine.webp 400w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s500/pierre-gasly-alpine.webp 500w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s600/pierre-gasly-alpine.webp 600w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s700/pierre-gasly-alpine.webp 700w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s800/pierre-gasly-alpine.webp 800w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s900/pierre-gasly-alpine.webp 900w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s1000/pierre-gasly-alpine.webp 1000w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s1100/pierre-gasly-alpine.webp 1100w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s1200/pierre-gasly-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s200/pierre-gasly-alpine.jpg 200w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s300/pierre-gasly-alpine.jpg 300w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s400/pierre-gasly-alpine.jpg 400w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s500/pierre-gasly-alpine.jpg 500w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s600/pierre-gasly-alpine.jpg 600w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s700/pierre-gasly-alpine.jpg 700w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s800/pierre-gasly-alpine.jpg 800w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s900/pierre-gasly-alpine.jpg 900w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s1000/pierre-gasly-alpine.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s1100/pierre-gasly-alpine.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/27NQLkK0/s1200/pierre-gasly-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/27NQLkK0/s700/pierre-gasly-alpine.jpg" alt="Pierre Gasly, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72160987" class="article-fullwidth-gallery_item" data-name="gal-11500-max-verstappen-red-bull-racing-72160987">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72160987" data-detail-url="/f1/photos/max-verstappen-red-bull-racing-72160987/72160987/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/68VWLgB2/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/68VWLgB2/s700/max-verstappen-red-bull-racing.jpg" alt="Max Verstappen, Red Bull Racing">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161341" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari-72161341">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161341" data-detail-url="/f1/photos/lewis-hamilton-ferrari-72161341/72161341/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/6n7AlOl0/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/6n7AlOl0/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72164255" class="article-fullwidth-gallery_item" data-name="gal-11500-lance-stroll-aston-martin--72164255">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72164255" data-detail-url="/f1/photos/lance-stroll-aston-martin--72164255/72164255/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s200/lance-stroll-aston-martin.webp 200w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s300/lance-stroll-aston-martin.webp 300w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s400/lance-stroll-aston-martin.webp 400w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s500/lance-stroll-aston-martin.webp 500w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s600/lance-stroll-aston-martin.webp 600w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s700/lance-stroll-aston-martin.webp 700w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s800/lance-stroll-aston-martin.webp 800w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s900/lance-stroll-aston-martin.webp 900w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s1000/lance-stroll-aston-martin.webp 1000w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s1100/lance-stroll-aston-martin.webp 1100w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s1200/lance-stroll-aston-martin.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s200/lance-stroll-aston-martin.jpg 200w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s300/lance-stroll-aston-martin.jpg 300w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s400/lance-stroll-aston-martin.jpg 400w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s500/lance-stroll-aston-martin.jpg 500w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s600/lance-stroll-aston-martin.jpg 600w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s700/lance-stroll-aston-martin.jpg 700w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s800/lance-stroll-aston-martin.jpg 800w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s900/lance-stroll-aston-martin.jpg 900w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s1000/lance-stroll-aston-martin.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s1100/lance-stroll-aston-martin.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/0mXROyg6/s1200/lance-stroll-aston-martin.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-2.motorsport.com/images/mgl/0mXROyg6/s700/lance-stroll-aston-martin.jpg" alt="Lance Stroll, Aston Martin ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162213" class="article-fullwidth-gallery_item" data-name="gal-11500-lando-norris-mclaren-72162213">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162213" data-detail-url="/f1/photos/lando-norris-mclaren-72162213/72162213/">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s200/lando-norris-mclaren.webp 200w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s300/lando-norris-mclaren.webp 300w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s400/lando-norris-mclaren.webp 400w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s500/lando-norris-mclaren.webp 500w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s600/lando-norris-mclaren.webp 600w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s700/lando-norris-mclaren.webp 700w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s800/lando-norris-mclaren.webp 800w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s900/lando-norris-mclaren.webp 900w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s1000/lando-norris-mclaren.webp 1000w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s1100/lando-norris-mclaren.webp 1100w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s1200/lando-norris-mclaren.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s200/lando-norris-mclaren.jpg 200w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s300/lando-norris-mclaren.jpg 300w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s400/lando-norris-mclaren.jpg 400w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s500/lando-norris-mclaren.jpg 500w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s600/lando-norris-mclaren.jpg 600w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s700/lando-norris-mclaren.jpg 700w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s800/lando-norris-mclaren.jpg 800w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s900/lando-norris-mclaren.jpg 900w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s1000/lando-norris-mclaren.jpg 1000w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s1100/lando-norris-mclaren.jpg 1100w, https://cdn-3.motorsport.com/images/mgl/25d3G8M0/s1200/lando-norris-mclaren.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/25d3G8M0/s700/lando-norris-mclaren.jpg" alt="Lando Norris, McLaren">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162161" class="article-fullwidth-gallery_item" data-name="gal-11500-isack-hadjar-red-bull-racing--72162161">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162161" data-detail-url="/f1/photos/isack-hadjar-red-bull-racing--72162161/72162161/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/0ZqAvLM6/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/0ZqAvLM6/s700/isack-hadjar-red-bull-racing.jpg" alt="Isack Hadjar, Red Bull Racing  ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162916" class="article-fullwidth-gallery_item" data-name="gal-11500-oliver-bearman-haas-f1-team--72162916">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162916" data-detail-url="/f1/photos/oliver-bearman-haas-f1-team--72162916/72162916/">
+                        <source type="image/webp" srcset="https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s200/oliver-bearman-haas-f1-team.webp 200w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s300/oliver-bearman-haas-f1-team.webp 300w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s400/oliver-bearman-haas-f1-team.webp 400w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s500/oliver-bearman-haas-f1-team.webp 500w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s600/oliver-bearman-haas-f1-team.webp 600w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s700/oliver-bearman-haas-f1-team.webp 700w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s800/oliver-bearman-haas-f1-team.webp 800w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s900/oliver-bearman-haas-f1-team.webp 900w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s1000/oliver-bearman-haas-f1-team.webp 1000w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s1100/oliver-bearman-haas-f1-team.webp 1100w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s1200/oliver-bearman-haas-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s200/oliver-bearman-haas-f1-team.jpg 200w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s300/oliver-bearman-haas-f1-team.jpg 300w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s400/oliver-bearman-haas-f1-team.jpg 400w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s500/oliver-bearman-haas-f1-team.jpg 500w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s600/oliver-bearman-haas-f1-team.jpg 600w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s700/oliver-bearman-haas-f1-team.jpg 700w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s800/oliver-bearman-haas-f1-team.jpg 800w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s900/oliver-bearman-haas-f1-team.jpg 900w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s1000/oliver-bearman-haas-f1-team.jpg 1000w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s1100/oliver-bearman-haas-f1-team.jpg 1100w, https://cdn-2.motorsport.com/images/mgl/YK13p7w0/s1200/oliver-bearman-haas-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/YK13p7w0/s700/oliver-bearman-haas-f1-team.jpg" alt="Oliver Bearman, Haas F1 Team ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162197" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari-72162197">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162197" data-detail-url="/f1/photos/lewis-hamilton-ferrari-72162197/72162197/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/2y7APGX6/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/2y7APGX6/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162728" class="article-fullwidth-gallery_item" data-name="gal-11500-arvid-lindblad-racing-bulls--72162728">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162728" data-detail-url="/f1/photos/arvid-lindblad-racing-bulls--72162728/72162728/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s200/arvid-lindblad-racing-bulls.webp 200w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s300/arvid-lindblad-racing-bulls.webp 300w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s400/arvid-lindblad-racing-bulls.webp 400w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s500/arvid-lindblad-racing-bulls.webp 500w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s600/arvid-lindblad-racing-bulls.webp 600w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s700/arvid-lindblad-racing-bulls.webp 700w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s800/arvid-lindblad-racing-bulls.webp 800w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s900/arvid-lindblad-racing-bulls.webp 900w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s1000/arvid-lindblad-racing-bulls.webp 1000w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s1100/arvid-lindblad-racing-bulls.webp 1100w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s1200/arvid-lindblad-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s200/arvid-lindblad-racing-bulls.jpg 200w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s300/arvid-lindblad-racing-bulls.jpg 300w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s400/arvid-lindblad-racing-bulls.jpg 400w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s500/arvid-lindblad-racing-bulls.jpg 500w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s600/arvid-lindblad-racing-bulls.jpg 600w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s700/arvid-lindblad-racing-bulls.jpg 700w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s800/arvid-lindblad-racing-bulls.jpg 800w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s900/arvid-lindblad-racing-bulls.jpg 900w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s1000/arvid-lindblad-racing-bulls.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s1100/arvid-lindblad-racing-bulls.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/6x7Zlw5Y/s1200/arvid-lindblad-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/6x7Zlw5Y/s700/arvid-lindblad-racing-bulls.jpg" alt="Arvid Lindblad, Racing Bulls ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162212" class="article-fullwidth-gallery_item" data-name="gal-11500-lando-norris-mclaren-72162212">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162212" data-detail-url="/f1/photos/lando-norris-mclaren-72162212/72162212/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s200/lando-norris-mclaren.webp 200w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s300/lando-norris-mclaren.webp 300w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s400/lando-norris-mclaren.webp 400w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s500/lando-norris-mclaren.webp 500w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s600/lando-norris-mclaren.webp 600w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s700/lando-norris-mclaren.webp 700w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s800/lando-norris-mclaren.webp 800w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s900/lando-norris-mclaren.webp 900w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s1000/lando-norris-mclaren.webp 1000w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s1100/lando-norris-mclaren.webp 1100w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s1200/lando-norris-mclaren.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s200/lando-norris-mclaren.jpg 200w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s300/lando-norris-mclaren.jpg 300w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s400/lando-norris-mclaren.jpg 400w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s500/lando-norris-mclaren.jpg 500w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s600/lando-norris-mclaren.jpg 600w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s700/lando-norris-mclaren.jpg 700w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s800/lando-norris-mclaren.jpg 800w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s900/lando-norris-mclaren.jpg 900w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s1000/lando-norris-mclaren.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s1100/lando-norris-mclaren.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/2jEDl1P0/s1200/lando-norris-mclaren.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/mgl/2jEDl1P0/s700/lando-norris-mclaren.jpg" alt="Lando Norris, McLaren">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162723" class="article-fullwidth-gallery_item" data-name="gal-11500-arvid-lindblad-racing-bulls--72162723">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162723" data-detail-url="/f1/photos/arvid-lindblad-racing-bulls--72162723/72162723/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s200/arvid-lindblad-racing-bulls.webp 200w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s300/arvid-lindblad-racing-bulls.webp 300w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s400/arvid-lindblad-racing-bulls.webp 400w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s500/arvid-lindblad-racing-bulls.webp 500w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s600/arvid-lindblad-racing-bulls.webp 600w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s700/arvid-lindblad-racing-bulls.webp 700w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s800/arvid-lindblad-racing-bulls.webp 800w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s900/arvid-lindblad-racing-bulls.webp 900w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s1000/arvid-lindblad-racing-bulls.webp 1000w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s1100/arvid-lindblad-racing-bulls.webp 1100w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s1200/arvid-lindblad-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s200/arvid-lindblad-racing-bulls.jpg 200w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s300/arvid-lindblad-racing-bulls.jpg 300w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s400/arvid-lindblad-racing-bulls.jpg 400w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s500/arvid-lindblad-racing-bulls.jpg 500w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s600/arvid-lindblad-racing-bulls.jpg 600w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s700/arvid-lindblad-racing-bulls.jpg 700w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s800/arvid-lindblad-racing-bulls.jpg 800w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s900/arvid-lindblad-racing-bulls.jpg 900w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s1000/arvid-lindblad-racing-bulls.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s1100/arvid-lindblad-racing-bulls.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/YXypvEN6/s1200/arvid-lindblad-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/YXypvEN6/s700/arvid-lindblad-racing-bulls.jpg" alt="Arvid Lindblad, Racing Bulls ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162005" class="article-fullwidth-gallery_item" data-name="gal-11500-george-russell-mercedes-w17--72162005">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162005" data-detail-url="/f1/photos/george-russell-mercedes-w17--72162005/72162005/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s200/george-russell-mercedes-w17.webp 200w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s300/george-russell-mercedes-w17.webp 300w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s400/george-russell-mercedes-w17.webp 400w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s500/george-russell-mercedes-w17.webp 500w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s600/george-russell-mercedes-w17.webp 600w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s700/george-russell-mercedes-w17.webp 700w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s800/george-russell-mercedes-w17.webp 800w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s900/george-russell-mercedes-w17.webp 900w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s1000/george-russell-mercedes-w17.webp 1000w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s1100/george-russell-mercedes-w17.webp 1100w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s1200/george-russell-mercedes-w17.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s200/george-russell-mercedes-w17.jpg 200w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s300/george-russell-mercedes-w17.jpg 300w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s400/george-russell-mercedes-w17.jpg 400w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s500/george-russell-mercedes-w17.jpg 500w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s600/george-russell-mercedes-w17.jpg 600w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s700/george-russell-mercedes-w17.jpg 700w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s800/george-russell-mercedes-w17.jpg 800w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s900/george-russell-mercedes-w17.jpg 900w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s1000/george-russell-mercedes-w17.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s1100/george-russell-mercedes-w17.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/6grBR57Y/s1200/george-russell-mercedes-w17.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/6grBR57Y/s700/george-russell-mercedes-w17.jpg" alt="George Russell, Mercedes W17 ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163029" class="article-fullwidth-gallery_item" data-name="gal-11500-esteban-ocon-haas-f1-team-72163029">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163029" data-detail-url="/f1/photos/esteban-ocon-haas-f1-team-72163029/72163029/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s200/esteban-ocon-haas-f1-team.webp 200w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s300/esteban-ocon-haas-f1-team.webp 300w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s400/esteban-ocon-haas-f1-team.webp 400w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s500/esteban-ocon-haas-f1-team.webp 500w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s600/esteban-ocon-haas-f1-team.webp 600w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s700/esteban-ocon-haas-f1-team.webp 700w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s800/esteban-ocon-haas-f1-team.webp 800w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s900/esteban-ocon-haas-f1-team.webp 900w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s1000/esteban-ocon-haas-f1-team.webp 1000w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s1100/esteban-ocon-haas-f1-team.webp 1100w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s1200/esteban-ocon-haas-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s200/esteban-ocon-haas-f1-team.jpg 200w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s300/esteban-ocon-haas-f1-team.jpg 300w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s400/esteban-ocon-haas-f1-team.jpg 400w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s500/esteban-ocon-haas-f1-team.jpg 500w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s600/esteban-ocon-haas-f1-team.jpg 600w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s700/esteban-ocon-haas-f1-team.jpg 700w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s800/esteban-ocon-haas-f1-team.jpg 800w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s900/esteban-ocon-haas-f1-team.jpg 900w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s1000/esteban-ocon-haas-f1-team.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s1100/esteban-ocon-haas-f1-team.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/6n7AlZg0/s1200/esteban-ocon-haas-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/6n7AlZg0/s700/esteban-ocon-haas-f1-team.jpg" alt="Esteban Ocon, Haas F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163375" class="article-fullwidth-gallery_item" data-name="gal-11500-andrea-kimi-antonelli-mercedes--72163375">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163375" data-detail-url="/f1/photos/andrea-kimi-antonelli-mercedes--72163375/72163375/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s200/andrea-kimi-antonelli-mercedes.webp 200w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s300/andrea-kimi-antonelli-mercedes.webp 300w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s400/andrea-kimi-antonelli-mercedes.webp 400w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s500/andrea-kimi-antonelli-mercedes.webp 500w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s600/andrea-kimi-antonelli-mercedes.webp 600w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s700/andrea-kimi-antonelli-mercedes.webp 700w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s800/andrea-kimi-antonelli-mercedes.webp 800w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s900/andrea-kimi-antonelli-mercedes.webp 900w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s1000/andrea-kimi-antonelli-mercedes.webp 1000w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s1100/andrea-kimi-antonelli-mercedes.webp 1100w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s1200/andrea-kimi-antonelli-mercedes.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s200/andrea-kimi-antonelli-mercedes.jpg 200w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s300/andrea-kimi-antonelli-mercedes.jpg 300w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s400/andrea-kimi-antonelli-mercedes.jpg 400w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s500/andrea-kimi-antonelli-mercedes.jpg 500w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s600/andrea-kimi-antonelli-mercedes.jpg 600w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s700/andrea-kimi-antonelli-mercedes.jpg 700w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s800/andrea-kimi-antonelli-mercedes.jpg 800w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s900/andrea-kimi-antonelli-mercedes.jpg 900w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s1000/andrea-kimi-antonelli-mercedes.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s1100/andrea-kimi-antonelli-mercedes.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/2jEDxDM0/s1200/andrea-kimi-antonelli-mercedes.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/mgl/2jEDxDM0/s700/andrea-kimi-antonelli-mercedes.jpg" alt="Andrea Kimi Antonelli, Mercedes ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72161994" class="article-fullwidth-gallery_item" data-name="gal-11500-oscar-piastri-mclaren-72161994">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72161994" data-detail-url="/f1/photos/oscar-piastri-mclaren-72161994/72161994/">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s200/oscar-piastri-mclaren.webp 200w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s300/oscar-piastri-mclaren.webp 300w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s400/oscar-piastri-mclaren.webp 400w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s500/oscar-piastri-mclaren.webp 500w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s600/oscar-piastri-mclaren.webp 600w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s700/oscar-piastri-mclaren.webp 700w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s800/oscar-piastri-mclaren.webp 800w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s900/oscar-piastri-mclaren.webp 900w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s1000/oscar-piastri-mclaren.webp 1000w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s1100/oscar-piastri-mclaren.webp 1100w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s1200/oscar-piastri-mclaren.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s200/oscar-piastri-mclaren.jpg 200w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s300/oscar-piastri-mclaren.jpg 300w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s400/oscar-piastri-mclaren.jpg 400w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s500/oscar-piastri-mclaren.jpg 500w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s600/oscar-piastri-mclaren.jpg 600w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s700/oscar-piastri-mclaren.jpg 700w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s800/oscar-piastri-mclaren.jpg 800w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s900/oscar-piastri-mclaren.jpg 900w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s1000/oscar-piastri-mclaren.jpg 1000w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s1100/oscar-piastri-mclaren.jpg 1100w, https://cdn-4.motorsport.com/images/mgl/24Qedr5Y/s1200/oscar-piastri-mclaren.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/mgl/24Qedr5Y/s700/oscar-piastri-mclaren.jpg" alt="Oscar Piastri, McLaren">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162199" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari-72162199">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162199" data-detail-url="/f1/photos/lewis-hamilton-ferrari-72162199/72162199/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/Y9lLXD82/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/mgl/Y9lLXD82/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162551" class="article-fullwidth-gallery_item" data-name="gal-11500-lando-norris-mclaren-mcl40--72162551">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162551" data-detail-url="/f1/photos/lando-norris-mclaren-mcl40--72162551/72162551/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s200/lando-norris-mclaren-mcl40.webp 200w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s300/lando-norris-mclaren-mcl40.webp 300w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s400/lando-norris-mclaren-mcl40.webp 400w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s500/lando-norris-mclaren-mcl40.webp 500w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s600/lando-norris-mclaren-mcl40.webp 600w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s700/lando-norris-mclaren-mcl40.webp 700w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s800/lando-norris-mclaren-mcl40.webp 800w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s900/lando-norris-mclaren-mcl40.webp 900w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s1000/lando-norris-mclaren-mcl40.webp 1000w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s1100/lando-norris-mclaren-mcl40.webp 1100w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s1200/lando-norris-mclaren-mcl40.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s200/lando-norris-mclaren-mcl40.jpg 200w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s300/lando-norris-mclaren-mcl40.jpg 300w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s400/lando-norris-mclaren-mcl40.jpg 400w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s500/lando-norris-mclaren-mcl40.jpg 500w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s600/lando-norris-mclaren-mcl40.jpg 600w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s700/lando-norris-mclaren-mcl40.jpg 700w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s800/lando-norris-mclaren-mcl40.jpg 800w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s900/lando-norris-mclaren-mcl40.jpg 900w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s1000/lando-norris-mclaren-mcl40.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s1100/lando-norris-mclaren-mcl40.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/6Al7yW9Y/s1200/lando-norris-mclaren-mcl40.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-7.motorsport.com/images/mgl/6Al7yW9Y/s700/lando-norris-mclaren-mcl40.jpg" alt="Lando Norris, McLaren MCL40 ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162280" class="article-fullwidth-gallery_item" data-name="gal-11500-pierre-gasly-alpine-72162280">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162280" data-detail-url="/f1/photos/pierre-gasly-alpine-72162280/72162280/">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s200/pierre-gasly-alpine.webp 200w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s300/pierre-gasly-alpine.webp 300w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s400/pierre-gasly-alpine.webp 400w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s500/pierre-gasly-alpine.webp 500w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s600/pierre-gasly-alpine.webp 600w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s700/pierre-gasly-alpine.webp 700w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s800/pierre-gasly-alpine.webp 800w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s900/pierre-gasly-alpine.webp 900w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s1000/pierre-gasly-alpine.webp 1000w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s1100/pierre-gasly-alpine.webp 1100w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s1200/pierre-gasly-alpine.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s200/pierre-gasly-alpine.jpg 200w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s300/pierre-gasly-alpine.jpg 300w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s400/pierre-gasly-alpine.jpg 400w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s500/pierre-gasly-alpine.jpg 500w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s600/pierre-gasly-alpine.jpg 600w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s700/pierre-gasly-alpine.jpg 700w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s800/pierre-gasly-alpine.jpg 800w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s900/pierre-gasly-alpine.jpg 900w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s1000/pierre-gasly-alpine.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s1100/pierre-gasly-alpine.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/YMX3K9g2/s1200/pierre-gasly-alpine.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/YMX3K9g2/s700/pierre-gasly-alpine.jpg" alt="Pierre Gasly, Alpine">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72162731" class="article-fullwidth-gallery_item" data-name="gal-11500-arvid-lindblad-racing-bulls--72162731">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72162731" data-detail-url="/f1/photos/arvid-lindblad-racing-bulls--72162731/72162731/">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/mgl/27NQLd30/s200/arvid-lindblad-racing-bulls.webp 200w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s300/arvid-lindblad-racing-bulls.webp 300w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s400/arvid-lindblad-racing-bulls.webp 400w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s500/arvid-lindblad-racing-bulls.webp 500w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s600/arvid-lindblad-racing-bulls.webp 600w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s700/arvid-lindblad-racing-bulls.webp 700w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s800/arvid-lindblad-racing-bulls.webp 800w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s900/arvid-lindblad-racing-bulls.webp 900w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s1000/arvid-lindblad-racing-bulls.webp 1000w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s1100/arvid-lindblad-racing-bulls.webp 1100w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s1200/arvid-lindblad-racing-bulls.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/mgl/27NQLd30/s200/arvid-lindblad-racing-bulls.jpg 200w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s300/arvid-lindblad-racing-bulls.jpg 300w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s400/arvid-lindblad-racing-bulls.jpg 400w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s500/arvid-lindblad-racing-bulls.jpg 500w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s600/arvid-lindblad-racing-bulls.jpg 600w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s700/arvid-lindblad-racing-bulls.jpg 700w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s800/arvid-lindblad-racing-bulls.jpg 800w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s900/arvid-lindblad-racing-bulls.jpg 900w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s1000/arvid-lindblad-racing-bulls.jpg 1000w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s1100/arvid-lindblad-racing-bulls.jpg 1100w, https://cdn-8.motorsport.com/images/mgl/27NQLd30/s1200/arvid-lindblad-racing-bulls.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-7.motorsport.com/images/mgl/27NQLd30/s700/arvid-lindblad-racing-bulls.jpg" alt="Arvid Lindblad, Racing Bulls ">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72165790" class="article-fullwidth-gallery_item" data-name="gal-11500-lewis-hamilton-ferrari-72165790">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72165790" data-detail-url="/f1/photos/lewis-hamilton-ferrari-72165790/72165790/">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s200/lewis-hamilton-ferrari.webp 200w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s300/lewis-hamilton-ferrari.webp 300w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s400/lewis-hamilton-ferrari.webp 400w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s500/lewis-hamilton-ferrari.webp 500w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s600/lewis-hamilton-ferrari.webp 600w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s700/lewis-hamilton-ferrari.webp 700w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s800/lewis-hamilton-ferrari.webp 800w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s900/lewis-hamilton-ferrari.webp 900w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s1000/lewis-hamilton-ferrari.webp 1000w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s1100/lewis-hamilton-ferrari.webp 1100w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s1200/lewis-hamilton-ferrari.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s200/lewis-hamilton-ferrari.jpg 200w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s300/lewis-hamilton-ferrari.jpg 300w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s400/lewis-hamilton-ferrari.jpg 400w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s500/lewis-hamilton-ferrari.jpg 500w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s600/lewis-hamilton-ferrari.jpg 600w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s700/lewis-hamilton-ferrari.jpg 700w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s800/lewis-hamilton-ferrari.jpg 800w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s900/lewis-hamilton-ferrari.jpg 900w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s1000/lewis-hamilton-ferrari.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s1100/lewis-hamilton-ferrari.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s1200/lewis-hamilton-ferrari.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/mgl/YpbPdxM0/s700/lewis-hamilton-ferrari.jpg" alt="Lewis Hamilton, Ferrari">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                                                <a href="https://www.motorsport.com/f1/galleries/barcelona-shakedown-in-photos/11500/#72163028" class="article-fullwidth-gallery_item" data-name="gal-11500-esteban-ocon-haas-f1-team-72163028">
+                            <div class="article-fullwidth-gallery_img-wrapper">
+                    
+<picture class="ms-item__picture " data-photo-id="72163028" data-detail-url="/f1/photos/esteban-ocon-haas-f1-team-72163028/72163028/">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s200/esteban-ocon-haas-f1-team.webp 200w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s300/esteban-ocon-haas-f1-team.webp 300w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s400/esteban-ocon-haas-f1-team.webp 400w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s500/esteban-ocon-haas-f1-team.webp 500w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s600/esteban-ocon-haas-f1-team.webp 600w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s700/esteban-ocon-haas-f1-team.webp 700w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s800/esteban-ocon-haas-f1-team.webp 800w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s900/esteban-ocon-haas-f1-team.webp 900w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s1000/esteban-ocon-haas-f1-team.webp 1000w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s1100/esteban-ocon-haas-f1-team.webp 1100w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s1200/esteban-ocon-haas-f1-team.webp 1200w" sizes="(min-width:650px) 700px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s200/esteban-ocon-haas-f1-team.jpg 200w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s300/esteban-ocon-haas-f1-team.jpg 300w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s400/esteban-ocon-haas-f1-team.jpg 400w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s500/esteban-ocon-haas-f1-team.jpg 500w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s600/esteban-ocon-haas-f1-team.jpg 600w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s700/esteban-ocon-haas-f1-team.jpg 700w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s800/esteban-ocon-haas-f1-team.jpg 800w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s900/esteban-ocon-haas-f1-team.jpg 900w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s1000/esteban-ocon-haas-f1-team.jpg 1000w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s1100/esteban-ocon-haas-f1-team.jpg 1100w, https://cdn-6.motorsport.com/images/mgl/2Qe8pAP2/s1200/esteban-ocon-haas-f1-team.jpg 1200w" sizes="(min-width:650px) 700px">
+            
+    <img loading="lazy" width="700" height="466" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/mgl/2Qe8pAP2/s700/esteban-ocon-haas-f1-team.jpg" alt="Esteban Ocon, Haas F1 Team">
+    </picture>                    
+                                        <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_next">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_next-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                    
+                    <div class="article-fullwidth-gallery_nav article-fullwidth-gallery_prev">
+                        <svg class="article-fullwidth-gallery_nav-icon article-fullwidth-gallery_prev-icon" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                    </div>
+                                    </div>
+
+                                    <h2 class="article-fullwidth-gallery_title">Barcelona shakedown, in photos</h2>
+                
+                                            </a>
+                    
+    </div>
+
+    <div class="article-fullwidth-gallery__info absolute top-2 left-2 right-2 flex gap-0.5">
+        
+                
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--dark msnt-badge--md -skew-x-3 ">
+    
+    <span class="msnt-badge__text skew-x-3 ">Formula 1</span>
+</div>        
+        
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--dark msnt-badge--md -skew-x-3 ">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-3-ef880ef0fa127f0efc48e7e728ebeca2.svg#camera-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 ">79</span>
+</div>    </div>
+</div>
+<section class="relatedContent" contenteditable="false" draggable="true" data-widget="related-content" data-widget-size="content" data-params="%7B%22type_id%22%3A0%2C%22title_id%22%3A%220_0%22%2C%22items%22%3A%5B%7B%22article_edition_id%22%3A%2210793307%22%2C%22title%22%3A%22Here's%20what%20happened%20on%20day%20two%20of%20F1%E2%80%99s%20secretive%20closed-door%202026%20shakedown%22%2C%22alias%22%3A%22what-happened-on-day-two-of-f1s-secret-2026-test%22%2C%22front_url%22%3A%22https%3A%2F%2Fwww.motorsport.com%2Ff1%2Fnews%2Fwhat-happened-on-day-two-of-f1s-secret-2026-test%2F10793307%2F%22%2C%22series%22%3A%22Formula%201%22%2C%22photo%22%3A%22%2F%2Fcdn.motorsport.com%2Fimages%2Famp%2F68VWLgB2%2Fs2%2Fmax-verstappen-red-bull-racing-2.jpg%22%7D%5D%7D"><span class="relatedContent__title">Read Also:</span>
+<ul>
+<li><a href="https://www.motorsport.com/f1/news/what-happened-on-day-two-of-f1s-secret-2026-test/10793307/"><img src="https://cdn.motorsport.com/images/amp/68VWLgB2/s2/max-verstappen-red-bull-racing-2.jpg" width="160" height="107" loading="lazy">
+<div class="relatedContent__info"><span class="relatedContent__series">Formula 1</span><span class="relatedContent__text">Here's what happened on day two of F1’s secretive closed-door 2026 shakedown</span></div>
+</a></li>
+</ul>
+</section>            
+    
+<msnt-survey-promo class="msnt-survey-promo bg-palette-bg-surface2 font-secondary py-3.5 px-4 hidden flex flex-col gap-2 text-palette-fg-soft border border-border-300  " style="border-left-width: 6px;">
+        <h2 class="text-4.5 leading-5.5 m-0 p-0 font-primary font-bold flex items-center gap-1.5">
+            <svg class="w-6 h-6" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-11-02a475dce372952dd75699d74da01e0c.svg#speakerphone"></use>
+            </svg>
+
+            <span>We want your opinion!</span>
+        </h2>
+
+        <div class="text-body-lg">
+            <p class="mt-auto">What would you like to see on Motorsport.com?</p>
+
+            <a href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www#" class="ms-link text-link font-bold">Take our 5 minute survey.</a>
+        </div>
+
+        <p class="mt-1 text-body">- The Motorsport.com Team</p>
+</msnt-survey-promo>
+
+
+
+            
+<msnt-comments-promo class="msnt-comments-promo hidden font-primary py-3 flex justify-center border-t border-b border-border-300  " target-selector=".ms-article__body .ms-article-content > p:last-of-type" target-position="beforebegin">
+    
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--md w-auto " commandfor="comments-drawer" command="--show">
+            <div class="relative">
+    
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 w-9 h-9 text-accent-color-default" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-15-5f63466e201d636fbb544ef5b9c6e073.svg#message-circle-2-filled"></use>
+</svg>
+    <span class="coral-count absolute inset-0 flex items-center justify-center text-body text-accent-color-on-accent font-bold underline group-hover/button:no-underline group-focus/button:no-underline" data-coral-notext="true" data-coral-id="article__10793339"></span>
+</div>        
+                    <span class="msnt-button__text inline text-4 leading-5 font-bold underline group-hover/button:no-underline group-focus/button:no-underline">Read and post comments</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+</msnt-comments-promo>
+    
+    
+            <div class="ms-apb ms-apb-inarticle ms-apb-inarticle-after-preview-without-sidebar " data-msnt-label="Advertisement"><div id="ads_6122441_MST_global_Rectangle_rectangle_3_1770093040" class="ms-ap" data-id="4" data-ad-unit-id="/6122441/MST/global/Rectangle/rectangle_3" style="width:300px;min-height:250px;" data-dfp-code="MST/global/Rectangle" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;rectangle_3&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;inarticle-after-preview-without-sidebar&quot;}" data-msnt-label="Advertisement"></div></div>    
+    <div id="ms-piano_article-prebanner" class="empty:contents"></div>
+
+    </div>
+
+<template id="froomle-article-read-also-tpl">
+    <section class="relatedContent relatedContent--dynamic" data-widget="related-content" data-no-recommendation-action="delete" aria-label="Read also">
+        <span class="relatedContent__title">Read also :</span>
+        <ul>
+                        <li>
+                <a class="ms-item--skeleton ms-item--skeleton--read-also" href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www#">
+                    <div class="ms-item__thumb">
+                        <img src="" width="160" height="107" loading="lazy">
+                    </div>
+                    <div class="relatedContent__info">
+                        <span class="relatedContent__series ms-item__series">&nbsp;</span>
+                        <span class="relatedContent__text ms-item__title">&nbsp;</span>
+                    </div>
+                </a>
+            </li>
+                        <li>
+                <a class="ms-item--skeleton ms-item--skeleton--read-also" href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www#">
+                    <div class="ms-item__thumb">
+                        <img src="" width="160" height="107" loading="lazy">
+                    </div>
+                    <div class="relatedContent__info">
+                        <span class="relatedContent__series ms-item__series">&nbsp;</span>
+                        <span class="relatedContent__text ms-item__title">&nbsp;</span>
+                    </div>
+                </a>
+            </li>
+                    </ul>
+    </section>
+</template>
+    
+    
+<div class="ms-recommendations-placeholder"></div>
+
+
+            
+<div class="ms-article-end mt-8 grid gap-6">
+    <div class="flex flex-col items-center gap-5">
+        <h4 class="text-3.5 leading-4 text-fg-soft font-bold">Share Or Save This Story</h4>
+
+        <div class="flex place-items-center justify-center">
+            <div class="inline-flex items-center gap-3">
+                
+<msnt-share class="msnt-share hidden flex flex-wrap gap-2
+         
+            " data-share-url="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" data-share-title="&quot;Very unfortunate&quot; Isack Hadjar crash leaves Red Bull undecided on third F1 test day" data-share-text="&quot;Very unfortunate&quot; Isack Hadjar crash leaves Red Bull undecided on third F1 test day" data-share-image="https://cdn-6.motorsport.com/images/amp/01QdMbx0/s2/isack-hadjar-red-bull-racing.jpg" data-entity-type="article" data-entity-id="10793339">
+
+            <div class="flex gap-2">
+            
+<a href="https://www.facebook.com/sharer/sharer.php?u=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" onclick="" target="_blank" data-name="facebook" data-width="600" data-height="600" data-official-name="Facebook" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__button" title="Facebook">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-facebook"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+
+<a href="https://twitter.com/intent/tweet?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;text=%22Very%20unfortunate%22%20Isack%20Hadjar%20crash%20leaves%20Red%20Bull%20undecided%20on%20third%20F1%20test%20day&amp;via=motorsport" onclick="" target="_blank" data-name="twitter" data-width="600" data-height="450" data-official-name="Twitter" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__button" title="Twitter">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+
+<a href="https://api.whatsapp.com/send?text=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" onclick="" target="_blank" data-name="whatsapp" data-width="1024" data-height="768" data-official-name="WhatsApp" data-collect="" data-entity-type="article" data-entity-id="10793339" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__button" title="WhatsApp">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-whatsapp"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+        </div>
+        
+    <div class="relative msnt-share__box">
+        
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__native msnt-share__android" title="Share">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-13-ac7e51d77a1c06140ec15a43b8cd8d90.svg#share"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__native msnt-share__ios" title="Share">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-13-ac7e51d77a1c06140ec15a43b8cd8d90.svg#share-2"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+<button onclick="" type="button" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default msnt-share__native msnt-share__windows" title="Share">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#share-3"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+        <div class="msnt-share__drawer group open-up absolute my-2  flex flex-col gap-1 py-2 px-1 border-neutral-100 border z-10 hidden msnt-share__drawer--soft">
+
+            <span class="msnt-share__arrow absolute w-3 h-3 border-neutral-100 msnt-share__arrow--soft"></span>
+
+            <div class="border-b border-neutral-100 rounded-none pb-1 flex flex-col">
+                
+<button data-href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" data-propagation="1" type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button msnt-share__button--copy">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-13-ac7e51d77a1c06140ec15a43b8cd8d90.svg#link"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Copy link</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+            </div>
+
+            
+<a href="https://www.facebook.com/sharer/sharer.php?u=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" target="_blank" data-name="facebook" data-width="600" data-height="600" data-official-name="Facebook" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-facebook"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Facebook</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://twitter.com/intent/tweet?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;text=%22Very%20unfortunate%22%20Isack%20Hadjar%20crash%20leaves%20Red%20Bull%20undecided%20on%20third%20F1%20test%20day&amp;via=motorsport" target="_blank" data-name="twitter" data-width="600" data-height="450" data-official-name="Twitter" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-x"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Twitter</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://api.whatsapp.com/send?text=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" target="_blank" data-name="whatsapp" data-width="1024" data-height="768" data-official-name="WhatsApp" data-collect="" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-whatsapp"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on WhatsApp</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://www.linkedin.com/cws/share?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;mini=true&amp;source=motorsport.com" target="_blank" data-name="linkedin" data-width="600" data-height="600" data-official-name="LinkedIn" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-linkedin"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Linkedin</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="https://www.pinterest.com/pin/create/button/?url=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/&amp;media=https://cdn-6.motorsport.com/images/amp/01QdMbx0/s2/isack-hadjar-red-bull-racing.jpg&amp;description=%22Very%20unfortunate%22%20Isack%20Hadjar%20crash%20leaves%20Red%20Bull%20undecided%20on%20third%20F1%20test%20day" target="_blank" data-name="pinterest" data-width="700" data-height="550" data-official-name="Pinterest" data-collect="1" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-pinterest"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Pinterest</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<a href="viber://forward?text=https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" target="_blank" data-name="viber" data-width="500" data-height="500" data-official-name="Viber" data-collect="" data-entity-type="article" data-entity-id="10793339" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--sm w-auto uppercase italic msnt-share__button">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-viber"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Share on Viber</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+        </div>
+    </div>
+</msnt-share>
+
+                
+<button onclick="" type="button" data-auth-required="1" data-url="https://pageinfo-k8s.motorsport.com/favorite/" data-favorites-url="/dashboard/favorite-news/" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default " title="Favorite" commandfor="document" command="--toggle-favorite">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden group-[.active]:hidden" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-14-eb78580f9053c252fa0632ddee8c4fa0.svg#bookmark"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 hidden group-[.wait]:hidden group-[.active]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-14-eb78580f9053c252fa0632ddee8c4fa0.svg#bookmark-filled"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+
+
+                
+<button onclick="" type="button" data-button="getAlerts" data-id="getAlerts" data-login="1" data-icon="/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#bell" data-ajax_url="/notification/check-status/" data-params="[{&quot;entity&quot;:&quot;driver&quot;,&quot;title&quot;:&quot;Subscribe to driver&quot;,&quot;items&quot;:[{&quot;title&quot;:&quot;Isack Hadjar&quot;,&quot;entity_id&quot;:827922}]},{&quot;entity&quot;:&quot;team&quot;,&quot;title&quot;:&quot;Subscribe to team&quot;,&quot;items&quot;:[{&quot;title&quot;:&quot;Red Bull Racing&quot;,&quot;entity_id&quot;:4}]},{&quot;entity&quot;:&quot;race-type&quot;,&quot;title&quot;:&quot;Subscribe to race-type&quot;,&quot;items&quot;:[{&quot;title&quot;:&quot;Formula 1&quot;,&quot;entity_id&quot;:54}]},{&quot;entity&quot;:&quot;location&quot;,&quot;title&quot;:&quot;Subscribe to location&quot;,&quot;items&quot;:[{&quot;title&quot;:&quot;Circuit de Barcelona Catalunya&quot;,&quot;entity_id&quot;:70}]},{&quot;entity&quot;:&quot;author&quot;,&quot;title&quot;:&quot;Subscribe to author&quot;,&quot;items&quot;:[{&quot;title&quot;:&quot;Filip Cleeren&quot;,&quot;entity_id&quot;:4294}]}]" data-request_data="[{&quot;entity_type&quot;:&quot;driver&quot;,&quot;entity_id&quot;:827922},{&quot;entity_type&quot;:&quot;team&quot;,&quot;entity_id&quot;:4},{&quot;entity_type&quot;:&quot;race-type&quot;,&quot;entity_id&quot;:54},{&quot;entity_type&quot;:&quot;location&quot;,&quot;entity_id&quot;:70},{&quot;entity_type&quot;:&quot;author&quot;,&quot;entity_id&quot;:4294}]" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--md msnt-icon-button--rounded-default " title="Manage Alerts">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#bell"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+            </div>
+        </div>
+
+    </div>
+
+        
+                                <div class="ms-sponsored-content-bootom-container" style="min-height:1px;" data-entity-id="10793339" data-entity-type="article"></div>
+            </div>
+            
+<div class="msnt-article-prev-next flex items-stretch gap-4 flex-wrap t:flex-nowrap">
+            <a href="https://www.motorsport.com/f1/news/what-happened-on-day-two-of-f1s-secret-2026-test/10793307/" title="Here's what happened on day two of F1’s secretive closed-door 2026 shakedown" class="px-2 py-3 w-full t:w-1/2 bg-surface-surface2 hover:bg-surface-surface3 focus:bg-surface-surface3 active:bg-surface-surface4 flex items-center justify-between gap-2 border border-border-100">
+            
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 rotate-180 rtl:rotate-0" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+</svg>
+            <div class="flex flex-col gap-elements-labeled-text-inner-gap font-secondary text-right">
+                <span class="text-fg-muted text-body-sm font-bold uppercase ">Previous article</span>
+                <span class="text-4 leading-5 text-fg-default">Here's what happened on day two of F1’s secretive closed-door 2026 shakedown</span>
+            </div>
+        </a>
+    
+            <a href="https://www.motorsport.com/f1/news/live-f1-barcelona-pre-season-testing-day-3/10793388/" title="LIVE: F1 Barcelona pre-season testing - Day 3" class="px-2 py-3 w-full t:w-1/2 bg-surface-surface2 hover:bg-surface-surface3 focus:bg-surface-surface3 active:bg-surface-surface4 flex items-center justify-between gap-2 border border-border-100">
+            <div class="flex flex-col gap-elements-labeled-text-inner-gap font-secondary">
+                <span class="text-fg-muted text-body-sm font-bold uppercase">Next article</span>
+                <span class="text-4 leading-5 text-fg-default">LIVE: F1 Barcelona pre-season testing - Day 3</span>
+            </div>
+
+            
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 rotate-0 rtl:rotate-180" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+</svg>        </a>
+    </div>        </div>
+    </div>
+</div>
+                                    <div class="ms-comments-wrapper">
+                        
+<section class="ms-top-comments" data-media-type="none" data-auser="0" data-prime="0" data-url="/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/" data-proxy-url="https://coral-proxy.motorsport.com" data-static-url="/all/news/_/10793339/" data-entity-id="10793339" data-entity-type="article" id="comments-block-anchor" data-messages-count="5" data-render-mode="iframe" aria-labelledby="top-comments-title">
+    <h3 id="top-comments-title" class="text-6 leading-7 font-bold uppercase mb-dynamic-no-small">Top Comments</h3>
+
+    <div class="ms-top-comments__body">
+        <button class="ms-top-comments__empty hidden text-center p-4 bg-bg-surface2 border-button-ghost-bg text-fg-muted" commandfor="comments-drawer" command="--show">
+            There are no comments at the moment. <span>Would you like to write one?</span>        </button>
+    </div>
+
+            <template id="top-comments-banner-tpl">
+            <div class="ms-apb ms-apb-rectangle "><div id="ads_6122441_MST_global_Rectangle_rectangle_4_1770093040" class="ms-ap" data-id="2" data-ad-unit-id="/6122441/MST/global/Rectangle/rectangle_4" style="width:300px;min-height:250px;" data-dfp-code="MST/global/Rectangle" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_position&quot;:&quot;comments&quot;,&quot;ms_banner_name&quot;:&quot;rectangle_4&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;]}" data-msnt-label="Advertisement"></div></div>        </template>
+    
+    <div class="ms-top-comments__footer flex justify-center mt-dynamic-no-small">
+        
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--prime msnt-button--md w-auto uppercase italic ms-top-comments__show-all-btn" commandfor="comments-drawer" command="--show">
+        
+                    <span class="msnt-button__text inline ">View More &amp; Comment</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+    </div>
+</section>
+                                            </div>
+                            </div>
+        </div>
+                    <aside class="ms-content__sidebar ms-layout-spaced--sidebar ms-content__sidebar--right-only">
+                
+
+<msnt-banner-repeater class="msnt-banner-repeater flex flex-col flex-1  ">
+        <div class="msnt-banner-repeater__block">
+        <div class="ms-apb ms-apb-dmpu ms-apb-dmpu--first "><div id="ads_6122441_MST_global_DMPU_dmpu_first_1770093040" class="ms-ap" data-id="3" data-ad-unit-id="/6122441/MST/global/DMPU/dmpu_first" style="width:300px;min-height:250px;" data-dfp-code="MST/global/DMPU" data-sizes="300x250,300x600" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;dmpu_first&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;sidebar&quot;}" data-msnt-label="Advertisement"></div></div>    </div>
+
+    <template id="msnt-banner-repeater-tpl">
+        <div class="msnt-banner-repeater__block">
+            <div class="ms-apb ms-apb-dmpu  "><div id="ads_6122441_MST_global_DMPU_dmpu_1_1770093040" class="ms-ap" data-id="3" data-ad-unit-id="/6122441/MST/global/DMPU/dmpu_1" style="width:300px;min-height:250px;" data-dfp-code="MST/global/DMPU" data-sizes="300x250,300x600" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;dmpu_1&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;sidebar&quot;}" data-msnt-label="Advertisement"></div></div>        </div>
+    </template>
+</msnt-banner-repeater>            </aside>
+            </div>
+
+    </article>
+
+<div class="ms-inarticle-widgets ms-layout-spaced">
+            
+<div class="ms-items-widget ms-items-widget--more-from-author ms-content ms-centered" data-widget="more-from">
+    <div class="ms-grid ms-grid-d-4 ms-grid-t-4 ms-grid-hor-m">
+        
+<div class="ms-item--more-from mt-[60px] t:mt-0 ms-item--more-from-author">
+    <div class="relative w-full h-full pt-[60px] t:pt-0 bg-surface-surface2 border border-divider-100">
+        <div class="flex flex-col h-full items-center justify-center p-4 gap-4">
+                            <a class="ms-item__link ms-item__link--text absolute top-0 left-1/2 translate- ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 t:static ltr:t:translate-x-0 rtl:t:translate-x-0 t:translate-y-0" href="https://www.motorsport.com/info/about-us/filip_cleeren/4294/">
+                    
+<picture class="ms-item__picture ms-item-more-from__picture">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s200/img546558274-2-2.webp 200w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s300/img546558274-2-2.webp 300w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s400/img546558274-2-2.webp 400w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s500/img546558274-2-2.webp 500w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s600/img546558274-2-2.webp 600w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s700/img546558274-2-2.webp 700w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s800/img546558274-2-2.webp 800w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s900/img546558274-2-2.webp 900w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s1000/img546558274-2-2.webp 1000w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s1100/img546558274-2-2.webp 1100w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s1200/img546558274-2-2.webp 1200w" sizes="100px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s200/img546558274-2-2.jpg 200w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s300/img546558274-2-2.jpg 300w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s400/img546558274-2-2.jpg 400w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s500/img546558274-2-2.jpg 500w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s600/img546558274-2-2.jpg 600w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s700/img546558274-2-2.jpg 700w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s800/img546558274-2-2.jpg 800w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s900/img546558274-2-2.jpg 900w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s1000/img546558274-2-2.jpg 1000w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s1100/img546558274-2-2.jpg 1100w, https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s1200/img546558274-2-2.jpg 1200w" sizes="100px">
+            
+    <img loading="lazy" width="100" height="100" class="ms-item__img ms-item__img--1_1 " src="https://cdn-7.motorsport.com/images/usa/80Z1mR6e/s100/img546558274-2-2.jpg" alt="">
+    </picture>                </a>
+            
+            <div class="flex flex-col items-center text-fg-default gap-1 text-center">
+                <span class="ms-item-more-from__label font-secondary text-3.5 leading-3.5">More from</span>
+
+                <a class="ms-item__link ms-item__link--text text-6 leading-7 font-bold font-secondary" href="https://www.motorsport.com/info/about-us/filip_cleeren/4294/">
+                    <address class="ms-item-more-from__author not-italic">
+                        <span ref="author">Filip Cleeren</span>
+                    </address>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+                    
+<a href="https://www.motorsport.com/f1/news/f1-management-set-for-new-93500-sq-ft-london-headquarters/10794801/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794801" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s200/40-broadway-st-james-park-web2.webp 200w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s300/40-broadway-st-james-park-web2.webp 300w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s400/40-broadway-st-james-park-web2.webp 400w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s500/40-broadway-st-james-park-web2.webp 500w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s600/40-broadway-st-james-park-web2.webp 600w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s700/40-broadway-st-james-park-web2.webp 700w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s800/40-broadway-st-james-park-web2.webp 800w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s900/40-broadway-st-james-park-web2.webp 900w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s1000/40-broadway-st-james-park-web2.webp 1000w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s1100/40-broadway-st-james-park-web2.webp 1100w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s1200/40-broadway-st-james-park-web2.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s200/40-broadway-st-james-park-web2.jpg 200w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s300/40-broadway-st-james-park-web2.jpg 300w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s400/40-broadway-st-james-park-web2.jpg 400w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s500/40-broadway-st-james-park-web2.jpg 500w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s600/40-broadway-st-james-park-web2.jpg 600w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s700/40-broadway-st-james-park-web2.jpg 700w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s800/40-broadway-st-james-park-web2.jpg 800w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s900/40-broadway-st-james-park-web2.jpg 900w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s1000/40-broadway-st-james-park-web2.jpg 1000w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s1100/40-broadway-st-james-park-web2.jpg 1100w, https://cdn-7.motorsport.com/images/amp/2jEDxNN0/s1200/40-broadway-st-james-park-web2.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/amp/2jEDxNN0/s300/40-broadway-st-james-park-web2.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            F1 management set for new 93,500 sq ft London headquarters        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T19:12:24Z">
+                9 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">F1 management set for new 93,500 sq ft London headquarters</div>
+
+        
+            </div>
+</a>                    
+<a href="https://www.motorsport.com/f1/news/toto-wolff-mercedes-f1-rivals-engine-complaints-get-your-shit-together/10794677/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794677" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-4.motorsport.com/images/amp/25d3y3l0/s200/andrea-kimi-antonelli-mercedes.webp 200w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s300/andrea-kimi-antonelli-mercedes.webp 300w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s400/andrea-kimi-antonelli-mercedes.webp 400w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s500/andrea-kimi-antonelli-mercedes.webp 500w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s600/andrea-kimi-antonelli-mercedes.webp 600w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s700/andrea-kimi-antonelli-mercedes.webp 700w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s800/andrea-kimi-antonelli-mercedes.webp 800w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s900/andrea-kimi-antonelli-mercedes.webp 900w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s1000/andrea-kimi-antonelli-mercedes.webp 1000w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s1100/andrea-kimi-antonelli-mercedes.webp 1100w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s1200/andrea-kimi-antonelli-mercedes.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-4.motorsport.com/images/amp/25d3y3l0/s200/andrea-kimi-antonelli-mercedes.jpg 200w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s300/andrea-kimi-antonelli-mercedes.jpg 300w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s400/andrea-kimi-antonelli-mercedes.jpg 400w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s500/andrea-kimi-antonelli-mercedes.jpg 500w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s600/andrea-kimi-antonelli-mercedes.jpg 600w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s700/andrea-kimi-antonelli-mercedes.jpg 700w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s800/andrea-kimi-antonelli-mercedes.jpg 800w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s900/andrea-kimi-antonelli-mercedes.jpg 900w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s1000/andrea-kimi-antonelli-mercedes.jpg 1000w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s1100/andrea-kimi-antonelli-mercedes.jpg 1100w, https://cdn-4.motorsport.com/images/amp/25d3y3l0/s1200/andrea-kimi-antonelli-mercedes.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/amp/25d3y3l0/s300/andrea-kimi-antonelli-mercedes.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            "Get your sh*t together" - Toto Wolff’s message to F1 rivals over Mercedes engine complaints        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Mercedes launch</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T12:43:39Z">
+                15 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">"Get your sh*t together" - Toto Wolff’s message to F1 rivals over Mercedes engine complaints</div>
+
+        
+            </div>
+</a>                    
+<a href="https://www.motorsport.com/f1/news/christian-horner-has-unfinished-business-in-f1-with-project-that-can-win/10794610/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794610" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s200/red-bull-racing-team-principal.webp 200w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s300/red-bull-racing-team-principal.webp 300w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s400/red-bull-racing-team-principal.webp 400w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s500/red-bull-racing-team-principal.webp 500w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s600/red-bull-racing-team-principal.webp 600w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s700/red-bull-racing-team-principal.webp 700w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s800/red-bull-racing-team-principal.webp 800w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s900/red-bull-racing-team-principal.webp 900w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s1000/red-bull-racing-team-principal.webp 1000w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s1100/red-bull-racing-team-principal.webp 1100w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s1200/red-bull-racing-team-principal.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s200/red-bull-racing-team-principal.jpg 200w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s300/red-bull-racing-team-principal.jpg 300w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s400/red-bull-racing-team-principal.jpg 400w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s500/red-bull-racing-team-principal.jpg 500w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s600/red-bull-racing-team-principal.jpg 600w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s700/red-bull-racing-team-principal.jpg 700w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s800/red-bull-racing-team-principal.jpg 800w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s900/red-bull-racing-team-principal.jpg 900w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s1000/red-bull-racing-team-principal.jpg 1000w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s1100/red-bull-racing-team-principal.jpg 1100w, https://cdn-7.motorsport.com/images/amp/YW7ozQ1Y/s1200/red-bull-racing-team-principal.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-5.motorsport.com/images/amp/YW7ozQ1Y/s300/red-bull-racing-team-principal.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Christian Horner has "unfinished business in F1" as he targets project that can "win"        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Barcelona-Catalunya Pre-Season Testing</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T10:37:21Z">
+                17 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Christian Horner has "unfinished business in F1" as he targets project that can "win"</div>
+
+        
+            </div>
+</a>            </div>
+</div>
+
+<div class="ms-items-widget ms-items-widget--more-from-driver ms-content ms-centered" data-widget="more-from">
+    <div class="ms-grid ms-grid-d-4 ms-grid-t-4 ms-grid-hor-m">
+        
+<div class="ms-item--more-from mt-[60px] t:mt-0 ">
+    <div class="relative w-full h-full pt-[60px] t:pt-0 bg-surface-surface2 border border-divider-100">
+        <div class="flex flex-col h-full items-center justify-center p-4 gap-4">
+                            <a class="ms-item__link ms-item__link--text absolute top-0 left-1/2 translate- ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 t:static ltr:t:translate-x-0 rtl:t:translate-x-0 t:translate-y-0" href="https://www.motorsport.com/driver/isack-hadjar/827922/">
+                    
+<picture class="ms-item__picture ms-item-more-from__picture">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="100px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="100px">
+            
+    <img loading="lazy" width="100" height="100" class="ms-item__img ms-item__img--1_1 " src="https://cdn-5.motorsport.com/images/mgl/0o5PLJxY/s100/isack-hadjar-red-bull-racing.jpg" alt="">
+    </picture>                </a>
+            
+            <div class="flex flex-col items-center text-fg-default gap-1 text-center">
+                <span class="ms-item-more-from__label font-secondary text-3.5 leading-3.5">More from</span>
+
+                <a class="ms-item__link ms-item__link--text text-6 leading-7 font-bold font-secondary" href="https://www.motorsport.com/driver/isack-hadjar/827922/">
+                    <address class="ms-item-more-from__author not-italic">
+                        <span ref="author">Isack Hadjar</span>
+                    </address>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+                    
+<a href="https://www.motorsport.com/f1/news/isack-hadjar-explains-red-bull-crash-at-barcelona-f1-shakedown/10794228/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794228" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-8.motorsport.com/images/amp/6Vy74qnY/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/amp/6Vy74qnY/s300/isack-hadjar-red-bull-racing.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Isack Hadjar explains Red Bull crash at Barcelona F1 shakedown        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Barcelona-Catalunya Pre-Season Testing</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-01T14:33:32Z">
+                1 d            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Isack Hadjar explains Red Bull crash at Barcelona F1 shakedown</div>
+
+        
+            </div>
+</a>                    
+<a href="https://www.motorsport.com/f1/news/can-isack-hadjar-succeed-alongside-max-verstappen-at-red-bull-james-hinchcliffe-weighs-in/10793583/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10793583" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-6.motorsport.com/images/amp/0qgPL4wY/s300/isack-hadjar-red-bull-racing.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Can Isack Hadjar succeed alongside Max Verstappen at Red Bull? James Hinchcliffe weighs in        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Barcelona-Catalunya Pre-Season Testing</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-01-29T09:50:34Z">
+                4 d            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Can Isack Hadjar succeed alongside Max Verstappen at Red Bull? James Hinchcliffe weighs in</div>
+
+        
+            </div>
+</a>                    
+<a href="https://www.motorsport.com/f1/news/isack-hadjar-crashes-red-bulls-new-f1-car/10793292/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10793292" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s200/isack-hadjar-red-bull-racing.webp 200w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s300/isack-hadjar-red-bull-racing.webp 300w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s400/isack-hadjar-red-bull-racing.webp 400w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s500/isack-hadjar-red-bull-racing.webp 500w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s600/isack-hadjar-red-bull-racing.webp 600w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s700/isack-hadjar-red-bull-racing.webp 700w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s800/isack-hadjar-red-bull-racing.webp 800w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s900/isack-hadjar-red-bull-racing.webp 900w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s1000/isack-hadjar-red-bull-racing.webp 1000w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s1100/isack-hadjar-red-bull-racing.webp 1100w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s1200/isack-hadjar-red-bull-racing.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s200/isack-hadjar-red-bull-racing.jpg 200w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s300/isack-hadjar-red-bull-racing.jpg 300w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s400/isack-hadjar-red-bull-racing.jpg 400w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s500/isack-hadjar-red-bull-racing.jpg 500w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s600/isack-hadjar-red-bull-racing.jpg 600w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s700/isack-hadjar-red-bull-racing.jpg 700w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s800/isack-hadjar-red-bull-racing.jpg 800w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s900/isack-hadjar-red-bull-racing.jpg 900w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s1000/isack-hadjar-red-bull-racing.jpg 1000w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s1100/isack-hadjar-red-bull-racing.jpg 1100w, https://cdn-5.motorsport.com/images/amp/6Vy74qnY/s1200/isack-hadjar-red-bull-racing.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-1.motorsport.com/images/amp/6Vy74qnY/s300/isack-hadjar-red-bull-racing.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Isack Hadjar crashes Red Bull’s new F1 car        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Barcelona-Catalunya Pre-Season Testing</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-01-27T17:23:44Z">
+                6 d            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Isack Hadjar crashes Red Bull’s new F1 car</div>
+
+        
+            </div>
+</a>            </div>
+</div>
+
+<div class="ms-items-widget ms-items-widget--more-from-team ms-content ms-centered" data-widget="more-from">
+    <div class="ms-grid ms-grid-d-4 ms-grid-t-4 ms-grid-hor-m">
+        
+<div class="ms-item--more-from mt-[60px] t:mt-0 ">
+    <div class="relative w-full h-full pt-[60px] t:pt-0 bg-surface-surface2 border border-divider-100">
+        <div class="flex flex-col h-full items-center justify-center p-4 gap-4">
+                            <a class="ms-item__link ms-item__link--text absolute top-0 left-1/2 translate- ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 t:static ltr:t:translate-x-0 rtl:t:translate-x-0 t:translate-y-0" href="https://www.motorsport.com/team/red-bull-racing/4/">
+                    
+<picture class="ms-item__picture ms-item-more-from__picture">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s200/red-bull-racing-logo-1.webp 200w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s300/red-bull-racing-logo-1.webp 300w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s400/red-bull-racing-logo-1.webp 400w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s500/red-bull-racing-logo-1.webp 500w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s600/red-bull-racing-logo-1.webp 600w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s700/red-bull-racing-logo-1.webp 700w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s800/red-bull-racing-logo-1.webp 800w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s900/red-bull-racing-logo-1.webp 900w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s1000/red-bull-racing-logo-1.webp 1000w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s1100/red-bull-racing-logo-1.webp 1100w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s1200/red-bull-racing-logo-1.webp 1200w" sizes="100px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s200/red-bull-racing-logo-1.jpg 200w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s300/red-bull-racing-logo-1.jpg 300w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s400/red-bull-racing-logo-1.jpg 400w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s500/red-bull-racing-logo-1.jpg 500w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s600/red-bull-racing-logo-1.jpg 600w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s700/red-bull-racing-logo-1.jpg 700w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s800/red-bull-racing-logo-1.jpg 800w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s900/red-bull-racing-logo-1.jpg 900w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s1000/red-bull-racing-logo-1.jpg 1000w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s1100/red-bull-racing-logo-1.jpg 1100w, https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s1200/red-bull-racing-logo-1.jpg 1200w" sizes="100px">
+            
+    <img loading="lazy" width="100" height="100" class="ms-item__img ms-item__img--1_1 " src="https://cdn-9.motorsport.com/images/mgl/Y99JQRbY/s100/red-bull-racing-logo-1.jpg" alt="">
+    </picture>                </a>
+            
+            <div class="flex flex-col items-center text-fg-default gap-1 text-center">
+                <span class="ms-item-more-from__label font-secondary text-3.5 leading-3.5">More from</span>
+
+                <a class="ms-item__link ms-item__link--text text-6 leading-7 font-bold font-secondary" href="https://www.motorsport.com/team/red-bull-racing/4/">
+                    <address class="ms-item-more-from__author not-italic">
+                        <span ref="author">Red Bull Racing</span>
+                    </address>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+                    
+<a href="https://www.motorsport.com/f1/news/max-verstappen-fans-snap-up-2026-hungary-gp-grandstand-tickets-before-season-starts/10794413/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794413" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s200/max-verstappen-red-bull-racing.webp 200w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s300/max-verstappen-red-bull-racing.webp 300w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s400/max-verstappen-red-bull-racing.webp 400w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s500/max-verstappen-red-bull-racing.webp 500w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s600/max-verstappen-red-bull-racing.webp 600w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s700/max-verstappen-red-bull-racing.webp 700w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s800/max-verstappen-red-bull-racing.webp 800w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s900/max-verstappen-red-bull-racing.webp 900w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s1000/max-verstappen-red-bull-racing.webp 1000w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s1100/max-verstappen-red-bull-racing.webp 1100w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s1200/max-verstappen-red-bull-racing.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s200/max-verstappen-red-bull-racing.jpg 200w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s300/max-verstappen-red-bull-racing.jpg 300w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s400/max-verstappen-red-bull-racing.jpg 400w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s500/max-verstappen-red-bull-racing.jpg 500w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s600/max-verstappen-red-bull-racing.jpg 600w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s700/max-verstappen-red-bull-racing.jpg 700w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s800/max-verstappen-red-bull-racing.jpg 800w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s900/max-verstappen-red-bull-racing.jpg 900w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s1000/max-verstappen-red-bull-racing.jpg 1000w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s1100/max-verstappen-red-bull-racing.jpg 1100w, https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s1200/max-verstappen-red-bull-racing.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-7.motorsport.com/images/amp/2GdwpbzY/s300/max-verstappen-red-bull-racing.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Max Verstappen fans snap up 2026 Hungary GP grandstand tickets before season starts        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Barcelona-Catalunya Pre-Season Testing</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-01-31T22:26:17Z">
+                2 d            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Max Verstappen fans snap up 2026 Hungary GP grandstand tickets before season starts</div>
+
+        
+            </div>
+</a>                    
+<a href="https://www.motorsport.com/culture/news/red-bull-supercars-drivers-take-on-five-lap-f1-challenge-in-title-winning-rb7/10794405/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794405" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-7.motorsport.com/images/amp/0qXqlng6/s200/sebastian-vettel-red-bull-raci.webp 200w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s300/sebastian-vettel-red-bull-raci.webp 300w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s400/sebastian-vettel-red-bull-raci.webp 400w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s500/sebastian-vettel-red-bull-raci.webp 500w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s600/sebastian-vettel-red-bull-raci.webp 600w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s700/sebastian-vettel-red-bull-raci.webp 700w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s800/sebastian-vettel-red-bull-raci.webp 800w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s900/sebastian-vettel-red-bull-raci.webp 900w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s1000/sebastian-vettel-red-bull-raci.webp 1000w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s1100/sebastian-vettel-red-bull-raci.webp 1100w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s1200/sebastian-vettel-red-bull-raci.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-7.motorsport.com/images/amp/0qXqlng6/s200/sebastian-vettel-red-bull-raci.jpg 200w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s300/sebastian-vettel-red-bull-raci.jpg 300w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s400/sebastian-vettel-red-bull-raci.jpg 400w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s500/sebastian-vettel-red-bull-raci.jpg 500w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s600/sebastian-vettel-red-bull-raci.jpg 600w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s700/sebastian-vettel-red-bull-raci.jpg 700w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s800/sebastian-vettel-red-bull-raci.jpg 800w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s900/sebastian-vettel-red-bull-raci.jpg 900w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s1000/sebastian-vettel-red-bull-raci.jpg 1000w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s1100/sebastian-vettel-red-bull-raci.jpg 1100w, https://cdn-7.motorsport.com/images/amp/0qXqlng6/s1200/sebastian-vettel-red-bull-raci.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/amp/0qXqlng6/s300/sebastian-vettel-red-bull-raci.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Red Bull Supercars drivers take on five-lap F1 challenge in title-winning RB7        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Culture</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Culture</span>
+            
+                            <div class="ms-item__info-conditional">
+                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-01-31T19:51:53Z">
+                2 d            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Red Bull Supercars drivers take on five-lap F1 challenge in title-winning RB7</div>
+
+        
+            </div>
+</a>                    
+<a href="https://www.motorsport.com/f1/news/newey-extreme-aston-red-bull-mercedes-early-tech-trends-f1-2026/10794222/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-hor-m  " data-entity-id="10794222" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s200/aston-martin-amr26.webp 200w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s300/aston-martin-amr26.webp 300w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s400/aston-martin-amr26.webp 400w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s500/aston-martin-amr26.webp 500w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s600/aston-martin-amr26.webp 600w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s700/aston-martin-amr26.webp 700w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s800/aston-martin-amr26.webp 800w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s900/aston-martin-amr26.webp 900w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s1000/aston-martin-amr26.webp 1000w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s1100/aston-martin-amr26.webp 1100w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s1200/aston-martin-amr26.webp 1200w" sizes="(min-width: 950px) 300px, 200px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s200/aston-martin-amr26.jpg 200w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s300/aston-martin-amr26.jpg 300w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s400/aston-martin-amr26.jpg 400w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s500/aston-martin-amr26.jpg 500w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s600/aston-martin-amr26.jpg 600w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s700/aston-martin-amr26.jpg 700w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s800/aston-martin-amr26.jpg 800w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s900/aston-martin-amr26.jpg 900w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s1000/aston-martin-amr26.jpg 1000w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s1100/aston-martin-amr26.jpg 1100w, https://cdn-5.motorsport.com/images/amp/Y9lL5NZ2/s1200/aston-martin-amr26.jpg 1200w" sizes="(min-width: 950px) 300px, 200px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-3.motorsport.com/images/amp/Y9lL5NZ2/s300/aston-martin-amr26.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Adrian Newey’s extreme Aston, Red Bull, and Mercedes: Early tech trends of F1 2026        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                    </div>
+
+    
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                            </div>
+
+                            
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Barcelona-Catalunya Pre-Season Testing</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-01-31T15:59:07Z">
+                2 d            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Adrian Newey’s extreme Aston, Red Bull, and Mercedes: Early tech trends of F1 2026</div>
+
+        
+            </div>
+</a>            </div>
+</div>
+
+<section class="
+        ms-items-widget 
+        ms-items-widget--latest-news        ms-content ms-content--start ms-centered    " aria-label="Latest news" data-widget="latest-news">
+    
+            
+<div class="ms-items-widget__header flex items-center gap-3 ">
+    <div class="ms-items-widget__header-start">
+                            
+<h3 class="msnt-heading text-7 leading-8 font-bold tracking-tight text-titles-fg font-primary capitalize ">
+            <div class="inline-flex items-center gap-2 relative pb-3">
+
+            <span class="msnt-heading__title">Latest news</span>
+        
+                            <div class="w-5/6 h-1.5 absolute left-0.5 bottom-0 z-10 -skew-x-12 bg-titles-accent"></div>
+            
+                    
+        </div>
+    
+</h3>
+            </div>
+
+    </div>    
+    
+<div class="ms-items-widget__body ms-grid ms-grid-d-4 ms-grid-t-4 ms-grid-m-2-1 ">
+            
+    
+            
+    
+<a href="https://www.motorsport.com/nascar-cup/news/kyle-busch-says-we-got-away-from-the-chase-for-a-reason/10794832/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-vert-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794832" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s200/kyle-busch-richard-childress-r.webp 200w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s300/kyle-busch-richard-childress-r.webp 300w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s400/kyle-busch-richard-childress-r.webp 400w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s500/kyle-busch-richard-childress-r.webp 500w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s600/kyle-busch-richard-childress-r.webp 600w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s700/kyle-busch-richard-childress-r.webp 700w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s800/kyle-busch-richard-childress-r.webp 800w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s900/kyle-busch-richard-childress-r.webp 900w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s1000/kyle-busch-richard-childress-r.webp 1000w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s1100/kyle-busch-richard-childress-r.webp 1100w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s1200/kyle-busch-richard-childress-r.webp 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+                    <source type="image/jpeg" srcset="https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s200/kyle-busch-richard-childress-r.jpg 200w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s300/kyle-busch-richard-childress-r.jpg 300w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s400/kyle-busch-richard-childress-r.jpg 400w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s500/kyle-busch-richard-childress-r.jpg 500w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s600/kyle-busch-richard-childress-r.jpg 600w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s700/kyle-busch-richard-childress-r.jpg 700w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s800/kyle-busch-richard-childress-r.jpg 800w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s900/kyle-busch-richard-childress-r.jpg 900w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s1000/kyle-busch-richard-childress-r.jpg 1000w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s1100/kyle-busch-richard-childress-r.jpg 1100w, https://cdn-6.motorsport.com/images/amp/6DGqqrxY/s1200/kyle-busch-richard-childress-r.jpg 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/amp/6DGqqrxY/s300/kyle-busch-richard-childress-r.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Kyle Busch says 'we got away from the Chase for a reason'        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">NASCAR Cup</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                                                <span class="ms-item__series ms-item__series--ultra-short">NAS</span>
+                
+                <span class="ms-item__series ms-item__series--title">NASCAR Cup</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Cook Out Clash at Bowman Gray</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-03T02:26:44Z">
+                2 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Kyle Busch says 'we got away from the Chase for a reason'</div>
+
+        
+            </div>
+</a>    
+            
+    
+<a href="https://www.motorsport.com/formula-e/news/abbi-pulling-explains-why-formula-e-is-cut-throat-after-miami-eprix-rookie-run/10794818/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-vert-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794818" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s200/abbi-pulling-and-nissan-formul.webp 200w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s300/abbi-pulling-and-nissan-formul.webp 300w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s400/abbi-pulling-and-nissan-formul.webp 400w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s500/abbi-pulling-and-nissan-formul.webp 500w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s600/abbi-pulling-and-nissan-formul.webp 600w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s700/abbi-pulling-and-nissan-formul.webp 700w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s800/abbi-pulling-and-nissan-formul.webp 800w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s900/abbi-pulling-and-nissan-formul.webp 900w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s1000/abbi-pulling-and-nissan-formul.webp 1000w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s1100/abbi-pulling-and-nissan-formul.webp 1100w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s1200/abbi-pulling-and-nissan-formul.webp 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+                    <source type="image/jpeg" srcset="https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s200/abbi-pulling-and-nissan-formul.jpg 200w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s300/abbi-pulling-and-nissan-formul.jpg 300w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s400/abbi-pulling-and-nissan-formul.jpg 400w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s500/abbi-pulling-and-nissan-formul.jpg 500w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s600/abbi-pulling-and-nissan-formul.jpg 600w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s700/abbi-pulling-and-nissan-formul.jpg 700w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s800/abbi-pulling-and-nissan-formul.jpg 800w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s900/abbi-pulling-and-nissan-formul.jpg 900w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s1000/abbi-pulling-and-nissan-formul.jpg 1000w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s1100/abbi-pulling-and-nissan-formul.jpg 1100w, https://cdn-5.motorsport.com/images/amp/2GdwVd1Y/s1200/abbi-pulling-and-nissan-formul.jpg 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-9.motorsport.com/images/amp/2GdwVd1Y/s300/abbi-pulling-and-nissan-formul.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Abbi Pulling explains why Formula E is "cut-throat" after Miami ePrix rookie run        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula E</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                                                <span class="ms-item__series ms-item__series--ultra-short">FE</span>
+                
+                <span class="ms-item__series ms-item__series--title">Formula E</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Miami ePrix</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T22:51:57Z">
+                5 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Abbi Pulling explains why Formula E is "cut-throat" after Miami ePrix rookie run</div>
+
+        
+            </div>
+</a>    
+            
+    
+<a href="https://www.motorsport.com/f1/news/mercedes-announces-new-development-driver-signing-as-full-line-up-confirmed/10794816/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-vert-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794816" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s200/george-russell-mercedes.webp 200w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s300/george-russell-mercedes.webp 300w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s400/george-russell-mercedes.webp 400w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s500/george-russell-mercedes.webp 500w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s600/george-russell-mercedes.webp 600w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s700/george-russell-mercedes.webp 700w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s800/george-russell-mercedes.webp 800w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s900/george-russell-mercedes.webp 900w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s1000/george-russell-mercedes.webp 1000w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s1100/george-russell-mercedes.webp 1100w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s1200/george-russell-mercedes.webp 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+                    <source type="image/jpeg" srcset="https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s200/george-russell-mercedes.jpg 200w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s300/george-russell-mercedes.jpg 300w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s400/george-russell-mercedes.jpg 400w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s500/george-russell-mercedes.jpg 500w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s600/george-russell-mercedes.jpg 600w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s700/george-russell-mercedes.jpg 700w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s800/george-russell-mercedes.jpg 800w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s900/george-russell-mercedes.jpg 900w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s1000/george-russell-mercedes.jpg 1000w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s1100/george-russell-mercedes.jpg 1100w, https://cdn-3.motorsport.com/images/amp/Y9lL5Lq2/s1200/george-russell-mercedes.jpg 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-8.motorsport.com/images/amp/Y9lL5Lq2/s300/george-russell-mercedes.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            Mercedes announces new development driver signing as full line-up confirmed        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Formula 1</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                                                <span class="ms-item__series ms-item__series--ultra-short">F1</span>
+                
+                <span class="ms-item__series ms-item__series--title">Formula 1</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Mercedes launch</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T22:47:59Z">
+                5 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">Mercedes announces new development driver signing as full line-up confirmed</div>
+
+        
+            </div>
+</a>    
+            
+    
+<a href="https://www.motorsport.com/nascar-cup/news/nascar-cup-drivers-are-helping-with-snow-removal-at-bowman-gray/10794793/" class="ms-item ms-item-vert-d ms-item-vert-t ms-item-vert-m   ms-item--skeleton" tabindex="-1" data-entity-id="10794793" data-entity-type="article">
+            
+<div class="ms-item__thumb ">
+    
+<picture class="ms-item__picture ">
+                        <source type="image/webp" srcset="https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s200/ricky-stenhouse-jr-hyak-motors.webp 200w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s300/ricky-stenhouse-jr-hyak-motors.webp 300w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s400/ricky-stenhouse-jr-hyak-motors.webp 400w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s500/ricky-stenhouse-jr-hyak-motors.webp 500w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s600/ricky-stenhouse-jr-hyak-motors.webp 600w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s700/ricky-stenhouse-jr-hyak-motors.webp 700w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s800/ricky-stenhouse-jr-hyak-motors.webp 800w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s900/ricky-stenhouse-jr-hyak-motors.webp 900w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s1000/ricky-stenhouse-jr-hyak-motors.webp 1000w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s1100/ricky-stenhouse-jr-hyak-motors.webp 1100w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s1200/ricky-stenhouse-jr-hyak-motors.webp 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+                    <source type="image/jpeg" srcset="https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s200/ricky-stenhouse-jr-hyak-motors.jpg 200w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s300/ricky-stenhouse-jr-hyak-motors.jpg 300w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s400/ricky-stenhouse-jr-hyak-motors.jpg 400w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s500/ricky-stenhouse-jr-hyak-motors.jpg 500w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s600/ricky-stenhouse-jr-hyak-motors.jpg 600w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s700/ricky-stenhouse-jr-hyak-motors.jpg 700w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s800/ricky-stenhouse-jr-hyak-motors.jpg 800w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s900/ricky-stenhouse-jr-hyak-motors.jpg 900w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s1000/ricky-stenhouse-jr-hyak-motors.jpg 1000w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s1100/ricky-stenhouse-jr-hyak-motors.jpg 1100w, https://cdn-9.motorsport.com/images/amp/2y3eE8n6/s1200/ricky-stenhouse-jr-hyak-motors.jpg 1200w" sizes="(min-width: 950px) 300px, (min-width: 768px) 200px, (min-width: 450px) 300px">
+            
+    <img loading="lazy" width="300" height="200" class="ms-item__img ms-item__img--3_2 " src="https://cdn-4.motorsport.com/images/amp/2y3eE8n6/s300/ricky-stenhouse-jr-hyak-motors.jpg" alt="">
+    </picture>
+    <div class="ms-item__thumb-info">
+        <p class="ms-item__thumb-title">
+            NASCAR Cup drivers are helping shovel snow at Bowman Gray after storm        </p>
+    </div>
+
+    <div class="ms-item__thumb-info-top">
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>        
+                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__thumb-series !hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">NASCAR Cup</span>
+</div>        
+                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-duration hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-photo-count hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#camera"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5"></span>
+</div>            
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-live-text hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#point-filled"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Live text</span>
+</div>
+            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--light msnt-badge--sm -skew-x-3 ms-item__thumb-rating hidden">
+            <svg class="w-4 h-4 skew-x-3" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chart-bar"></use>
+        </svg>
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Ratings</span>
+</div>            </div>
+
+    
+            <span class="ms-item__play  hidden">
+            <svg class="ms-item__play-icon" aria-hidden="true">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#player-play-filled"></use>
+            </svg>
+        </span>
+    </div>    
+    
+    <div class="ms-item__info">
+        <div class="ms-item__info-top">
+            <div class="ms-item__info-conditional ms-item__info-conditional--prime">
+                                    
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--prime msnt-badge--sm -skew-x-3 ms-item__prime  hidden">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Prime</span>
+</div>                            </div>
+
+                                                <span class="ms-item__series ms-item__series--ultra-short">NAS</span>
+                
+                <span class="ms-item__series ms-item__series--title">NASCAR Cup</span>
+            
+                            <div class="ms-item__info-conditional">
+                                            
+<div class="msnt-badge font-secondary font-bold inline-flex uppercase items-center gap-1 msnt-badge--default msnt-badge--sm -skew-x-3 ms-item__event">
+    
+    <span class="msnt-badge__text skew-x-3 -mt-0.5">Cook Out Clash at Bowman Gray</span>
+</div>                                    </div>
+            
+            <span class="ms-item__icon--trending" data-count-type="trending">
+                <svg aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-hot"></use>
+                </svg>
+            </span>
+
+                        <time class="ms-item__date " datetime="2026-02-02T19:29:29Z">
+                9 h            </time>
+                    </div>
+
+        
+                <div class="ms-item__title">NASCAR Cup drivers are helping shovel snow at Bowman Gray after storm</div>
+
+        
+            </div>
+</a>    </div>
+        
+    
+    </section>    
+                
+    </div>
+
+
+<template id="adblock-content-blocked-tpl">
+
+
+<div class="adblock-content-blocked">
+    <h3 class="adblock-content-blocked__title">
+                    Subscribe and access Motorsport.com with your ad-blocker.            </h3>
+    <p class="adblock-content-blocked__descr">From Formula 1 to MotoGP we report straight from the paddock because we love our sport, just like you. In order to keep delivering our expert journalism, our website uses advertising. Still, we want to give you the opportunity to enjoy an ad-free and tracker-free website and to continue using your adblocker.</p>
+    <p class="adblock-content-blocked__options-title">You have 2 options:</p>
+    <ul class="adblock-content-blocked__options">
+        <li class="adblock-content-blocked__option">Become a subscriber.</li>
+        <li class="adblock-content-blocked__option">Disable your adblocker.</li>
+    </ul>
+    <div class="adblock-content-blocked__actions">
+        <div class="adblock-content-blocked__action-block">
+            <a class="adblock-content-blocked__action" href="https://www.motorsport.com/prime/?refEdition=global&amp;offer=adblock">Subscribe now</a>
+
+            <span class="adblock-content-blocked__action-text adblock-content-blocked__action--signin">Already subscribed? <a href="javascript:void(0)">Sign in here</a></span>
+        </div>
+
+        <div class="adblock-content-blocked__action-block">
+            <a href="javascript:window.location.reload();" class="adblock-content-blocked__action">Already disabled your adblocker?<br>Reload page</a>
+        </div>
+    </div>
+</div>
+</template></div>
+
+
+
+<template id="news-alert-dialog-tpl">
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center  msnt-dialog-transition-default" aria-label="News Alerts" id="news-alert-dialog">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface3 w-max max-w-90vw">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-6 pt-6 pb-3 ">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-titles-fg font-primary capitalize msnt-dialog__title">
+                                    
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ps-6 pt-3 pb-3">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full pe-6 ">
+                    
+<div class="grid gap-6">
+    
+    <msnt-notifications></msnt-notifications>
+    <input id="ms-pn-token-dialog-field" type="hidden" name="token">
+    <input id="ms-pn-device_id-dialog-field" type="hidden" name="device_id">
+    <input id="ms-pn-user_id-dialog-field" type="hidden" name="user_id">
+    <input id="ms-pn-platform-dialog-field" type="hidden" name="platform">
+</div>            </div>
+        </div>
+        
+                    <footer class="msnt-dialog__actions flex gap-6 flex-wrap px-6 pb-6 pt-3 justify-end">
+                                    
+<a href="https://www.motorsport.com/dashboard/notifications/" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost msnt-button--md w-auto uppercase italic ">
+        
+                    <span class="msnt-button__text inline ">Manage Alerts</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+<button type="button" data-action="submit" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--neutral msnt-button--md w-auto uppercase italic ">
+        
+                    <span class="msnt-button__text inline ">Subscribe</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+                            </footer>
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+</template>
+
+
+                    </main>
+
+        <div id="ms-piano_prefooter" class="empty:contents"></div>
+
+        
+<footer class="ms-footer pb-2 bg-menu-bg z-footer relative text-menu-fg text-body md:pt-[70px]">
+
+    <div class="mx-auto md:grid md:grid-cols-2 md:gap-x-8 gap-y-4 xl:grid-cols-4 max-w-largest-width">
+
+        <section aria-labelledby="footer-subscribe-to-newsletter-title" class="ms-footer--subscribe px-6 py-4 flex flex-col bg-menu-bg-soft md:bg-transparent ">
+            <h4 id="footer-subscribe-to-newsletter-title" class="text-5 leading-6 font-bold font-primary">Subscribe to our newsletter</h4>
+
+            <p class="text-body mt-2 mb-4 font-secondary">Receive exciting Motorsport news, updates, and special offers straight to your inbox.</p>
+
+            
+<button type="button" data-event="showEmailNewsletterPopupOnClick" data-init="initSubscribeEmailButton" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--accent msnt-button--md w-full justify-center uppercase italic invisible" commandfor="document" command="--gtm-event">
+        
+                    <span class="msnt-button__text inline msnt-button__text--active ">Subscribe</span>
+                
+                    <span class="hidden msnt-button__active-text--active">You already subscribed</span>
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+        </section>
+
+        <div class="ms-footer--social-block">
+            <section aria-labelledby="footer-download-app-title" class="ms-footer--app flex flex-col gap-3 px-6 py-4">
+                <h4 id="footer-download-app-title" class="text-5 leading-6 font-bold mb-4 text-center md:text-left font-primary">Get the app</h4>
+                
+                
+                <div class="flex justify-center gap-4 md:justify-start flex-wrap">
+                    
+
+    <a target="_blank" class="ms-item__link" href="https://apps.apple.com/us/app/motorsport-com/id1459863859?ls=1&amp;ct=side-banner&amp;mt=8">
+        
+<picture class="msnt-picture block  min-w-[135px] w-[135px]">
+            <source type="image\png" srcset="https://us-east-1-cdn-ui.motorsport.com/895/design/images/apps/download-app/app_store_white.png, https://us-east-1-cdn-ui.motorsport.com/895/design/images/apps/download-app/app_store_white_x2.png 2x">
+    
+    <img src="https://us-east-1-cdn-ui.motorsport.com/895/design/images/apps/download-app/app_store_white_x2.png" loading="lazy" width="138" height="40" alt="Google Play" class="w-full aspect-photo">
+</picture>    </a>
+
+                    
+
+    <a target="_blank" class="ms-item__link" href="https://play.google.com/store/apps/details?id=com.motorsport.application&amp;referrer=https%3A%2F%2Fwww.motorsport.com%2Ff1%2Fnews%2Fvery-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day%2F10793339%2F&amp;utm_campaign=installations&amp;utm_medium=side-banner&amp;utm_source=www.motorsport.com">
+        
+<picture class="msnt-picture block  min-w-[135px] w-[135px]">
+            <source type="image\png" srcset="https://us-east-1-cdn-ui.motorsport.com/895/design/images/apps/download-app/google_play_white.png, https://us-east-1-cdn-ui.motorsport.com/895/design/images/apps/download-app/google_play_white_x2.png 2x">
+    
+    <img src="https://us-east-1-cdn-ui.motorsport.com/895/design/images/apps/download-app/google_play_white_x2.png" loading="lazy" width="138" height="40" alt="App Store" class="w-full aspect-photo">
+</picture>    </a>
+
+                </div>
+            </section>
+
+            
+<div class="w-full h-px bg-menu-divider-100 block md:hidden"></div>
+
+            <section aria-labelledby="footer-social-links-title" class="ms-footer--social flex flex-col gap-4 text-center md:text-left px-6 py-4">
+                <h4 id="footer-social-links-title" class="text-5 leading-6 font-bold text-center md:text-left font-primary">Social media</h4>
+
+                
+<div class="ms-corporate-menu-socials ms-footer--social-list inline-flex justify-center md:justify-start">
+    
+    <div class="flex flex-wrap gap-3 md:gap-4 justify-start">
+                    
+<a href="https://www.facebook.com/motorsportcom/" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg-soft bg-icon-button-ghost-bg/0 hover:bg-icon-button-ghost-bg-hover/10 focus:bg-icon-button-ghost-bg-hover/10 active:bg-icon-button-ghost-bg-active/20" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-facebook"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                    
+<a href="https://twitter.com/motorsport" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg-soft bg-icon-button-ghost-bg/0 hover:bg-icon-button-ghost-bg-hover/10 focus:bg-icon-button-ghost-bg-hover/10 active:bg-icon-button-ghost-bg-active/20" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-x"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                    
+<a href="https://instagram.com/motorsportcom" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg-soft bg-icon-button-ghost-bg/0 hover:bg-icon-button-ghost-bg-hover/10 focus:bg-icon-button-ghost-bg-hover/10 active:bg-icon-button-ghost-bg-active/20" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-instagram"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                    
+<a href="https://www.youtube.com/c/MotorsporttvGlobal" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg-soft bg-icon-button-ghost-bg/0 hover:bg-icon-button-ghost-bg-hover/10 focus:bg-icon-button-ghost-bg-hover/10 active:bg-icon-button-ghost-bg-active/20" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-youtube"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                            
+<a href="https://www.motorsport.com/rss/" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg-soft bg-icon-button-ghost-bg/0 hover:bg-icon-button-ghost-bg-hover/10 focus:bg-icon-button-ghost-bg-hover/10 active:bg-icon-button-ghost-bg-active/20" title="RSS">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#rss"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+            </div>
+</div>
+            </section>
+        </div>
+
+        
+<div class="w-full h-px bg-menu-divider-100 block md:hidden"></div>
+
+        <section class="ms-footer--properties px-6 py-4 text-center md:text-left" aria-labelledby="footer-motorsport-network-title">
+            <div class="flex justify-center md:justify-start">
+                <a class="ms-footer__logo-msn" href="https://www.motorsportnetwork.com/" target="_blank">
+                    <svg id="footer-motorsport-network-title" class="h-9 mb-4 w-[133px]" aria-label="Motorsport Network">
+                                                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-network-logo"></use>
+                                            </svg>
+                </a>
+            </div>
+
+                            <ul class="ms-footer__list flex flex-col gap-4 font-secondary">
+                                                                                            <li><a class="hover:underline" href="https://motorsport.tv/" target="_blank">Motorsport.tv</a></li>
+                                                                    <li><a class="hover:underline" href="https://www.motor1.com/" target="_blank">Motor1.com</a></li>
+                                                                    <li><a class="hover:underline" href="https://www.motorsportjobs.com/" target="_blank">Motorsportjobs.com</a></li>
+                                                                    <li><a class="hover:underline" href="https://www.autosport.com/" target="_blank">Autosport.com</a></li>
+                                                                    <li><a class="hover:underline" href="https://motorsportstats.com/" target="_blank">Motorsportstats.com</a></li>
+                                    </ul>
+                    </section>
+
+        
+<div class="w-full h-px bg-menu-divider-100 block md:hidden"></div>
+
+        <section aria-labelledby="footer-contact-us-title" class="ms-footer--contacts px-6 py-4 text-center md:text-left">
+            <h4 id="footer-contact-us-title" class="text-5 leading-6 font-bold mb-4 text-center md:text-left font-primary">Contact us</h4>
+
+            <ul class="ms-footer__list flex flex-col gap-4 font-secondary">
+
+                
+                <li class="ms-footer__list">
+                    <a class="hover:underline" href="https://www.motorsport.com/info/feedback/">Feedback</a>
+                </li>
+
+                
+                <li class="ms-footer__list">
+                    <a class="hover:underline" href="https://www.motorsport.com/info/advertising/">Advertise with Motorsport.com</a>
+                </li>
+                
+                
+                <li class="ms-footer__list">
+                    <a class="hover:underline" href="https://www.motorsport.com/info/contact/">Contact the team</a>
+                </li>
+                                                            <li class="ms-footer__list">
+                            <a class="hover:underline" target="_blank" href="mailto:sales@motorsport.com">sales@motorsport.com</a>
+                        </li>
+                    
+                    
+                    
+                    
+                                        
+
+                                                                <li class="ms-footer__list font"><address>650 Madison Avenue,<br>New York, NY 10022<br>USA</address></li>
+                                    
+                            </ul>
+        </section>
+
+        
+<div class="w-full h-px bg-menu-divider-100 block md:col-start-1 md:col-end-3 xl:col-end-5"></div>
+
+        <nav class="ms-footer__copyright font-secondary px-6 py-4 md:pt-0 text-center md:col-start-1 md:col-end-3 xl:col-end-5" aria-label="Legal">
+                        <div class="ms-copyright text-body flex flex-col-reverse gap-3">
+                <div class="ms-copyright_start font-bold">
+                    <span class="font">© 2026</span> 
+                    <a class="text-static-error hover:underline" target="_blank" href="https://www.motorsportnetwork.com/company/about">Motorsport Network</a>
+                    <a class="ms-link text-inherit" href="https://www.motorsport.com/info/copyright/">All rights reserved.</a>
+                </div>
+                <div class="ms-copyright_end">
+                    <ul class="flex gap-x-4 gap-y-2 whitespace-nowrap flex-wrap justify-center">
+                        <li><a class="ms-link text-inherit" href="https://www.motorsport.com/info/terms-of-use/">Terms &amp; Conditions</a></li>
+                        <li><a class="ms-link text-inherit" href="https://www.motorsport.com/info/cookie-policy/">Cookie policy</a></li>
+                        <li><a class="ms-link text-inherit" href="https://accounts.motorsportnetwork.com/legal/privacy-policy/en" target="_blank">Privacy Policy</a></li>
+
+                        
+                                                    <li>
+                                
+<msnt-cookie-settings-cta class="msnt-cookie-settings-cta  ">
+    <button class="msnt-consent-settings-btn gdpr hidden ms-link flex items-center gap-2 text-inherit font-secondary">
+        <span>Cookie Settings</span>
+    </button>
+
+    <button class="msnt-consent-settings-btn usnat hidden ms-link flex items-center gap-2 text-inherit font-secondary">
+        <span>Your Privacy Choices</span>
+
+        
+<svg class="msnt-svg-icon msnt-svg-icon--primary " style="width: 30px; height: 14px" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#privacyoptions"></use>
+</svg>    </button>
+</msnt-cookie-settings-cta>                            </li>
+                                            </ul>
+                </div>
+            </div>
+        </nav>
+    </div>
+
+    <div id="ms-footer_piano-footer"></div>
+
+</footer>
+            </div>
+
+    
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center msnt-drawer  msnt-dialog-transition-inline-end" aria-label="User menu" id="msnt-user-menu-drawer" data-side="inlineEnd">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface7 text-fg-on-color msnt-drawer__wrapper ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-4.5 msnt-drawer__header ">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-item-card-on-dark-heading font-primary capitalize msnt-dialog__title">
+                                    
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full  msnt-drawer__content px-4">
+                    
+<div class="ms-user-menu bg-menu-bg ">
+            <div class="px-3 pt-3 ">
+            <h3 class="text-body-lg text-menu-fg font-bold font-secondary uppercase">Sign up for free</h3>
+        </div>
+        <ul class="flex flex-col gap-4 px-3 pt-3 pb-4 ">
+            <li class="flex items-center gap-2">
+                <svg class="w-6 h-6 min-w-6 block text-menu-auth-modal-benefits" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#news"></use>
+                </svg>
+                <p class="text-body text-menu-auth-modal-benefits font font-secondary">Get quick access to your favorite articles</p>
+            </li>
+            <li class="flex items-center gap-2">
+                <svg class="w-6 h-6 min-w-6 block text-menu-auth-modal-benefits" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#bell"></use>
+                </svg>
+                <p class="text-body text-menu-auth-modal-benefits font font-secondary">Manage alerts on breaking news and favorite drivers</p>
+            </li>
+            <li class="flex items-center gap-2">
+                <svg class="w-6 h-6 min-w-6 block text-menu-auth-modal-benefits" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#message-circle-2"></use>
+                </svg>
+                <p class="text-body text-menu-auth-modal-benefits font font-secondary">Make your voice heard with article commenting.</p>
+            </li>
+        </ul>
+        <div class="px-3 flex flex-col gap-2 pb-3 ">
+                            
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--outline-on-dark border msnt-button--sm w-full justify-center uppercase italic " commandfor="document" command="--show-dialog-auth">
+        
+                    <span class="msnt-button__text inline ">Sign in</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+                    </div>
+
+                
+                    
+<div class="w-full h-px bg-menu-divider-100 "></div>
+            
+            
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden text-start msnt-button--ghost-on-dark w-full justify-center uppercase italic p-3" title="Select edition" commandfor="select-edition-drawer" command="--show">
+        
+            
+<h3 class="text-body-sm font-bold text-menu-accent uppercase pb-2">Edition</h3>
+
+<div class="flex items-center gap-2">
+    <img src="https://cdn-1.motorsport.com/static/img/cf/global-2.svg" alt="Global" title="Global" width="34" height="20" loading="lazy">
+    
+    <span class="text-body-lg text-menu-fg uppercase font-bold mr-auto">
+        Global    </span>
+
+    <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180">
+        <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+    </svg>
+</div>    
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+            
+    </div>            </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+    
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center msnt-drawer  msnt-dialog-transition-inline-start" aria-label="Main menu" id="main-menu-drawer" data-side="inlineStart">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface7 text-fg-on-color msnt-drawer__wrapper ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-4.5 msnt-drawer__header ">
+                                
+                                    
+<a class="no-underline h-full" style="width: 140px;" href="https://www.motorsport.com/">
+    <svg class="h-full w-full" aria-label="Motorsport.com">
+                                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-logo"></use>
+                        </svg>
+</a>                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full  msnt-drawer__content ">
+                                </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+
+<template id="main-menu-drawer-tpl">
+        
+    <div class="ms-main-menu-accordion default visible">
+            <nav class="mt-4" aria-labelledby="quick-links-mm-accordion">
+            <h3 id="quick-links-mm-accordion" class="uppercase font-bold font-secondary text-menu-accent text-3.5 leading-4">
+                Quick links:            </h3>
+            <ul class="flex flex-col py-2 border-b border-menu-divider-100">
+                                    <li class="ms-main-menu-accordion__item">
+                        <div class="ms-main-menu-accordion__item-content relative flex items-center justify-between py-3">
+                            <a class="ms-main-menu-accordion__item-link text-4 leading-4.5 font-secondary font-bold" href="https://www.motorsport.com/f1/schedule/2026/">F1 Schedule 2026</a>
+                        </div>
+                    </li>
+                                    <li class="ms-main-menu-accordion__item">
+                        <div class="ms-main-menu-accordion__item-content relative flex items-center justify-between py-3">
+                            <a class="ms-main-menu-accordion__item-link text-4 leading-4.5 font-secondary font-bold" href="https://www.motorsport.com/all/galleries/">Photo Galleries</a>
+                        </div>
+                    </li>
+                                    <li class="ms-main-menu-accordion__item">
+                        <div class="ms-main-menu-accordion__item-content relative flex items-center justify-between py-3">
+                            <a class="ms-main-menu-accordion__item-link text-4 leading-4.5 font-secondary font-bold" href="https://www.motorsport.com/all/videos/">Videos</a>
+                        </div>
+                    </li>
+                                    <li class="ms-main-menu-accordion__item">
+                        <div class="ms-main-menu-accordion__item-content relative flex items-center justify-between py-3">
+                            <a class="ms-main-menu-accordion__item-link text-4 leading-4.5 font-secondary font-bold" href="https://www.motorsport.com/topic/autosport-awards/2333/">2026 Autosport Awards</a>
+                        </div>
+                    </li>
+                            </ul>
+        </nav>
+    
+    <nav class="mt-6" aria-labelledby="popular-series-mm-accordion">
+        <h3 id="popular-series-mm-accordion" class="uppercase font-bold font-secondary text-menu-accent text-3.5 leading-4">
+            Popular series        </h3>
+
+        
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none current ws current ws current ws">
+            <details open="">
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/f1/">
+                    <div class="w-48 h-8 -ms-1 flex items-center justify-center rounded-xsm bg-surface-surface6">
+                <img loading="lazy" srcset="https://cdn-6.motorsport.com/images/mrtp/yq63aE2A/s4/img1495562572-9-9.png, https://cdn-4.motorsport.com/images/mrtp/yq63aE2A/s3/img1495562572-9-9.png 2x" src="https://cdn-6.motorsport.com/images/mrtp/yq63aE2A/s4/img1495562572-9-9.png" alt="Formula 1" title="Formula 1" width="32" aria-hidden="true">
+            </div>
+        
+        Formula 1    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/teams/">Teams</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1/driver-ratings/">Ratings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/live/">Live</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws ws ws">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/motogp/">
+                    <div class="w-48 h-8 -ms-1 flex items-center justify-center rounded-xsm bg-surface-surface6">
+                <img loading="lazy" srcset="https://cdn-5.motorsport.com/images/mrtp/qN6VON0A/s4/motogp-4.png, https://cdn-8.motorsport.com/images/mrtp/qN6VON0A/s3/motogp-4.png 2x" src="https://cdn-5.motorsport.com/images/mrtp/qN6VON0A/s4/motogp-4.png" alt="MotoGP" title="MotoGP" width="32" aria-hidden="true">
+            </div>
+        
+        MotoGP    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/motogp/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws ws ws">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/nascar-cup/">
+                    <div class="w-48 h-8 -ms-1 flex items-center justify-center rounded-xsm bg-surface-surface6">
+                <img loading="lazy" srcset="https://cdn-9.motorsport.com/images/mrtp/en0myk0z/s4/img193773334-5-5.png, https://cdn-3.motorsport.com/images/mrtp/en0myk0z/s3/img193773334-5-5.png 2x" src="https://cdn-9.motorsport.com/images/mrtp/en0myk0z/s4/img193773334-5-5.png" alt="NASCAR Cup" title="NASCAR Cup" width="32" aria-hidden="true">
+            </div>
+        
+        NASCAR Cup    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-cup/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws ws ws">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/indycar/">
+                    <div class="w-48 h-8 -ms-1 flex items-center justify-center rounded-xsm bg-surface-surface6">
+                <img loading="lazy" srcset="https://cdn-8.motorsport.com/images/mrtp/o3YWe0OV/s4/img2039077430-3-3.png, https://cdn-4.motorsport.com/images/mrtp/o3YWe0OV/s3/img2039077430-3-3.png 2x" src="https://cdn-8.motorsport.com/images/mrtp/o3YWe0OV/s4/img2039077430-3-3.png" alt="IndyCar" title="IndyCar" width="32" aria-hidden="true">
+            </div>
+        
+        IndyCar    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indycar/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws ws ws">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/wec/">
+                    <div class="w-48 h-8 -ms-1 flex items-center justify-center rounded-xsm bg-surface-surface6">
+                <img loading="lazy" srcset="https://cdn-5.motorsport.com/images/mrtp/W901r2VO/s4/img1361993580-3-3.png, https://cdn-1.motorsport.com/images/mrtp/W901r2VO/s3/img1361993580-3-3.png 2x" src="https://cdn-5.motorsport.com/images/mrtp/W901r2VO/s4/img1361993580-3-3.png" alt="WEC" title="WEC" width="32" aria-hidden="true">
+            </div>
+        
+        WEC    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wec/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul>
+    </nav>
+
+    <section class="mt-1" aria-labelledby="all-series-mm-accordion">
+        <h3 id="all-series-mm-accordion" class="my-6 font-bold text-menu-accent text-4 leading-5  font-secondary">
+            All Series        </h3>
+        
+                                    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws ws ws">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/imsa/">
+        
+        IMSA    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/imsa/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul>                                                
+<nav class="my-6" aria-labelledby="openwheel-mm-accordion">
+    <h3 id="openwheel-mm-accordion" class="uppercase mb-2 font-bold font-secondary text-menu-accent text-3.5 leading-4">
+        Open wheel    </h3>
+    
+    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/formula-e/">
+        
+        Formula E    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/formula-e/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/fia-f2/">
+        
+        FIA F2    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f2/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/fia-f3/">
+        
+        FIA F3    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/fia-f3/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/super-formula/">
+        
+        Super Formula    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/super-formula/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/f1-academy/">
+        
+        F1 Academy    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1-academy/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1-academy/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1-academy/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1-academy/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/f1-academy/standings/">Standings</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/indylights/">
+        
+        Indy NXT    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/indylights/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul></nav>
+
+                                                
+<nav class="my-6" aria-labelledby="rally-mm-accordion">
+    <h3 id="rally-mm-accordion" class="uppercase mb-2 font-bold font-secondary text-menu-accent text-3.5 leading-4">
+        Rally    </h3>
+    
+    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/wrc/">
+        
+        WRC    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wrc/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/dakar/">
+        
+        Dakar    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dakar/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dakar/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dakar/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dakar/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dakar/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul></nav>
+
+                                                
+<nav class="my-6" aria-labelledby="sportscar-mm-accordion">
+    <h3 id="sportscar-mm-accordion" class="uppercase mb-2 font-bold font-secondary text-menu-accent text-3.5 leading-4">
+        Sportscars    </h3>
+    
+    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/lemans/">
+        
+        Le Mans    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/lemans/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/lemans/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/lemans/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/lemans/videos/">Videos</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/supergt/">
+        
+        Super GT    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/supergt/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/supergt/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/supergt/schedule/">Schedule</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul></nav>
+
+                                                
+<nav class="my-6" aria-labelledby="bikes-mm-accordion">
+    <h3 id="bikes-mm-accordion" class="uppercase mb-2 font-bold font-secondary text-menu-accent text-3.5 leading-4">
+        Bikes    </h3>
+    
+    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/moto2/">
+        
+        Moto2    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto2/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/moto3/">
+        
+        Moto3    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/moto3/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/wsbk/">
+        
+        World Superbike    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/wsbk/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul></nav>
+
+                                                
+<nav class="my-6" aria-labelledby="nascar-mm-accordion">
+    <h3 id="nascar-mm-accordion" class="uppercase mb-2 font-bold font-secondary text-menu-accent text-3.5 leading-4">
+        Other NASCAR    </h3>
+    
+    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/nascar-os/">
+        
+        NASCAR O'Reilly    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-os/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-os/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-os/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-os/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-os/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-os/videos/">Videos</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/nascar-truck/">
+        
+        NASCAR Truck    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-truck/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-truck/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-truck/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-truck/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-truck/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-truck/videos/">Videos</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/nascar-euro/">
+        
+        NASCAR Euro    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-euro/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-euro/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/nascar-euro/schedule/">Schedule</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul></nav>
+
+                                                
+<nav class="my-6" aria-labelledby="touring-mm-accordion">
+    <h3 id="touring-mm-accordion" class="uppercase mb-2 font-bold font-secondary text-menu-accent text-3.5 leading-4">
+        Touring    </h3>
+    
+    
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/v8supercars/">
+        
+        Supercars    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/v8supercars/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none ws type-series ws type-series ws type-series">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/dtm/">
+        
+        DTM    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/schedule/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/results/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/standings/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/galleries/">Photo galleries</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/dtm/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul></nav>
+
+                                                
+<ul class="msnt-accordion  pt-2">
+            <li class="ms-main-menu-accordion__item border-b border-menu-divider-100 select-none section-all ws section-all ws section-all ws">
+            <details>
+                <summary>
+<div class="ms-main-menu-accordion__item-content relative px-1 flex items-center justify-between h-12 w-full">
+    <a class="ms-main-menu-accordion__item-link text-menu-fg text-4 leading-5 flex gap-2.5 items-center font-secondary" href="https://www.motorsport.com/">
+        
+        All Series    </a>
+    
+            <svg class="ms-main-menu-accordion__expand-arrow" aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+        </svg>
+    </div>
+</summary>
+                
+<ul class="ms-main-menu-accordion__item-submenu">
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/news/">News</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/schedule/2026/upcoming/">Schedule</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/results/2026/">Results</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/standings/2026/">Standings</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/videos/">Videos</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/drivers/">Drivers</a>
+            </div>
+        </li>
+            <li class="ms-main-menu-accordion__item-lvl2 ws ws ws">
+            <div class="ms-main-menu-accordion__item-lvl2-content">
+                <a class="ms-main-menu-accordion__item-lvl2-link text-body font-bold uppercase font-secondary" href="https://www.motorsport.com/all/teams/">Teams</a>
+            </div>
+        </li>
+    </ul>
+            </details>
+        </li>
+    </ul>                        </section>
+
+    <nav class="ms-main-menu-accordion__item px-1 mt-6 mb-10 flex items-center justify-between h-12 border-b border-menu-divider-100 select-none section-all ws section-all ws section-all ws" aria-labelledby="all-series-listing-mm-accordion">
+        <a id="all-series-listing-mm-accordion" class="ms-main-menu-accordion__item-link text-4 leading-5 font-secondary" href="https://www.motorsport.com/series/" target="_blank">
+            Go to all series listing        </a>
+    </nav>
+
+    
+<search class="relative w-full border border-menu-border-100">
+     
+</search></div>
+    
+    <section class="px-4.5" data-section="corporate">
+        <nav class="ms-corporate-projects" aria-labelledby="corporate-project-mm-accordion">
+    <h3 id="corporate-project-mm-accordion" class="block font-bold font-secondary mb-3 mt-1 text-3.5 leading-4">
+        <a class="no-underline text-accent-color-default uppercase" href="https://www.motorsportnetwork.com/" target="_blank">Motorsport Network</a>
+    </h3>
+    
+    <ul class="flex flex-col">
+        <li>
+            <a href="https://motorsport.tv/" target="_blank" class="border-b border-menu-divider-100 flex items-center gap-2 px-1 py-1.5 text-menu-fg hover:text-menu-accent">
+                <svg class="w-8 h-8" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-tv-logo-mini"></use>
+                </svg>
+                <span class="text-4 leading-5 font font-secondary">Motorsport.tv</span>
+            </a>
+        </li>
+
+        
+        <li>
+            <a href="https://www.motorsportjobs.com/" target="_blank" class="border-b border-menu-divider-100 flex items-center gap-2 px-1 py-1.5 text-menu-fg hover:text-menu-accent">
+                <svg class="w-8 h-8" aria-hidden="true">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-jobs-logo-mini"></use>
+                </svg>
+                <span class="text-4 leading-5 font font-secondary">Motorsport Jobs</span>
+            </a>
+        </li>
+
+        
+        <li>
+            <a href="https://www.motor1.com/" target="_blank" class="border-b border-menu-divider-100 flex items-center gap-2 px-1 py-1.5 text-menu-fg hover:text-menu-accent">
+                                    <svg class="w-8 h-8" aria-hidden="true">
+                        <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motor1-logo-mini-white"></use>
+                    </svg>
+                                <span class="text-4 leading-5 font font-secondary">Motor1.com</span>
+            </a>
+        </li>
+        <li>
+            <a href="https://insideevs.com/" target="_blank" class="border-b border-menu-divider-100 flex items-center gap-2 px-1 py-1.5 text-menu-fg hover:text-menu-accent">
+            
+                                    <svg class="w-8 h-8" aria-hidden="true">
+                        <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#insideevs-logo-mini"></use>
+                    </svg>
+                                <span class="text-4 leading-5 font font-secondary">InsideEVs</span>
+            </a>
+        </li>
+
+        
+        
+        
+        
+        
+        
+        
+                
+        
+            </ul>
+</nav>          
+
+
+<nav class="ms-corporate-menu-apps" aria-labelledby="corporate-menu-apps-mm-accordion">
+    <h3 id="corporate-menu-apps-mm-accordion" class="block uppercase font-bold font-secondary mb-2 mt-6 text-accent-color-default text-3.5 leading-4">
+        Mobile apps    </h3>
+
+    <ul class="flex flex-col">
+        <li>
+            <a href="https://apps.apple.com/us/app/motorsport-com/id1459863859?ls=1&amp;ct=header&amp;mt=8" target="_blank" class="border-b border-menu-divider-100 flex items-center gap-2 px-1 py-3 text-4 leading-5 font text-menu-fg hover:text-menu-accent font-secondary">
+                App Store
+            </a>
+        </li>
+
+        <li>
+            <a href="https://play.google.com/store/apps/details?id=com.motorsport.application&amp;referrer=https%3A%2F%2Fwww.motorsport.com%2Ff1%2Fnews%2Fvery-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day%2F10793339%2F&amp;utm_campaign=installations&amp;utm_medium=header&amp;utm_source=www.motorsport.com" target="_blank" class="border-b border-menu-divider-100 flex items-center gap-2 px-1 py-3 text-4 leading-5 font text-menu-fg hover:text-menu-accent font-secondary">
+                Google Play
+            </a>
+        </li>
+    </ul>
+</nav>
+        <section class="pb-2" aria-label="Socials">
+            <h3 class="block text-3.5 leading-4 uppercase font-bold font-secondary mb-2 mt-6 text-accent-color-default">
+                Socials            </h3>
+            
+            
+<div class="ms-corporate-menu-socials -ml-1">
+    
+    <div class="flex flex-wrap gap-3 md:gap-4 justify-start">
+                    
+<a href="https://www.facebook.com/motorsportcom/" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg hover:text-menu-accent" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-facebook"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                    
+<a href="https://twitter.com/motorsport" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg hover:text-menu-accent" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-x"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                    
+<a href="https://instagram.com/motorsportcom" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg hover:text-menu-accent" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-instagram"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                    
+<a href="https://www.youtube.com/c/MotorsporttvGlobal" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg hover:text-menu-accent" title="">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#brand-youtube"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+                            
+<a href="https://www.motorsport.com/rss/" onclick="" target="_blank" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--md msnt-icon-button--rounded-default text-menu-fg hover:text-menu-accent" title="RSS">
+
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#rss"></use>
+</svg>
+<svg class="msnt-svg-icon min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</a>
+            </div>
+</div>
+        </section>
+    </section>
+
+    <nav class="grid gap-8 px-4.5 pb-4.5 pt-6 bg-menu-bg-soft d:hidden" aria-label="Corporate menu">
+        
+<div class="msnt-part-of flex flex-col gap-2 items-center">
+    <a href="https://www.motorsport.com/" style="width: 119px; height: 34px" class="block">
+                    <svg class="h-full w-full">
+                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-logo"></use>
+            </svg>
+            </a>
+            <span class="uppercase inline-block mt-3 mb-3 text-3 leading-3.5 font-bold text-menu-fg-soft font-secondary">part of</span>
+        <a href="https://www.motorsportnetwork.com/" target="_blank" style="width: 119px; height: 34px" class="block">
+                            <svg class="h-full w-full">
+                    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-network-logo"></use>
+                </svg>
+                    </a>
+    </div>        
+<ul class="ms-corporate-menu-sections ms-corporate-menu-sections--flat grid grid-cols-2 gap-6">
+                        <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/about-us/">
+                    About us                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/about-edition/">
+                    About Edition                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/press/">
+                    Press                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/advertising/">
+                    Advertise                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/terms-of-use/">
+                    Terms of Use                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/membership-agreement/">
+                    Membership agreement                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/copyright/">
+                    Copyright                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://accounts.motorsportnetwork.com/legal/privacy-policy/en">
+                    Privacy policy                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/cookie-policy/">
+                    Cookie policy                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/contact/">
+                    Contact                </a>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <button class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" command="--gtm-event" commandfor="document" data-event="showEmailNewsletterPopupOnClick">Newsletter</button>
+                    </li>
+                            <li class="ms-corporate-menu-sections__item ">
+            
+                            <a class="text-menu-fg-soft text-3 leading-3.5 font-bold uppercase font-secondary hover:underline" href="https://www.motorsport.com/info/feedback/">
+                    Feedback                </a>
+                    </li>
+            </ul>
+        <div class="msnt-corporate-projects-other grid grid-cols-2 gap-4">
+    
+<a href="https://motorsport.tv/" target="_blank" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--accent msnt-button--sm w-full justify-center uppercase italic ">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#ms-tv-play-cog"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">TV</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+    
+<a href="https://www.motorsportjobs.com/en" target="_blank" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--accent msnt-button--sm w-full justify-center uppercase italic ">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#motorsport-jobs-logo-white"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Jobs</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+
+    
+<a href="https://motorsporttickets.com/en/f1?utm_content=Homepage+Headline&amp;utm_medium=Widget&amp;utm_source=www.motorsport.com" target="_blank" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--accent msnt-button--sm w-full justify-center uppercase italic ">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-motorsport-ticket"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Tickets</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+</div>    </nav>
+</template>    <dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center msnt-drawer  msnt-dialog-transition-inline-end" aria-label="Filters" id="filters-drawer" data-side="inlineEnd">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface7 text-fg-on-color msnt-drawer__wrapper ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-4.5 msnt-drawer__header ">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-item-card-on-dark-heading font-primary capitalize msnt-dialog__title">
+                        Filters            
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full  msnt-drawer__content p-4 h-full msnt-drawer_filter--selects group ms-filter ms-filter--mobile">
+                                </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+    <dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center msnt-drawer msnt-drawer--wide  msnt-dialog-transition-inline-end" aria-label="Comments" id="comments-drawer" data-side="inlineEnd">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface7 text-fg-on-color msnt-drawer__wrapper ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-4.5 msnt-drawer__header ">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-item-card-on-dark-heading font-primary capitalize msnt-dialog__title">
+                        Comments            
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full  msnt-drawer__content ">
+                                </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+
+<template id="comments-drawer-tpl">
+                                
+        <iframe id="comments-block-anchor" src="https://www.motorsport.com/coral/embed/article/10793339/?commentsCount=0" width="100%" height="100%" frameborder="0"></iframe>
+                        </template>    
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center msnt-drawer  msnt-dialog-transition-inline-end" aria-label="Select edition" id="select-edition-drawer" data-side="inlineEnd">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface7 text-fg-on-color msnt-drawer__wrapper ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-4.5 msnt-drawer__header ">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-item-card-on-dark-heading font-primary capitalize msnt-dialog__title">
+                                    
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full  msnt-drawer__content px-4">
+                                </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+
+<template id="select-edition-drawer-tpl">
+    <div>
+        <h3 class="text-3.5 leading-4 font-bold font-primary text-menu-accent pb-2.5">Current edition</h3>
+
+                                                                                            <div class="py-2 hover:bg-menu-bg-main-hover">
+                    <a class="flex items-center justify-between px-1" href="https://www.motorsport.com/">
+                        <div class="">
+                            <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Global</span>
+                                                                                        <span class="flex items-center gap-2.5">
+                                                                                                                    <div>
+                                            <img src="https://cdn-1.motorsport.com/static/img/cf/global-2.svg" alt="Global" title="Global" width="34" height="20" loading="lazy" aria-hidden="true">
+                                        </div>
+                                                                                                                    <div>
+                                            <img src="https://cdn-1.motorsport.com/static/img/cf/us-2.svg" alt="Global" title="Global" width="34" height="20" loading="lazy" aria-hidden="true">
+                                        </div>
+                                                                    </span>
+                                                    </div>
+
+                                                    <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                                <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                            </svg>
+                                            </a>
+                </div>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    </div>
+    
+    <h3 class="text-3.5 leading-4 font-bold font-primary text-menu-accent pt-2.5">Other editions</h3>
+
+    <ul class="flex flex-col pb-5 pt-2.5">
+                                                        <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover current">
+                <a class="flex items-center justify-between" href="https://www.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Global</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/global-2.svg" alt="Global" title="Global" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/us-2.svg" alt="Global" title="Global" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://fr.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">France</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/fr-2.svg" alt="France" title="France" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/lu-2.svg" alt="France" title="France" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/mc-2.svg" alt="France" title="France" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/ch-2.svg" alt="France" title="France" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://es.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">España</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/es-2.svg" alt="España" title="España" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://motorsport.uol.com.br/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Brasil</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/br-2.svg" alt="Brasil" title="Brasil" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/pt-2.svg" alt="Brasil" title="Brasil" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://de.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Deutschland</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/de-2.svg" alt="Deutschland" title="Deutschland" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/at-2.svg" alt="Deutschland" title="Deutschland" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/ch-2.svg" alt="Deutschland" title="Deutschland" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://it.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Italia</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/it-2.svg" alt="Italia" title="Italia" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/ch-2.svg" alt="Italia" title="Italia" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://cn.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">中文</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/zh-2.svg" alt="中文" title="中文" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://hu.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Magyarország</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/hu-2.svg" alt="Magyarország" title="Magyarország" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://id.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Indonesia</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/id-2.svg" alt="Indonesia" title="Indonesia" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://jp.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">日本</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/jp-2.svg" alt="日本" title="日本" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://nl.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Nederland</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/nl-2.svg" alt="Nederland" title="Nederland" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/be-2.svg" alt="Nederland" title="Nederland" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://me.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">الشرق الأوسط</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/ae-2.svg" alt="الشرق الأوسط" title="الشرق الأوسط" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/bh-2.svg" alt="الشرق الأوسط" title="الشرق الأوسط" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/lb-2.svg" alt="الشرق الأوسط" title="الشرق الأوسط" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/qa-2.svg" alt="الشرق الأوسط" title="الشرق الأوسط" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/sa-2.svg" alt="الشرق الأوسط" title="الشرق الأوسط" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://tr.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Türkİye</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/tr-2.svg" alt="Türkİye" title="Türkİye" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://espanol.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Espanol</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/us-2.svg" alt="Espanol" title="Espanol" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://lat.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Latinoamérica</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/ar-2.svg" alt="Latinoamérica" title="Latinoamérica" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/cl-2.svg" alt="Latinoamérica" title="Latinoamérica" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/co-2.svg" alt="Latinoamérica" title="Latinoamérica" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/mx-2.svg" alt="Latinoamérica" title="Latinoamérica" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/pe-2.svg" alt="Latinoamérica" title="Latinoamérica" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/ve-2.svg" alt="Latinoamérica" title="Latinoamérica" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                                        <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://au.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Australia</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/au-2.svg" alt="Australia" title="Australia" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/nz-2.svg" alt="Australia" title="Australia" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                                            <li class="px-1 py-2 border-b border-menu-divider-100 hover:bg-menu-bg-main-hover ">
+                <a class="flex items-center justify-between" href="https://pl.motorsport.com/">
+                    <div class="">
+                        <span class="text-4 leading-5 font text-menu-fg uppercase inline-block pb-2.5">Polska</span>
+                                                                            <span class="flex items-center gap-2.5">
+                                                                                                        <div>
+                                        <img src="https://cdn-1.motorsport.com/static/img/cf/pl-2.svg" alt="Polska" title="Polska" width="34" height="20" loading="lazy" aria-hidden="true">
+                                    </div>
+                                                            </span>
+                                            </div>
+
+                                            <svg class="block w-6 h-6 text-menu-fg transform-none rtl:transform rotate-180" aria-hidden="true">
+                            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#chevron-right"></use>
+                        </svg>
+                                    </a>
+            </li>
+                        </ul>
+</template>
+
+
+
+
+
+    <div class="ms-footer-fixbox hidden">
+        <div class="ms-footer-editions-messages">
+            
+
+<msnt-suggested-editions class="msnt-suggested-editions relative !hidden">
+    <template class="msnt-suggested-editions--main">
+        <div class="title mb-2.5 text-3.5 md:text-4">Available editions in your language</div>
+        <ul class="editions mb-5 p-0 w-full"></ul>
+
+        <div class="close"></div>
+
+        <div class="flex justify-center">
+            
+<button type="button" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--prime msnt-button--md w-auto uppercase italic ">
+        
+                    <span class="msnt-button__text inline ">Do not show again</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+        </div>
+    </template>
+    
+    <template class="msnt-suggested-editions--list">
+        <li class="border-b border-menu-divider-100 uppercase">
+            <a class="edition-link block text-fg-on-color-soft text-3.5 leading-4.5 p-2.5 no-underline" href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www#">
+                <div class="edition-title"></div>
+                <div class="edition-flags flex gap-1"></div>
+            </a>
+        </li>
+    </template>
+</msnt-suggested-editions>
+        </div>
+        <div class="ms-footer-messages"></div>
+    </div>
+
+    
+        
+
+        
+    <template id="msnt-dialog-tpl">
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center  msnt-dialog-transition-default" aria-label="" id="msnt-dialog">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full w-300 max-w-90vw bg-palette-bg-surface3 ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-6 pt-6 pb-3 ">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-titles-fg font-primary capitalize msnt-dialog__title">
+                                    
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ps-6 pt-3 pb-3">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full pe-6 ">
+                                </div>
+        </div>
+        
+                    <footer class="msnt-dialog__actions flex gap-6 flex-wrap px-6 pb-6 pt-3 justify-center">
+                                    
+<button type="button" data-action="ok" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--neutral msnt-button--md w-auto uppercase italic ">
+        
+                    <span class="msnt-button__text inline ">Ok</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+
+                    
+<button type="button" data-action="cancel" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--outline border msnt-button--md w-auto uppercase italic ">
+        
+                    <span class="msnt-button__text inline ">Cancel</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</button>
+                            </footer>
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+</template>
+<template id="msnt-dialog-auth-tpl">
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center  msnt-dialog-transition-default" aria-label="Authorization" id="msnt-dialog-auth">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface7 text-fg-on-color w-[400px] max-w-90vw">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-6 pt-6 pb-3 ">
+                                    
+<a href="https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&amp;utm_medium=referral&amp;utm_campaign=RSS-F1&amp;utm_term=News&amp;utm_content=www#" class="msnt-button group/button select-none relative appearance-none overflow-hidden inline-flex items-center whitespace-nowrap font-secondary font-bold msnt-button--ghost-on-dark msnt-button--sm w-auto uppercase italic msnt-dialog__back">
+            <svg class="w-5 h-5 -ms-1 " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#chevron-left"></use>
+        </svg>
+        
+                    <span class="msnt-button__text inline ">Back</span>
+                
+            
+    
+    <div class="msnt-button__overlay absolute inset-0 justify-center items-center hidden">
+        <svg class="w-5 h-5 animate-spin transform-none text-static-white fill-static-white " aria-hidden="true">
+            <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+        </svg>
+    </div>
+</a>
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-item-card-on-dark-heading font-primary capitalize msnt-dialog__title">
+                                    
+</h2>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--secondary min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ps-6 pt-3 pb-6">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full pe-6 ">
+                                </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+</template>
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center  msnt-dialog-transition-default" aria-label="Advertisement" id="msnt-dialog-exit-ad">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full bg-palette-bg-surface3 w-auto max-w-90vw">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center px-6 pt-6 pb-3 ">
+                                
+                                    
+<h3 class="msnt-heading text-4 leading-5 font-bold tracking-tight text-titles-fg font-primary capitalize msnt-dialog__title">
+                        Advertisement            
+</h3>
+                
+                <div class="flex items-center gap-2">
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ps-6 pt-3 pb-6">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full pe-6 ">
+                    <div class="ms-apb ms-apb-exit-ad "><div id="ads_6122441_MST_global_ExitAd_ExitAd_1770093040" class="ms-ap" data-id="23" data-ad-unit-id="/6122441/MST/global/ExitAd/ExitAd" style="width:300px;min-height:250px;" data-dfp-code="MST/global/ExitAd" data-sizes="300x250,300x600,970x250,320x480,480x320,336x280" data-width="300" data-height="250" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;ExitAd&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;ExitAd&quot;}" data-msnt-label="Advertisement"></div></div>            </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+                <template class="msnt-tray-alert__message-tpl" data-template-name="default">
+            <output class="msnt-tray-alert__message group/message pointer-events-auto" style="box-shadow:
+    0 18px 29px 0 rgb(0, 0, 0, 0.18),
+    0 6.57px 10.585px 0 rgb(0, 0, 0, 0.12),
+    0 3.19px 5.139px 0 rgb(0, 0, 0, 0.1),
+    0 1.564px 2.519px 0 rgb(0, 0, 0, 0.08),
+    0 0.618px 0.996px 0 rgb(0, 0, 0, 0.06);">
+                <div class="bg-surface-surface8 text-fg-on-color relative mb-px overflow-hidden font-secondary py-2 px-3 flex gap-3">
+                    <svg class="block w-8 h-8 min-w-8 self-center group-[.message]/message:text-static-success  group-[.error]/message:text-static-warning" data-slot="icon" aria-hidden="true"></svg>
+                    <div class="flex flex-col flex-1 gap-1">
+                        <h3 class="font-secondary text-4 leading-5 font-bold" data-slot="title"></h3>
+                        <p class="font-secondary text-body-lg" data-slot="message"></p>
+                    </div>
+                    <svg tabindex="0" role="button" class="block w-10 h-10 min-w-10 text-fg-on-color-soft p-2 cursor-pointer" data-action="close">
+                        <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+                    </svg>
+                </div>
+
+                <span class="absolute pointer-events-none inset-px border border-border-500"></span>
+            </output>
+        </template>
+    </msnt-tray-alert>
+<template id="msnt-styled-embed-tpl">
+    <div class="msnt-styled-embed relative flex flex-col gap-4 p-3 bg-bg-surface3 d:gap-6 d:p-6  ">
+        
+<h3 class="msnt-heading text-7 leading-8 font-bold tracking-tight text-titles-fg font-primary capitalize ">
+            <div class="inline-flex items-center gap-2 relative pb-3">
+
+            <span class="msnt-heading__title"></span>
+        
+                            <div class="w-5/6 h-1.5 absolute left-0.5 bottom-0 z-10 -skew-x-12 bg-titles-accent"></div>
+            
+                    
+        </div>
+    
+</h3>
+
+        <div class="msnt-styled-embed__content"></div>
+    </div>
+</template>
+<template id="msnt-vertical-gallery-dialog-tpl">
+<dialog class="msnt-dialog bg-transparent w-full h-full hidden open:flex items-center justify-center  msnt-dialog-transition-default m-0 max-w-none max-h-none msnt-dialog--with-ads" aria-label="Photo gallery " id="msnt-vertical-gallery-dialog">
+    <div class="msnt-dialog__wrapper flex flex-col max-h-full w-full h-full bg-palette-bg-surface3 ">
+                    <header class="msnt-dialog__header flex gap-6 justify-between items-center  p-3 d:fixed d:z-10 d:top-0 d:left-0 d:right-0">
+                                
+                                    
+<h2 class="msnt-heading text-6 leading-7 font-bold tracking-tight text-titles-fg font-primary capitalize msnt-dialog__title">
+                                    
+</h2>
+                
+                <div class="flex items-center gap-2">
+                     
+                        
+<button onclick="" type="button" data-action="fullscreen" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm msnt-icon-button--rounded-default hidden" title="Toggle fullscreen">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden group-[.active]:hidden" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#maximize"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 hidden group-[.wait]:hidden group-[.active]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-0-fc475fdbae9d0e8efa4a61e495f1e743.svg#minimize"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                                        
+                    
+<button onclick="" type="button" data-action="close" class="msnt-icon-button group inline-flex uppercase items-center justify-center cursor-pointer msnt-icon-button--no-fill msnt-icon-button--sm at-end msnt-icon-button--rounded-default " title="Close">
+
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 group-[.wait]:hidden " style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#x"></use>
+</svg>
+<svg class="msnt-svg-icon msnt-svg-icon--no-fill min-w-6 w-6 h-6 animate-spin transform-none hidden group-[.wait]:block" style="" aria-hidden="true">
+    <use xlink:href="https://www.motorsport.com/design/dist/critical/icons/sprite-common-1-3d95249d302790eb176ee8318a65f93e.svg#ms-spinner"></use>
+</svg>
+</button>
+                </div>
+            </header>
+                
+                        <div class="msnt-dialog__body flex-1 basis-auto overflow-auto overscroll-none ">
+                        <div class="msnt-dialog__content overflow-auto text-fg-default w-min min-w-full  pb-3 d:py-5 h-full">
+                                </div>
+        </div>
+        
+            </div>
+    
+    
+<msnt-tray-alert class="fixed pointer-events-none max-w-full overflow-auto block m-2 z-trayAlert top-0 right-0 " style="max-height: 50vh; width: 350px; ">
+        </msnt-tray-alert></dialog>
+</template>
+
+        <div class="ms-apb ms-apb-overlay "><div id="ads_6122441_MST_global_Overlay2_overlay2_1770093040" class="ms-ap" data-id="21" data-ad-unit-id="/6122441/MST/global/Overlay2/overlay2" style="width:0px;min-height:0px;" data-dfp-code="MST/global/Overlay2" data-width="0" data-height="0" data-dfp-attrs="{&quot;ms_banner_name&quot;:&quot;overlay2&quot;,&quot;msnt_env&quot;:&quot;production&quot;,&quot;ms_category&quot;:&quot;all&quot;,&quot;ms_series&quot;:&quot;f1&quot;,&quot;ms_edition&quot;:&quot;global&quot;,&quot;ms_lang&quot;:&quot;en&quot;,&quot;ms_page_type&quot;:&quot;detail&quot;,&quot;ms_page_content_type&quot;:&quot;article&quot;,&quot;ms_page_content_id&quot;:&quot;10793339&quot;,&quot;ms_event_id&quot;:&quot;662326&quot;,&quot;ms_author_id&quot;:&quot;4294&quot;,&quot;ms_location_id&quot;:&quot;70&quot;,&quot;ms_drivers&quot;:[&quot;827922&quot;],&quot;ms_teams&quot;:[&quot;4&quot;],&quot;ms_banner_position&quot;:&quot;overlay2&quot;}" data-msnt-label="Advertisement"></div></div>
+
+
+</body></html>

--- a/src/extractors/custom/index.js
+++ b/src/extractors/custom/index.js
@@ -199,3 +199,4 @@ export * from './www.ilfattoquotidiano.it';
 export * from './actualidad.rt.com';
 export * from './www.tweaktown.com';
 export * from './www.frandroid.com';
+export * from './www.motorsport.com';

--- a/src/extractors/custom/www.motorsport.com/index.js
+++ b/src/extractors/custom/www.motorsport.com/index.js
@@ -1,0 +1,36 @@
+export const WwwMotorsportComExtractor = {
+  domain: 'www.motorsport.com',
+
+  title: {
+    selectors: [['meta[name="og:title"]', 'value']],
+  },
+
+  author: {
+    selectors: ['.msnt-author-toolbar a[href*="/info/about-us/"]'],
+  },
+
+  date_published: {
+    selectors: [['meta[name="datePublished"]', 'value']],
+  },
+
+  dek: {
+    selectors: ['h2.text-article-description'],
+  },
+
+  lead_image_url: {
+    selectors: [['meta[name="og:image"]', 'value']],
+  },
+
+  content: {
+    selectors: ['.ms-article-content'],
+    transforms: {
+      h2: node => node.attr('class', 'mercury-parser-keep'),
+    },
+    clean: [
+      '.relatedContent',
+      '.ms-apb',
+      '.ms-ap-native',
+      '.outstream_partner',
+    ],
+  },
+};

--- a/src/extractors/custom/www.motorsport.com/index.test.js
+++ b/src/extractors/custom/www.motorsport.com/index.test.js
@@ -1,0 +1,80 @@
+import assert from 'assert';
+import * as cheerio from 'cheerio';
+
+import Parser from 'mercury';
+import getExtractor from 'extractors/get-extractor';
+import { excerptContent } from 'utils/text';
+
+const fs = require('fs');
+
+describe('WwwMotorsportComExtractor', () => {
+  describe('initial test case', () => {
+    let result;
+    let url;
+    beforeAll(() => {
+      url =
+        'https://www.motorsport.com/f1/news/very-unfortunate-isack-hadjar-crash-leaves-red-bull-undecided-on-third-f1-test-day/10793339/?utm_source=RSS&utm_medium=referral&utm_campaign=RSS-F1&utm_term=News&utm_content=www';
+      const html = fs.readFileSync(
+        './fixtures/www.motorsport.com/1770093049254.html'
+      );
+      result = Parser.parse(url, { html, fallback: false });
+    });
+
+    it('is selected properly', () => {
+      const extractor = getExtractor(url);
+      assert.strictEqual(extractor.domain, new URL(url).hostname);
+    });
+
+    it('returns the title', async () => {
+      const { title } = await result;
+
+      assert.strictEqual(
+        title,
+        `"Very unfortunate" Isack Hadjar crash leaves Red Bull undecided on third F1 test day`
+      );
+    });
+
+    it('returns the author', async () => {
+      const { author } = await result;
+
+      assert.strictEqual(author, 'Filip Cleeren');
+    });
+
+    it('returns the date_published', async () => {
+      const { date_published } = await result;
+
+      assert.strictEqual(date_published, `2026-01-27T20:16:22.000Z`);
+    });
+
+    it('returns the dek', async () => {
+      const { dek } = await result;
+
+      assert.strictEqual(
+        dek,
+        `Hadjar crashed his Red Bull RB22 on a treacherous wet second day of Formula 1's Barcelona shakedown`
+      );
+    });
+
+    it('returns the lead_image_url', async () => {
+      const { lead_image_url } = await result;
+
+      assert.strictEqual(
+        lead_image_url,
+        `https://cdn-2.motorsport.com/images/amp/01QdMbx0/s6/isack-hadjar-red-bull-racing.jpg`
+      );
+    });
+
+    it('returns the content', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      const first13 = excerptContent($('*').first().text(), 13);
+
+      assert.strictEqual(
+        first13,
+        'The Red Bull Formula 1 team is still evaluating its plans for a'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds custom parser for `www.motorsport.com` covering the new site template
- Pulls article fields from meta tags where possible (`og:title`, `og:image`, `datePublished`)
- Cleans inline ad placements (`.ms-apb`, `.ms-ap-native`, `.outstream_partner`) and the related-content sidebar
- Preserves embedded images and section/picture markup so image-heavy articles render with figures intact

References jocmp/capyreader#1725. Replaces the closed PR #110 from the prior `jc/motorsport.com` branch.

## Test plan
- [x] `npx jest src/extractors/custom/www.motorsport.com/index.test.js`