### PR TITLE
feat: Add actualidad.rt.com custom parser

### DIFF
--- a/fixtures/actualidad.rt.com/1781468121405.html
+++ b/fixtures/actualidad.rt.com/1781468121405.html
@@ -1,0 +1,652 @@
+<!DOCTYPE html><html prefix="og: http://ogp.me/ns#" lang="es"><head>
+		
+		<meta charset="UTF-8">
+		<meta name="viewport" value="width=device-width, initial-scale=1.0, user-scalable=yes">
+		<meta http-equiv="X-UA-Compatible" value="ie=edge">
+		<meta name="apple-mobile-web-app-capable" value="no">
+		<meta name="format-detection" value="telephone=yes">
+		<meta name="HandheldFriendly" value="true">
+		<meta name="MobileOptimzied" value="width">
+		<meta http-equiv="Content-Security-Policy" value="upgrade-insecure-requests">
+		<meta http-equiv="cleartype" value="on">
+		<meta name="navigation" value="tabbed">
+		<meta value="RT en Español" name="og:site_name">
+		<meta value="1208719029" name="fb:admins">
+		<meta value="272487402772119" name="fb:app_id">
+		<meta value="296334033272,1617180398564925,137254146931398,517943768564992,438569186541152,983067238497760,748645601988049" name="fb:pages">
+		<meta name="robots" value="max-snippet:-1, max-image-preview:large">
+		<meta name="theme-color" media="(prefers-color-scheme: light)" value="#ffffff">
+		<meta name="theme-color" media="(prefers-color-scheme: dark)" value="#161618">
+
+		<title>Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición - RT</title>
+
+					<meta name="description" value="Amir Saeid Iravani denunció que &quot;las acciones de EE.UU. contradicen flagrantemente sus objetivos declarados y solo han servido para intensificar las tensiones&quot;.">
+		
+		<meta name="google-site-verification" value="NSXcARMfqMVdr_6SIvsk-wyen25_5U-zwm4EJqv5bKM">
+		<meta name="apple-itunes-app" value="app-id=649316948, app-argument=spanishrtnews://articles/603743">
+
+
+		
+		<link rel="preconnect" href="https://graph.facebook.com/" crossorigin="anonymous">
+<link rel="preconnect" href="https://mc.yandex.ru/" crossorigin="anonymous">
+<link rel="preconnect" href="https://counter.yadro.ru/" crossorigin="anonymous">		<link as="style" href="https://sf.esrt.site/static/build/css/main.9e55aa80.chunk.css" rel="preload">
+<link as="script" href="https://sf.esrt.site/static/build/js/35.65cf0274.chunk.js" rel="preload">
+<link as="script" href="https://sf.esrt.site/static/build/js/main.701fc6da.chunk.js" rel="preload"><link rel="dns-prefetch" href="https://connect.ok.ru/">
+					<meta value="article" name="og:type">
+					<meta value="https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion" name="og:url">
+					<meta value="Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición" name="og:title">
+		
+					<meta value="RT en Español" name="article:author">
+							<meta value="Amir Saeid Iravani denunció que &quot;las acciones de EE.UU. contradicen flagrantemente sus objetivos declarados y solo han servido para intensificar las tensiones&quot;." name="og:description">
+										<meta value="2026-05-07T22:03:26Z" name="article:modified_time">
+										<meta value="Actualidad" name="article:section">
+					
+		
+									<meta name="publish-date" value="2026-05-07 22:03:26">
+					
+		
+		        <link rel="amphtml" href="https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion/amp">
+    
+									<link rel="canonical" href="https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion">
+					
+		    <meta name="twitter:site" value="@ActualidadRT">
+    <meta name="twitter:card" value="summary_large_image">
+    <meta name="twitter:description" value="Amir Saeid Iravani denunció que &quot;las acciones de EE.UU. contradicen flagrantemente sus objetivos declarados y solo han servido para intensificar las tensiones&quot;.">
+    <meta name="twitter:image:width" value="630">
+    <meta name="twitter:image:height" value="354">
+            <meta name="twitter:image" value="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fcfeb1e9ff710ff61e5ff9.jpg">
+                <meta name="published_time_telegram" value="2026-05-07T22:03:26+00:00">
+    
+									<meta name="mediator_published_time" value="2026-05-07T22:03:26+00:00">
+					
+					<meta value="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fcfeb1e9ff710ff61e5ff9.jpg" name="og:image">
+		
+						
+
+		<link rel="manifest" href="https://actualidad.rt.com/manifest.webmanifest">
+		<link href="https://plus.google.com/117205813728682314068" rel="publisher">
+		<link rel="shortcut icon" href="https://actualidad.rt.com/favicon.ico" type="image/x-icon">
+		<link rel="icon" href="https://actualidad.rt.com/favicon.ico" type="image/x-icon">
+		<link rel="apple-touch-icon" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-precomposed.png">
+		<link rel="apple-touch-icon" sizes="72x72" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-72x72-precomposed.png">
+		<link rel="apple-touch-icon" sizes="114x114" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-114x114-precomposed.png">
+		<link rel="apple-touch-icon" sizes="144x144" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-144x144-precomposed.png">
+
+
+				    <link as="style" href="https://sf.esrt.site/static/css/custom.css?v=2" rel="preload">
+    <link href="https://sf.esrt.site/static/css/custom.css?v=2" rel="stylesheet">
+    
+    <link href="https://sf.esrt.site/static/build/css/main.9e55aa80.chunk.css" rel="stylesheet">
+
+		
+
+				
+				    
+    
+    
+
+			
+
+			
+			
+
+			
+	</head>
+
+
+		<body class="Theme-isDefault" data-nav="false"> 				
+
+		    <div class="ReadLine-isReact" data-rtcomponent="ReadLine"></div>
+
+		<div class="App-root App-isColumn-isCenter">
+							<div class="App-header App-isColumn-isCenter" id="app-header">
+					
+
+<header class="Header-root Header-white" id="header-root" data-module="Header" data-color="true"><div class="Header-logo"><a href="https://actualidad.rt.com/" class="Header-RT" aria-label="Home"><span class="Header-logoImage"><svg class="Icon-root Icon-rtLogo" width="64px" height="64px" fill="#77BC1F" version="1.1" viewBox="0 0 56 56" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><rect width="56" height="56"></rect><path d="m1 0h54c0.55228-1.0145e-16 1 0.44772 1 1v54c0 0.55228-0.44772 1-1 1h-54c-0.55228 0-1-0.44772-1-1v-54c-6.7635e-17 -0.55228 0.44772-1 1-1z"></path><g transform="translate(8 20)" fill="#000"><polygon points="24.372 0.32996 24.372 2.3017 31.843 2.3017 31.843 17 40.53 17 40.53 2.3017 48 2.3017 48 0.32996"></polygon><path d="m12.907 7.8584c0.66346 0 1.2681-0.28214 1.7137-0.76234 0.47758-0.51014 0.76946-1.2094 0.76946-1.9264h-0.003977 0.003977c0-0.71699-0.29188-1.5059-0.76946-2.0165-0.44559-0.47895-1.0503-0.85143-1.7137-0.85143h-3.5163v5.5567h3.5163zm7.0223-7.5284c1.1876 0.046067 2.298 0.4535 3.0839 1.2933 0.81597 0.88441 1.3622 2.1124 1.3622 3.5464h0.0065706-0.0065706c0 1.2547-0.50646 2.4435-1.3223 3.3198-0.50923 0.54545-1.1267 0.93836-1.8244 1.1771l5.1548 7.3334h-9.4655l-4.592-6.9907h-2.9354v6.9907h-8.6456v-16.67h19.184z"></path></g></g></svg></span></a></div><div class="header--notification">El canal internacional<br>de noticias en español<br>más visto en el mundo</div><div class="Header-enVivo"><a href="https://actualidad.rt.com/en_vivo" class="Link-root Link-isEnVivo">En vivo</a></div><div class="Header-nav"><nav class="MainMenu-root"><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/todas_las_noticias" class="Link-root Link-isHover">Noticias</a></div><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/viral" class="Link-root Link-isHover">Viral</a></div><div class="MainMenu-itemMenu MainMenu-itemSubMenu" tabindex="0"><a href="https://actualidad.rt.com/programas" class="Link-root Link-hasDownIcon MainMenu-linkDesktop">
+                        Programas
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></a><input type="checkbox" name="menu" class="MainMenu-input" id="programas" aria-label="programas"><label class="Link-root Link-hasDownIcon MainMenu-linkMobile" for="programas">
+                        Programas
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></label><div class="MainMenu-subMenu"><div class="MainMenu-subList"><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/rt_reporta" class="Link-root Link-isNoHover">RT reporta</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://www.ahilesva.info/" class="Link-root Link-isNoHover">Ahí les Va</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/conversando-correa" class="Link-root Link-isNoHover">Conversando con Correa</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/cartas-mesa" class="Link-root Link-isNoHover">Cartas sobre la mesa</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/documentales" class="Link-root Link-isNoHover">Documentales</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/africa-lumumba" class="Link-root Link-isNoHover">El África de Lumumba</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/zoom" class="Link-root Link-isNoHover">El Zoom</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/zoom_plus" class="Link-root Link-isNoHover">ZOOM+</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/entrevista" class="Link-root Link-isNoHover">Entrevista</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/codigo-abierto" class="Link-root Link-isNoHover">Código Abierto</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/impacto-directo" class="Link-root Link-isNoHover">Impacto Directo</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/la_lista_de_erick" class="Link-root Link-isNoHover">La lista de Erick</a></div></div></div></div></div><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/opinion" class="Link-root Link-isHover">Opinión</a></div><div class="MainMenu-itemMenu MainMenu-itemSubMenu" tabindex="0"><a href="https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion#" class="Link-root Link-hasDownIcon MainMenu-linkDesktop">
+                        Multimedia
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></a><input type="checkbox" name="menu" class="MainMenu-input" id="multimedia" aria-label="multimedia"><label class="Link-root Link-hasDownIcon MainMenu-linkMobile" for="multimedia">
+                        Multimedia
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></label><div class="MainMenu-subMenu"><div class="MainMenu-subList"><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/video" class="Link-root Link-isNoHover">Videos</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/promo" class="Link-root Link-isNoHover">Promo</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/comics" class="Link-root Link-isNoHover">Osografía</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/falso-real-ia" class="Link-root Link-isNoHover">Falso o real</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/palabra_secreta" class="Link-root Link-isNoHover">Palabra secreta</a></div></div></div></div></div><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/acerca/equipo" class="Link-root Link-isHover">Equipo de RT</a></div></nav><div class="MainMenu-mobile MainMenu-socials"><ul class="Socials-root"><li class="Socials-item Socials-VkIcon"><a href="https://vk.com/actualidadrt" class="Link-root Link-socials" target="_blank" aria-label="VkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-vk" height="13px" fill="#141414" version="1.1" viewBox="0 0 22 13" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -10)"><path d="m26.16 11.013c0.16-0.49333 0-0.85333-0.69333-0.85333h-2.32c-0.44243-0.020208-0.84913 0.242-1.0133 0.65333-0.72722 1.7134-1.6923 3.3159-2.8667 4.76-0.53333 0.53333-0.78667 0.72-1.08 0.72-0.29333 0-0.36-0.18667-0.36-0.68v-4.6133c0-0.58667-0.18667-0.85333-0.68-0.85333h-3.6533c-0.14856-0.0072434-0.29391 0.044915-0.40397 0.14497s-0.17579 0.23978-0.1827 0.38836c0 0.56 0.84 0.70667 0.93333 2.28v3.4267c0 0.74667-0.13333 0.88-0.42667 0.88-0.8 0-2.6667-2.9067-3.8533-6.2267-0.22667-0.65333-0.45333-0.89333-1.04-0.89333h-2.3467c-0.68 0-0.78667 0.30667-0.78667 0.65333 0 0.6 0.78667 3.6667 3.6667 7.72 1.5436 2.4836 4.1889 4.0718 7.1067 4.2667 1.48 0 1.6667-0.34667 1.6667-0.90667v-2.0933c0-0.68 0.13333-0.78667 0.61333-0.78667s0.94667 0.17333 2.32 1.5067c1.5733 1.5733 1.84 2.2933 2.6667 2.2933h2.32c0.68 0 1-0.33333 0.81333-0.98667-0.50005-0.99197-1.1625-1.8933-1.96-2.6667-0.54667-0.64-1.3333-1.3333-1.6-1.68-0.26667-0.34667-0.25333-0.62667 0-1.0267 0 0 2.8133-4 3.1067-5.3333"></path></g></g></svg></a></li><li class="Socials-item Socials-Rumble"><a href="https://rumble.com/c/RTES" class="Link-root Link-socials" target="_blank" aria-label="Rumble" rel="noopener noreferrer"><svg class="Icon-root Icon-rumble" width="18" height="19.773768216516" fill="#141414" xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="0 0 1441 1583"><path id="Layer" fill-rule="evenodd" d="m1339.3 537.2c32.1 35.2 57.5 75.9 74.8 120.3 17.2 44.4 26.1 91.5 26.2 139.2 0.1 47.6-8.6 94.8-25.7 139.2-17.1 44.4-42.3 85.3-74.3 120.6-57.2 63.1-119 121.9-184.9 175.9-65.9 54-135.7 103-208.9 146.7-73.1 43.6-149.4 81.8-228.2 114.2-78.8 32.4-159.9 59-242.6 79.4-42.2 10.6-86.1 12.9-129.1 6.8-43.1-6.1-84.6-20.4-122.2-42.3-37.7-21.8-70.7-50.7-97.4-85-26.6-34.4-46.4-73.6-58.2-115.4-100.4-343-85.6-730.8 11.2-1075.3 51-180.9 221.3-294.5 396.7-252.7 324.8 77.4 629.6 276.7 862.6 528.4zm-457.3 356.2c61.2-48.4 61.2-142.7 0-192.6q-32.6-27.1-66.8-52.1-34.2-25.1-69.9-48-35.6-22.9-72.6-43.7-37-20.7-75.2-39.2c-70.3-33.6-148.8 13.3-160.1 93.3-17.3 122.3-20.4 245.6-9.1 362.8 7.6 81.1 85.1 129.5 156.5 98.4q39.9-17.2 78.6-37 38.7-19.8 76-42.2 37.3-22.4 73-47.2 35.7-24.8 69.6-52z"></path></svg></a></li><li class="Socials-item Socials-XIcon"><a href="https://x.com/ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="XIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-x" fill="#141414" version="1.1" viewBox="0 0 24 24" width="18" height="18" xmlns="https://www.w3.org/2000/svg"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg></a></li><li class="Socials-item Socials-TelegramIcon"><a href="https://telegram.me/rtnoticias" class="Link-root Link-socials" target="_blank" aria-label="TelegramIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-telegram" height="16px" fill="#141414" version="1.1" viewBox="0 0 20 16" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -8)"><path d="m24.798 8.8742v-0.084507c0.021962-0.35088-0.19811-0.67117-0.53226-0.77465-0.12528-0.020023-0.25291-0.020023-0.37818 0-0.41728-0.009814-0.83209 0.066897-1.2186 0.22535-1.2186 0.45071-2.4232 0.92958-3.6278 1.4085l-2.4512 0.87324-1.1065 0.46479-1.3166 0.5493-1.2466 0.53521c-1.6341 0.68545-3.2589 1.4038-4.8744 2.1549-0.70034 0.33803-1.4007 0.67606-2.073 1.0563-0.10024 0.054347-0.19029 0.12584-0.26613 0.21127-0.068477 0.066368-0.10716 0.15789-0.10716 0.25352s0.038685 0.18715 0.10716 0.25352c0.071194 0.080837 0.15668 0.1477 0.25212 0.19718 0.14189 0.093286 0.29192 0.17343 0.44822 0.23944 0.66227 0.30344 1.3458 0.55764 2.045 0.76056 0.49383 0.17864 1.0059 0.30146 1.5267 0.3662 0.58774 0.065441 1.181-0.057813 1.6948-0.35211 0.75637-0.43193 1.4987-0.90141 2.2271-1.4085 1.2606-0.83099 2.5072-1.7183 3.7398-2.5916 0.44956-0.34416 0.91712-0.66387 1.4007-0.95775 0.14179-0.1018 0.29748-0.18245 0.46223-0.23944 0.0693-0.014425 0.1408-0.014425 0.2101 0 0.11205 0 0.16808 0 0.15408 0.16901-0.0049925 0.14954-0.059181 0.2932-0.15408 0.40845-0.4062 0.42254-0.8124 0.84507-1.2326 1.2535-0.84041 0.80282-1.7088 1.5634-2.5492 2.3521l-1.4007 1.2817c-0.24176 0.22419-0.43282 0.49797-0.56027 0.80282-0.087561 0.19393-0.12143 0.40804-0.098048 0.61972 0.032149 0.24791 0.16373 0.47181 0.36418 0.61972l0.71435 0.50704 5.1825 3.5211 0.30815 0.21127c0.43391 0.27815 0.97867 0.31543 1.4461 0.098957 0.46738-0.21647 0.79328-0.65701 0.86507-1.1694l0.42021-2.3944 0.42021-2.5634c0.15408-0.88733 0.29414-1.7747 0.43421-2.662 0.11205-0.64789 0.2101-1.2958 0.30815-1.9437l0.37818-2.7324c0-0.50704 0.056027-1.0141 0.084041-1.5211z"></path></g></g></svg></a></li><li class="Socials-item Socials-BlueSky"><a href="https://bsky.app/profile/actualidadrt.bsky.social" class="Link-root Link-socials" target="_blank" aria-label="BlueSky" rel="noopener noreferrer"><svg class="Icon-root Icon-blueSky" width="20" height="17.666666666667" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" version="1.1"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"></path></svg></a></li><li class="Socials-item Socials-OkIcon"><a href="https://ok.ru/group/70000046273774" class="Link-root Link-socials" target="_blank" aria-label="OkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-ok" width="25" height="25" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" version="1.1"><path d="M100.1 99.2C109.8 99.2 118.6 95.2 124.9 88.9C131.2 82.6 135.2 73.8 135.2 64.1C135.2 54.4 131.2 45.6 124.9 39.3C118.6 33 109.8 29 100.1 29C90.3999 29 81.5999 33 75.2999 39.3C68.9999 45.5 64.9999 54.3 64.9999 64.1C64.9999 73.9 68.9999 82.6 75.2999 88.9C81.5999 95.2 90.4999 99.2 100.1 99.2ZM88.8999 52.7C91.7999 49.8 95.7999 48 100.2 48C104.7 48 108.6 49.8 111.5 52.7C114.4 55.6 116.2 59.6 116.2 64C116.2 68.5 114.4 72.4 111.5 75.3C108.6 78.2 104.6 80 100.2 80C95.6999 80 91.7999 78.2 88.8999 75.3C85.9999 72.4 84.1999 68.4 84.1999 64C84.1999 59.6 86.0999 55.6 88.8999 52.7Z"></path><path d="M147.5 113.4L137.2 99.3C136.6 98.5 135.4 98.4 134.7 99.1C125 107.4 113 112.8 100.1 112.8C87.2 112.8 75.3 107.4 65.5 99.1C64.8 98.5 63.6 98.6 63 99.3L52.7 113.4C52.2 114.1 52.3 115 52.9 115.6C61.6 122.6 71.7 127.4 82.2 129.9L60.4 168.3C59.8 169.4 60.6 170.8 61.8 170.8H83.1C83.8 170.8 84.4 170.4 84.6 169.7L99.8 135.7L115 169.7C115.2 170.3 115.8 170.8 116.5 170.8H137.8C139.1 170.8 139.8 169.5 139.2 168.3L117.4 129.9C127.9 127.4 138 122.8 146.7 115.6C148 115 148.1 114.1 147.5 113.4Z"></path></svg></a></li><li class="Socials-item Socials-feedback"><div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022icon\u0022'),
+    };"></div></li></ul></div><div class="MainMenu-mobile MainMenu-onTv"><a href="https://actualidad.rt.com/satelites" class="Link-root Link-isOnTv">Véanos en TV</a></div></div><div class="Header-search"><div class="Search-isReact" data-rtcomponent="Search"></div></div><div class="Header-onTv"><a href="https://actualidad.rt.com/satelites" class="Link-root Link-isOnTv">Véanos en TV</a></div><div class="Header-socials"><ul class="Socials-root"><li class="Socials-item Socials-VkIcon"><a href="https://vk.com/actualidadrt" class="Link-root Link-socials" target="_blank" aria-label="VkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-vk" height="13px" fill="#141414" version="1.1" viewBox="0 0 22 13" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -10)"><path d="m26.16 11.013c0.16-0.49333 0-0.85333-0.69333-0.85333h-2.32c-0.44243-0.020208-0.84913 0.242-1.0133 0.65333-0.72722 1.7134-1.6923 3.3159-2.8667 4.76-0.53333 0.53333-0.78667 0.72-1.08 0.72-0.29333 0-0.36-0.18667-0.36-0.68v-4.6133c0-0.58667-0.18667-0.85333-0.68-0.85333h-3.6533c-0.14856-0.0072434-0.29391 0.044915-0.40397 0.14497s-0.17579 0.23978-0.1827 0.38836c0 0.56 0.84 0.70667 0.93333 2.28v3.4267c0 0.74667-0.13333 0.88-0.42667 0.88-0.8 0-2.6667-2.9067-3.8533-6.2267-0.22667-0.65333-0.45333-0.89333-1.04-0.89333h-2.3467c-0.68 0-0.78667 0.30667-0.78667 0.65333 0 0.6 0.78667 3.6667 3.6667 7.72 1.5436 2.4836 4.1889 4.0718 7.1067 4.2667 1.48 0 1.6667-0.34667 1.6667-0.90667v-2.0933c0-0.68 0.13333-0.78667 0.61333-0.78667s0.94667 0.17333 2.32 1.5067c1.5733 1.5733 1.84 2.2933 2.6667 2.2933h2.32c0.68 0 1-0.33333 0.81333-0.98667-0.50005-0.99197-1.1625-1.8933-1.96-2.6667-0.54667-0.64-1.3333-1.3333-1.6-1.68-0.26667-0.34667-0.25333-0.62667 0-1.0267 0 0 2.8133-4 3.1067-5.3333"></path></g></g></svg></a></li><li class="Socials-item Socials-Rumble"><a href="https://rumble.com/c/RTES" class="Link-root Link-socials" target="_blank" aria-label="Rumble" rel="noopener noreferrer"><svg class="Icon-root Icon-rumble" width="18" height="19.773768216516" fill="#141414" xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="0 0 1441 1583"><path id="Layer" fill-rule="evenodd" d="m1339.3 537.2c32.1 35.2 57.5 75.9 74.8 120.3 17.2 44.4 26.1 91.5 26.2 139.2 0.1 47.6-8.6 94.8-25.7 139.2-17.1 44.4-42.3 85.3-74.3 120.6-57.2 63.1-119 121.9-184.9 175.9-65.9 54-135.7 103-208.9 146.7-73.1 43.6-149.4 81.8-228.2 114.2-78.8 32.4-159.9 59-242.6 79.4-42.2 10.6-86.1 12.9-129.1 6.8-43.1-6.1-84.6-20.4-122.2-42.3-37.7-21.8-70.7-50.7-97.4-85-26.6-34.4-46.4-73.6-58.2-115.4-100.4-343-85.6-730.8 11.2-1075.3 51-180.9 221.3-294.5 396.7-252.7 324.8 77.4 629.6 276.7 862.6 528.4zm-457.3 356.2c61.2-48.4 61.2-142.7 0-192.6q-32.6-27.1-66.8-52.1-34.2-25.1-69.9-48-35.6-22.9-72.6-43.7-37-20.7-75.2-39.2c-70.3-33.6-148.8 13.3-160.1 93.3-17.3 122.3-20.4 245.6-9.1 362.8 7.6 81.1 85.1 129.5 156.5 98.4q39.9-17.2 78.6-37 38.7-19.8 76-42.2 37.3-22.4 73-47.2 35.7-24.8 69.6-52z"></path></svg></a></li><li class="Socials-item Socials-XIcon"><a href="https://x.com/ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="XIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-x" fill="#141414" version="1.1" viewBox="0 0 24 24" width="18" height="18" xmlns="https://www.w3.org/2000/svg"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg></a></li><li class="Socials-item Socials-TelegramIcon"><a href="https://telegram.me/rtnoticias" class="Link-root Link-socials" target="_blank" aria-label="TelegramIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-telegram" height="16px" fill="#141414" version="1.1" viewBox="0 0 20 16" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -8)"><path d="m24.798 8.8742v-0.084507c0.021962-0.35088-0.19811-0.67117-0.53226-0.77465-0.12528-0.020023-0.25291-0.020023-0.37818 0-0.41728-0.009814-0.83209 0.066897-1.2186 0.22535-1.2186 0.45071-2.4232 0.92958-3.6278 1.4085l-2.4512 0.87324-1.1065 0.46479-1.3166 0.5493-1.2466 0.53521c-1.6341 0.68545-3.2589 1.4038-4.8744 2.1549-0.70034 0.33803-1.4007 0.67606-2.073 1.0563-0.10024 0.054347-0.19029 0.12584-0.26613 0.21127-0.068477 0.066368-0.10716 0.15789-0.10716 0.25352s0.038685 0.18715 0.10716 0.25352c0.071194 0.080837 0.15668 0.1477 0.25212 0.19718 0.14189 0.093286 0.29192 0.17343 0.44822 0.23944 0.66227 0.30344 1.3458 0.55764 2.045 0.76056 0.49383 0.17864 1.0059 0.30146 1.5267 0.3662 0.58774 0.065441 1.181-0.057813 1.6948-0.35211 0.75637-0.43193 1.4987-0.90141 2.2271-1.4085 1.2606-0.83099 2.5072-1.7183 3.7398-2.5916 0.44956-0.34416 0.91712-0.66387 1.4007-0.95775 0.14179-0.1018 0.29748-0.18245 0.46223-0.23944 0.0693-0.014425 0.1408-0.014425 0.2101 0 0.11205 0 0.16808 0 0.15408 0.16901-0.0049925 0.14954-0.059181 0.2932-0.15408 0.40845-0.4062 0.42254-0.8124 0.84507-1.2326 1.2535-0.84041 0.80282-1.7088 1.5634-2.5492 2.3521l-1.4007 1.2817c-0.24176 0.22419-0.43282 0.49797-0.56027 0.80282-0.087561 0.19393-0.12143 0.40804-0.098048 0.61972 0.032149 0.24791 0.16373 0.47181 0.36418 0.61972l0.71435 0.50704 5.1825 3.5211 0.30815 0.21127c0.43391 0.27815 0.97867 0.31543 1.4461 0.098957 0.46738-0.21647 0.79328-0.65701 0.86507-1.1694l0.42021-2.3944 0.42021-2.5634c0.15408-0.88733 0.29414-1.7747 0.43421-2.662 0.11205-0.64789 0.2101-1.2958 0.30815-1.9437l0.37818-2.7324c0-0.50704 0.056027-1.0141 0.084041-1.5211z"></path></g></g></svg></a></li><li class="Socials-item Socials-BlueSky"><a href="https://bsky.app/profile/actualidadrt.bsky.social" class="Link-root Link-socials" target="_blank" aria-label="BlueSky" rel="noopener noreferrer"><svg class="Icon-root Icon-blueSky" width="20" height="17.666666666667" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" version="1.1"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"></path></svg></a></li><li class="Socials-item Socials-OkIcon"><a href="https://ok.ru/group/70000046273774" class="Link-root Link-socials" target="_blank" aria-label="OkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-ok" width="25" height="25" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" version="1.1"><path d="M100.1 99.2C109.8 99.2 118.6 95.2 124.9 88.9C131.2 82.6 135.2 73.8 135.2 64.1C135.2 54.4 131.2 45.6 124.9 39.3C118.6 33 109.8 29 100.1 29C90.3999 29 81.5999 33 75.2999 39.3C68.9999 45.5 64.9999 54.3 64.9999 64.1C64.9999 73.9 68.9999 82.6 75.2999 88.9C81.5999 95.2 90.4999 99.2 100.1 99.2ZM88.8999 52.7C91.7999 49.8 95.7999 48 100.2 48C104.7 48 108.6 49.8 111.5 52.7C114.4 55.6 116.2 59.6 116.2 64C116.2 68.5 114.4 72.4 111.5 75.3C108.6 78.2 104.6 80 100.2 80C95.6999 80 91.7999 78.2 88.8999 75.3C85.9999 72.4 84.1999 68.4 84.1999 64C84.1999 59.6 86.0999 55.6 88.8999 52.7Z"></path><path d="M147.5 113.4L137.2 99.3C136.6 98.5 135.4 98.4 134.7 99.1C125 107.4 113 112.8 100.1 112.8C87.2 112.8 75.3 107.4 65.5 99.1C64.8 98.5 63.6 98.6 63 99.3L52.7 113.4C52.2 114.1 52.3 115 52.9 115.6C61.6 122.6 71.7 127.4 82.2 129.9L60.4 168.3C59.8 169.4 60.6 170.8 61.8 170.8H83.1C83.8 170.8 84.4 170.4 84.6 169.7L99.8 135.7L115 169.7C115.2 170.3 115.8 170.8 116.5 170.8H137.8C139.1 170.8 139.8 169.5 139.2 168.3L117.4 129.9C127.9 127.4 138 122.8 146.7 115.6C148 115 148.1 114.1 147.5 113.4Z"></path></svg></a></li><li class="Socials-item Socials-feedback"><div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022icon\u0022'),
+    };"></div></li></ul></div><div class="Header-langSelect"><div class="LangSelect-root" tabindex="0"><div class="LangSelect-selected">
+            Esp
+        </div><ul class="LangSelect-options"><li class="LangSelect-option "><a href="https://rtbrasil.com/" target="_blank" rel="noopener noreferrer">Br</a></li><li class="LangSelect-option "><a href="https://arabic.rt.com/" target="_blank" rel="noopener noreferrer">Ar</a></li><li class="LangSelect-option "><a href="https://de.rt.com/" target="_blank" rel="noopener noreferrer">De</a></li><li class="LangSelect-option "><a href="https://swentr.site/" target="_blank" rel="noopener noreferrer">En</a></li><li class="LangSelect-option LangSelect-isSelect"><a href="https://actualidad.rt.com/" target="_blank" rel="noopener noreferrer">Esp</a></li><li class="LangSelect-option "><a href="https://francais.rt.com/" target="_blank" rel="noopener noreferrer">Fr</a></li><li class="LangSelect-option "><a href="https://rt.rs/" target="_blank" rel="noopener noreferrer">Rs</a></li><li class="LangSelect-option "><a href="https://russian.rt.com/" target="_blank" rel="noopener noreferrer">Ru</a></li></ul></div></div><div class="Header-menuToggle"><button class="Header-item" type="button" id="nav-close" aria-label="Burger"><svg class="Icon-root Icon-burger Icon-burger_open" width="16px" height="16px" fill="#141414" version="1.1" viewBox="0 0 16 12" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-382 -18)"><g transform="translate(382 18)"><rect width="16" height="1.7143"></rect><rect y="5.1429" width="16" height="1.7143"></rect><rect y="10.286" width="16" height="1.7143"></rect></g></g></g></svg><svg class="Icon-root Icon-burger Icon-burger_close" width="16px" height="16px" fill="#141414" version="1.1" viewBox="0 0 12 12" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-384 -16)"><g transform="translate(384 16)"><polygon transform="translate(5.996 5.9918) rotate(225) translate(-5.996 -5.9918)" points="-1.1646 5.1481 13.157 5.1481 13.157 6.8356 -1.1646 6.8356"></polygon><polygon transform="translate(6.0082 5.996) rotate(-45) translate(-6.0082 -5.996)" points="-1.1525 5.1523 13.169 5.1523 13.169 6.8398 -1.1525 6.8398"></polygon></g></g></g></svg></button></div></header>					
+											<div class="Breaking-root Breaking-red" data-newsline-has-alias=""><li class="Breaking-item"><a class="Breaking-link" href="https://actualidad.rt.com/actualidad/610987-iran-culpa-eeuu-violacion-alto-fuego">
+                                            Irán culpa a EE.UU. por la violación del alto el fuego por parte de Israel en el Líbano
+                                    </a></li></div>
+
+									</div>
+			
+			
+
+						    <div class="TopBanner-root top-banners-with-mobile">
+                
+                    <div id="adfox_163033544650936060" style="margin: 0 auto; max-width: 1488px; width: 100%;"></div>
+        <div id="adfox_163033548998539595" style="margin: 0 auto; max-width: 1488px; width: 100%;"></div>
+        
+    
+    
+        </div>
+			
+
+			    <main class="App-content">
+        <div class="Grid-root">
+            <div class="Grid-title Grid-isSticky">
+                        
+                                                                                
+            
+                                                                        
+            
+            <div class="HeaderVertical-root HeaderVertical-type_1 ColorTxt-WhiteSmoke">
+                Actualidad
+            </div>
+            
+            </div>
+            <section class="Grid-container Grid-isWrap">
+                <div class="Grid-block Grid-is3to4-sm_is1to1-xs_is1to1">
+                                        <div class="Section-root Section-is1to1">
+                        <div class="Section-container Section-isRow-isTop">
+                            <div class="Section-block Section-is1to1 pr-24 pl-24 pt-24 pb-4">
+                                
+<div class="Breadcrumbs-root"><span class="Breadcrumbs-item"><a class="RTLink-root RTLink-breadcrumb RTLink-size_1" href="https://actualidad.rt.com/"><span>Portada</span></a></span><span class="Breadcrumbs-item Breadcrumbs-arrow"><svg width="6px" height="10px" fill="#888"><use xlink:href="https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion#arrowRight"></use></svg></span><span class="Breadcrumbs-item"><a class="RTLink-root RTLink-breadcrumb RTLink-size_1" href="https://actualidad.rt.com/actualidad"><span>Actualidad</span></a></span></div>                            </div>
+                        </div>
+                    </div>
+
+                    <div class="Section-root Section-is1to1">
+                        <div class="Section-container Section-isRow-isTop">
+                            <div class="Section-block Section-is1to1">
+                                                                
+
+
+
+
+
+
+
+
+
+
+<div class="ArticleView-root ArticleView-is1to1"><div class="ArticleView-container" data-counterurl="https://nbc.rt.com/nbc/es/" data-counterpublicid="603743"><div class="ArticleView-block ArticleView-is1to1-sm_is1to1-xs_is1to1 p-24"><div class="ArticleView-title"><h1 class="HeadLine-root HeadLine-type_2 ">
+                Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición
+            </h1></div><div class="ArticleView-timestamp-and-authors"><div class="ArticleView-authors"></div><div class="ArticleView-timestamp"><span>Publicado:</span><time class="Timestamp-root Timestamp-isBlackColor " datetime="2026-05-07T22:03:26+00:00">
+        7 may 2026 22:03 GMT
+    </time></div></div><div class="ArticleView-shares"><div class="ShareBlock-isReact" data-rtcomponent="ShareBlock" onload="return {
+        socials: JSON.parse('\u005B\u0022facebook\u0022,\u0022xtwitter\u0022,\u0022whatsapp\u0022,\u0022telegram\u0022,\u0022mailto\u0022,\u0022copylink\u0022\u005D'),
+        direction: JSON.parse('\u0022column\u0022'),
+        type: JSON.parse('\u0022hasFull\u0022'),
+        params: JSON.parse('\u007B\u0022counters\u0022\u003Atrue,\u0022href\u0022\u003A\u0022https\u003A\\\/\\\/actualidad.rt.com\\\/actualidad\\\/603743\u002Diran\u002Dafirma\u002Donu\u002Dgarantizara\u002Dnavegacion\u0022,\u0022shortUrl\u0022\u003A\u0022https\u003A\\\/\\\/es\u002Drt.com\\\/cxun\u0022\u007D'),
+    };"></div></div><div class="ArticleView-summary"><div class="Text-root Text-type_1 ">
+                Amir Saeid Iravani denunció que "las acciones de EE.UU. contradicen flagrantemente sus objetivos declarados y solo han servido para intensificar las tensiones".
+            </div></div><div class="ArticleView-coverWrap"><figure class="Cover-root"><div class="Cover-image"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fcfeb1e9ff710ff61e5ff9.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fcfeb1e9ff710ff61e5ff9.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fcfeb1e9ff710ff61e5ff9.jpg 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fcfeb1e9ff710ff61e5ff9.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fcfeb1e9ff710ff61e5ff9.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fcfeb1e9ff710ff61e5ff9.jpg" alt="Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fcfeb1e9ff710ff61e5ff9.jpg" alt="Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición" /></noscript></div><figcaption class="Cover-footer"><span class="Cover-caption"><span class="Cover-captionItem">Estados Unidos lleva a cabo operaciones de bloqueo cerca del estrecho de Ormuz.</span></span><span class="Cover-source"><span class="Cover-captionItem">Handout / Handout</span><span class="Cover-captionItem"> /  Gettyimages.ru </span></span></figcaption></figure></div><div itemprop="articleBody"><div class="Text-root Text-type_5 ArticleView-text ViewText-root "><p>El representante permanente de Irán ante la ONU, Amir Saeid Iravani, <a href="https://www.youtube.com/watch?v=J5g88Yh7KyU" target="_blank" rel="nofollow noopener noreferrer">ha afirmado</a> este jueves que su país está dispuesto a garantizar la libertad de navegación en el estrecho de Ormuz, con la condición de que cese la guerra.</p>
+    <div class="ReadMore-root Section-root Section-is1to3-xs_is1to1" data-widgets="ReadMore">
+        <div class="Section-container Section-isRow-isTop-isWrap">
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<article class="Card-root Card-is1to1 Card-default">
+    
+                    
+            <div class="Card-imageWrap">
+                            
+    
+            
+        
+            
+    <div class="Card-picture">
+        
+<picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc435459bf5b6dd6308fee.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fc435459bf5b6dd6308fee.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc435459bf5b6dd6308fee.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fc435459bf5b6dd6308fee.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc435459bf5b6dd6308fee.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc435459bf5b6dd6308fee.jpg" alt="Esto podría ser un serio obstáculo para poner fin a la guerra de Irán"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fc435459bf5b6dd6308fee.jpg" alt="Esto podría ser un serio obstáculo para poner fin a la guerra de Irán" /></noscript>    </div>
+
+                                            
+                    </div>
+        <div class="Card-contentWrap">
+        <div class="Card-content">
+                            
+                
+    <div class="Card-title">
+                        
+                                                                                            
+            
+                                                                        
+            
+            <div class="HeaderNews-root HeaderNews-type_6 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/actualidad/603598-poder-serio-obstaculo-poner-fin-guerra-eeuu-iran" class="Link-root Link-isFullCard ">
+                Esto podría ser un serio obstáculo para poner fin a la guerra de Irán
+            </a>
+            
+            </div>
+            
+    </div>
+
+                
+        </div>
+            
+    
+            
+    
+    </div>
+</article>
+        </div>
+    </div>
+
+<p>"Las acciones de Estados Unidos contradicen flagrantemente sus objetivos declarados y solo han servido para intensificar las tensiones y profundizar la inestabilidad en la región", denunció.</p><p>"La postura de Irán es clara. <strong>La única solución viable en el estrecho de Ormuz es el fin definitivo de la guerra</strong>, el levantamiento del bloqueo marítimo y el restablecimiento del paso normal. En cambio, Estados Unidos impulsa un proyecto de resolución defectuoso y con motivaciones políticas bajo el pretexto de la libertad de navegación para promover su agenda política y legitimar acciones ilegales que no resuelven la crisis", agregó.</p><p>"El proyecto de resolución<strong> no busca proteger la navegación internacional</strong>. Su verdadero propósito es legitimar la acción ilegal de Estados Unidos contra Irán", concluyó&nbsp;Iravani.</p><p>Estados Unidos, junto con Baréin y sus socios del Golfo (Arabia Saudita, Emiratos Árabes Unidos, Kuwait y Catar), <a href="https://www.state.gov/releases/office-of-the-spokesperson/2026/05/the-united-states-proposes-a-un-security-council-resolution-to-defend-freedom-of-navigation-and-secure-the-strait-of-hormuz/" target="_blank" rel="nofollow noopener noreferrer">propuso</a> el martes una resolución del Consejo de Seguridad de la ONU para "defender la libertad de navegación y garantizar la seguridad del estrecho de Ormuz".</p><p>"El proyecto de resolución exige a Irán que cese los ataques, el minado y el cobro de peajes. Asimismo, exige que Irán revele el número y la ubicación de las minas marinas", declaró el secretario de Estado Marco Rubio en un comunicado.</p>
+    <div class="ReadMore-root Section-root Section-is1to3-xs_is1to1" data-widgets="ReadMore">
+        <div class="Section-container Section-isRow-isTop-isWrap">
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<article class="Card-root Card-is1to1 Card-default">
+    
+                    
+            <div class="Card-imageWrap">
+                            
+    
+            
+        
+            
+    <div class="Card-picture">
+        
+<picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc442459bf5b72621d0f69.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fc442459bf5b72621d0f69.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc442459bf5b72621d0f69.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fc442459bf5b72621d0f69.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc442459bf5b72621d0f69.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/69fc442459bf5b72621d0f69.jpg" alt="Gigante logístico cifra las pérdidas millonarias semanales por el bloqueo de Ormuz"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fc442459bf5b72621d0f69.jpg" alt="Gigante logístico cifra las pérdidas millonarias semanales por el bloqueo de Ormuz" /></noscript>    </div>
+
+                                            
+                    </div>
+        <div class="Card-contentWrap">
+        <div class="Card-content">
+                            
+                
+    <div class="Card-title">
+                        
+                                                                                            
+            
+                                                                        
+            
+            <div class="HeaderNews-root HeaderNews-type_6 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/actualidad/603596-naviera-revela-perdidas-millonarias-ormuz" class="Link-root Link-isFullCard ">
+                Gigante logístico cifra las pérdidas millonarias semanales por el bloqueo de Ormuz
+            </a>
+            
+            </div>
+            
+    </div>
+
+                
+        </div>
+            
+    
+            
+    
+    </div>
+</article>
+        </div>
+    </div>
+
+<p>"Estados Unidos espera que esta resolución sea votada en los próximos días y que reciba el apoyo de los miembros del Consejo de Seguridad", agregó.</p><ul><li>El domingo 3 de mayo, el presidente de EE.UU., Donald Trump,&nbsp;<a href="https://esrt.space/actualidad/602870-trump-proyecto-libertad-barcos-retenidos-estrecho-ormuz">anunció</a>&nbsp;una iniciativa para liberar los buques retenidos en el estrecho de Ormuz. El '<strong>Proyecto Libertad</strong>' comenzó la mañana de este lunes, hora de Oriente Medio, con la&nbsp;<a href="https://esrt.space/actualidad/602899-equipos-belicos-iniciativa-trump-buques-ormuz">participación</a>&nbsp;de destructores de misiles guiados, más de 100 aeronaves, plataformas no tripuladas multidominio, además de 15.000 efectivos de las Fuerzas Armadas.</li><li>Sin embargo, el líder estadounidense&nbsp;<a href="https://esrt.space/actualidad/603318-trump-proyecto-libertad-suspendera-durante">declaró</a>&nbsp;este martes que la operación&nbsp;se suspendería&nbsp;por un breve periodo de tiempo. Medios&nbsp;<a href="https://actualidad.rt.com/actualidad/603594-entendimiento-aliviar-bloqueo-eeuu-reabrir-ormuz" target="_blank" rel="nofollow noopener noreferrer">reportan</a>&nbsp;que Estados Unidos e Irán han alcanzado un entendimiento para aliviar el bloqueo naval estadounidense en el estrecho de Ormuz, a cambio de una reapertura gradual de esta vía marítima.</li><li>No obstante, Irán no ha confirmado ningún avance al respecto.&nbsp;</li></ul><p><strong><em>El&nbsp;</em></strong><strong><em><a href="https://esrt.space/a-fondo/554476-estrecho-ormuz-verdadera-arma-nuclear-iran">estrecho de Ormuz</a></em></strong><strong><em>, la verdadera 'arma' de Irán</em></strong></p></div></div><div class="ArticleView-sharesInline"><span>Compartir:</span><div class="ShareBlock-isReact" data-rtcomponent="ShareBlock" onload="return {
+        socials: JSON.parse('\u005B\u0022facebook\u0022,\u0022xtwitter\u0022,\u0022whatsapp\u0022,\u0022telegram\u0022,\u0022mailto\u0022,\u0022copylink\u0022\u005D'),
+        direction: JSON.parse('\u0022column\u0022'),
+        type: JSON.parse('\u0022hasFull\u0022'),
+        params: JSON.parse('\u007B\u0022counters\u0022\u003Atrue,\u0022href\u0022\u003A\u0022https\u003A\\\/\\\/actualidad.rt.com\\\/actualidad\\\/603743\u002Diran\u002Dafirma\u002Donu\u002Dgarantizara\u002Dnavegacion\u0022,\u0022shortUrl\u0022\u003A\u0022https\u003A\\\/\\\/es\u002Drt.com\\\/cxun\u0022\u007D'),
+    };"></div></div><div class="ArticleView-tags"><div class="Tags-wrapper"><div id="tags-left-arrow-js" class="Tags-arrow Tags-arrow_left Tags-arrow__none"></div><div id="tags-js" class="Tags-root Tags-default"><ul class="Tags-list Tags-default"><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/Conflictos">Conflictos</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/EE.%C2%A0UU.-vs.-Ir%C3%A1n">EE.&nbsp;UU. vs. Irán</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/estados_unidos">Estados Unidos</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/estrecho-ormuz">Estrecho de Ormuz</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/Ir%C3%A1n">Irán</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/ONU">ONU</a></li></ul></div><div id="tags-right-arrow-js" class="Tags-arrow Tags-arrow_right"></div></div></div><div class="ArticleView-rotatorBanners"><div class="CookiesBanner-isReact" data-rtcomponent="RotatorBanner" onload="return {
+        socials: JSON.parse('\u005B\u0022telegramRtlatam\u0022,\u0022telegramRtreporteros\u0022,\u0022rtVkact\u0022,\u0022telegramAhilesva\u0022,\u0022rumble\u0022,\u0022whatsapp\u0022\u005D')
+    }"></div></div><div class="ArticleView-rsya"><div id="adfox_174039172114627785"></div></div><div class="ArticleView-comments"><div data-rtcomponent="Comments" onload="return {
+            title: `Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición`,
+            host: `https://actualidad.b37m.ru`,
+            url: `https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion`,
+            theme: `light`,
+            hasButton: `1`,
+          };"></div><noscript>You use your browser with disabled JavaScript. Please enable JavaScript for comments.</noscript></div><div class="articles-listing" data-articleslisting="/listing/category.actualidad/prepare/articles-listing/24/1" hidden=""><span>/actualidad/610018-taiwan-china-ejercicios-militares</span><span>/actualidad/610986-video-momento-cayo-helicopteros-estrellaron-aire-brasil</span><span>/actualidad/609805-inesperado-negocio-silicon-valley</span><span>/actualidad/610985-pelicula-michael-biopic-musical-taquillera-historia</span><span>/actualidad/610987-iran-culpa-eeuu-violacion-alto-fuego</span><span>/actualidad/610961-exanalista-cia-enfoque-principal-biolaboratorios</span><span>/actualidad/610980-iran-rechazado-peticion-trump</span><span>/actualidad/610982-alemania-aplastar-novata-curazao-estreno-mundial</span><span>/actualidad/610981-keiko-fujimori-irse-peru-promesa</span><span>/actualidad/610936-famoso-cantante-estadounidense-fallece-accidente-brasil</span><span>/actualidad/610973-general-irani-iran-dedo-gatillo</span><span>/actualidad/610975-kremlin-desvela-secreto-conversacion-putin-trump</span><span>/actualidad/610976-muertos-accidente-aereo-eeuu</span><span>/actualidad/610951-fenomeno-control-orbita-terrestre-campo-escombros</span><span>/actualidad/610930-puntos-clave-laboratorios-destapados-ucrania</span><span>/actualidad/610971-presidente-irani-iran-continuar-dialogo-eeuu</span><span>/actualidad/610960-insolito-final-viuda-negra-llevaba-a%C3%B1o-profuga-argentina</span><span>/actualidad/610970-caza-acero-dron-hezbola-destruir-tanque-israeli</span><span>/actualidad/610953-podria-ataque-israeli-interrumpir-negociaciones</span><span>/actualidad/610963-trump-asegura-esta-cerca-acuerdo-iran</span><span>/actualidad/610969-tiene-puto-criterio-furioso-comentario-trump-netanyahu</span><span>/actualidad/610968-putin-trump-acordar-visita-witkoff-kushner</span><span>/actualidad/610962-exigencia-pentagono-iran-medio-negociaciones</span><span>/actualidad/610967-putin-trump-abordar-memorando-eeuu-iran</span><div data-rtcomponent="ArticlesListing"></div></div></div></div></div>                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="Grid-block Grid-is1to4-sm_is1to1-xs_is1to1">
+                                                            
+    <div class="Section-root">
+        <div class="Section-container Section-isRow-isTop">
+            <div class="Section-block Section-is1to1 p-24">
+                <div class="Banners-root">
+                                                                                                        <div style="width: 100%;margin-bottom: 10px;border-radius: 3px;overflow:hidden;">
+    
+    <div id="banner--player" style="width: 100%;border-radius: 4px;overflow: hidden;margin-bottom: 12px;"></div>
+    <a href="https://actualidad.rt.com/en_vivo" target="_blank" class="ac_youtube_video--title">
+        RT en Español en vivo - TELEVISIÓN GRATIS 24/7
+    </a>
+    
+    
+</div>
+                                                    
+                                    </div>
+            </div>
+        </div>
+    </div>
+<div class="Section-root Section-isSticky"><div class="Section-root"><div class="Section-container Section-isRow-isTop"><div class="Section-block Section-is1to1 p-24"><div class="Advertisings-root Advertisings-topRight" id="right_banner_2"><div id="adfox_163033562334623855"></div><div id="adfox_163033558617098540"></div></div></div></div></div>
+<div class="Section-root" data-widgets="PopularNews"><div class="Section-title p-24 pb-0"><h2 class="HeaderNews-root HeaderNews-type_1 ">
+                Lo más popular
+            </h2></div><div class="Section-container Section-isRow-isTop-isWrap"><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610941-nuevo-video-caida-mortal-vacio-mujer-puenting" class="Link-root Link-isFullCard ">
+                Nuevo VIDEO de la caída mortal al vacío de una mujer a la que los instructores de 'puenting' olvidaron atar
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T12:39:32+00:00">
+        14 jun 2026 | 12:39 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610969-tiene-puto-criterio-furioso-comentario-trump-netanyahu" class="Link-root Link-isFullCard ">
+                "No tiene puto criterio": Furioso comentario de Trump sobre Netanyahu tras el ataque contra el Líbano
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T16:24:06+00:00">
+        14 jun 2026 | 16:24 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610957-clara-advertencia-trump-israel-iran-libano" class="Link-root Link-isFullCard ">
+                La clara advertencia de Trump a Israel en medio de las negociaciones con Irán
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T14:52:39+00:00">
+        14 jun 2026 | 14:52 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610966-kremlin-revela-detalles-conversacion-putin-trump" class="Link-root Link-isFullCard ">
+                El Kremlin revela detalles de la conversación entre Putin y Trump
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T15:52:27+00:00">
+        14 jun 2026 | 15:52 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 pb-24"><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610965-putin-felicita-trump-cumpleanos-conversacion" class="Link-root Link-isFullCard ">
+                Putin felicita a Trump por su cumpleaños en una conversación que duró cerca de una hora
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T15:47:11+00:00">
+        14 jun 2026 | 15:47 GMT
+    </time></div></div></div></div></div></div></div></div><div class="Section-root"><div class="Section-container Section-isRow-isTop"><div class="Section-block Section-is1to1 p-24"><div class="Subscription-isReact" data-rtcomponent="Subscription" onload="return {
+        elements: JSON.parse('\u005B\u0022blockInput\u0022,\u0022blockButton\u0022,\u0022blockButtonCircle\u0022,\u0022blockCheckbox\u0022,\u0022blockInfoText\u0022\u005D'),
+        id: JSON.parse('\u0022sidebar\u0022'),
+    };"></div></div></div></div>        
+    <div class="Section-root">
+        <div class="Section-container Section-isRow-isTop">
+            <div class="Section-block Section-is1to1 p-24">
+                <div class="Banners-root">
+                                                                        <a class="Link-root Link-isInline videoLink" id="" href="https://esrt.space/actualidad/610026-europa-militarizacion-impacto-economico">
+                                <video class="Banners-image lazyload" autoplay="" loop="" muted="" playsinline="">
+                                    <source type="video/mp4" src="https://mf.b37mrtl.ru/actualidad/public_video/2026.06/6a2b055659bf5b20671ba918.mp4">
+                                </video>
+                            </a>
+                        
+                                    </div>
+            </div>
+        </div>
+    </div>
+
+            
+    <div class="Section-root Section-isNoAnchor" data-listing="Comics">
+        <div class="Section-title p-24 pb-0">
+                            
+                                                                                            
+            
+                                                                        
+            
+            <h2 class="HeaderNews-root HeaderNews-type_1 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/comics" class="Link-root ">
+                Osografía
+            </a>
+            
+            </h2>
+            
+        </div>
+        <div class="Section-container Section-isRow-isTop-isWrap Listing-root" data-count="1">
+                            
+<div class="Section-block  Section-is1to1-sm_is1to1-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2993d7e9ff714dd00eb1af.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2993d7e9ff714dd00eb1af.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg" alt="Doble incertidumbre en el Perú: resultados… y duración en el cargo"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2993d7e9ff714dd00eb1af.jpg" alt="Doble incertidumbre en el Perú: resultados… y duración en el cargo" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/comics/610225-doble-incertidumbre-peru-resultados-duracion" class="Link-root Link-isFullCard ">
+                Doble incertidumbre en el Perú: resultados… y duración en el cargo
+            </a></div></div></div></div></article></div>                    </div>
+    </div>
+<div class="Section-root"><div class="Section-container Section-isRow-isTop"><div class="Section-block Section-is1to1 p-24"><div class="Advertisings-root Advertisings-bottomRight" id="right_banner_3"><div id="adfox_163033564640081029"></div><div id="adfox_163033560186651459"></div></div></div></div></div></div>                </div>
+            </section>
+        </div>
+    </main>
+
+							<div class="App-footer">
+					
+
+
+
+
+
+
+
+
+<div class="Footer-root Footer-expanded"><div class="Footer-container Footer-containerWithLine"><div class="Footer-block Footer-is1to4-sm_is1to1-xs_is1to1"><div class="Footer-subscription p-24"><div class="Subscription-isReact" data-rtcomponent="Subscription" onload="return {
+        elements: JSON.parse('\u005B\u0022blockTitle\u0022,\u0022blockInput\u0022,\u0022blockButton\u0022,\u0022blockButtonCircle\u0022,\u0022blockCheckbox\u0022,\u0022blockInfoText\u0022\u005D'),
+        id: JSON.parse('\u0022footer\u0022'),
+    };"></div></div><div class="Footer-telegram p-24"><a class="Button-root Button-is1to1 Button-type_xl Button-fill_dark " href="https://x.com/ActualidadRT" target="_blank" rel="noopener noreferrer" aria-label="Button">
+                RT en X
+            </a></div></div><div class="Footer-block Footer-is1to2-sm_is1to1-xs_is1to1"><div class="Footer-nav"><div class="Footer-group Footer-is1to3-sm_is1to3-xs_is1to1 p-24"><ul class="Footer-groupList"><li><a href="https://actualidad.rt.com/todas_las_noticias" class="Link-root Link-isInFooterLink">Noticias</a></li><li><a href="https://actualidad.rt.com/viral" class="Link-root Link-isInFooterLink">Viral</a></li><li><a href="https://actualidad.rt.com/programas" class="Link-root Link-isInFooterLink">Programas</a></li><li><a href="https://actualidad.rt.com/video" class="Link-root Link-isInFooterLink">Videos</a></li><li><a href="https://actualidad.rt.com/opinion" class="Link-root Link-isInFooterLink">Opinión</a></li><li><a href="https://actualidad.rt.com/rtpedia" class="Link-root Link-isInFooterLink">RTpedia</a></li><li><a href="https://actualidad.rt.com/sp/lideres" class="Link-root Link-isInFooterLink">Líderes Mundiales</a></li></ul></div><div class="Footer-group Footer-is1to3-sm_is1to3-xs_is1to1 p-24"><h3 class="Footer-groupTitle">Acerca de RT</h3><ul class="Footer-groupList"><li><a href="https://actualidad.rt.com/acerca/quienes_somos" class="Link-root Link-isInFooterLink">Quiénes somos</a></li><li><a href="https://actualidad.rt.com/acerca/contactos" class="Link-root Link-isInFooterLink">Contactos</a></li><li><a href="https://actualidad.rt.com/acerca/equipo" class="Link-root Link-isInFooterLink">Equipo</a></li><li><a href="https://actualidad.rt.com/acerca/cobertura" class="Link-root Link-isInFooterLink">Cobertura</a></li><li><a href="https://actualidad.rt.com/acerca/carrera" class="Link-root Link-isInFooterLink">Carrera en RT</a></li><li><a href="https://actualidad.rt.com/acerca/condiciones_de_uso" class="Link-root Link-isInFooterLink">Condiciones de uso</a></li></ul></div><div class="Footer-group Footer-is1to3-sm_is1to3-xs_is1to1 p-24"><h3 class="Footer-groupTitle">Aplicación móvil</h3><ul class="Footer-groupList"><li><a href="https://cdn.rt.com/app/rtnews.apk" class="Link-root Link-isInFooterLink" target="_blank" rel="noopener noreferrer">Android</a></li></ul></div></div></div><div class="Footer-block Footer-is1to4-sm_is1to1-xs_is1to1"><div class="Footer-search p-24"><div class="Search-field"><div class="Search-input Search-is1to1"></div><div class="Search-buttonCircle Search-isAbsoluteToRight"><button class="IconButton-root IconButton-size_m IconButton-fill_transparent " aria-label="Button"><svg class="Icon-root Icon-search" width="16px" stroke="#888888" version="1.1" viewBox="0 0 16 16" xmlns="https://www.w3.org/2000/svg"><g stroke-width="2"><circle cx="6.8" cy="6.8" r="5.8" fill="none"></circle><line x1="11" x2="15.3" y1="11" y2="15.3"></line></g></svg></button></div></div></div><div class="Footer-groupSocials p-24 pt-0"><ul class="Socials-root"><li class="Socials-item Socials-VkIcon"><a href="https://vk.com/actualidadrt" class="Link-root Link-socials" target="_blank" aria-label="VkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-vk" height="13px" fill="#888888" version="1.1" viewBox="0 0 22 13" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -10)"><path d="m26.16 11.013c0.16-0.49333 0-0.85333-0.69333-0.85333h-2.32c-0.44243-0.020208-0.84913 0.242-1.0133 0.65333-0.72722 1.7134-1.6923 3.3159-2.8667 4.76-0.53333 0.53333-0.78667 0.72-1.08 0.72-0.29333 0-0.36-0.18667-0.36-0.68v-4.6133c0-0.58667-0.18667-0.85333-0.68-0.85333h-3.6533c-0.14856-0.0072434-0.29391 0.044915-0.40397 0.14497s-0.17579 0.23978-0.1827 0.38836c0 0.56 0.84 0.70667 0.93333 2.28v3.4267c0 0.74667-0.13333 0.88-0.42667 0.88-0.8 0-2.6667-2.9067-3.8533-6.2267-0.22667-0.65333-0.45333-0.89333-1.04-0.89333h-2.3467c-0.68 0-0.78667 0.30667-0.78667 0.65333 0 0.6 0.78667 3.6667 3.6667 7.72 1.5436 2.4836 4.1889 4.0718 7.1067 4.2667 1.48 0 1.6667-0.34667 1.6667-0.90667v-2.0933c0-0.68 0.13333-0.78667 0.61333-0.78667s0.94667 0.17333 2.32 1.5067c1.5733 1.5733 1.84 2.2933 2.6667 2.2933h2.32c0.68 0 1-0.33333 0.81333-0.98667-0.50005-0.99197-1.1625-1.8933-1.96-2.6667-0.54667-0.64-1.3333-1.3333-1.6-1.68-0.26667-0.34667-0.25333-0.62667 0-1.0267 0 0 2.8133-4 3.1067-5.3333"></path></g></g></svg></a></li><li class="Socials-item Socials-Rumble"><a href="https://rumble.com/c/RTES" class="Link-root Link-socials" target="_blank" aria-label="Rumble" rel="noopener noreferrer"><svg class="Icon-root Icon-rumble" width="18" height="19.773768216516" fill="#888888" xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="0 0 1441 1583"><path id="Layer" fill-rule="evenodd" d="m1339.3 537.2c32.1 35.2 57.5 75.9 74.8 120.3 17.2 44.4 26.1 91.5 26.2 139.2 0.1 47.6-8.6 94.8-25.7 139.2-17.1 44.4-42.3 85.3-74.3 120.6-57.2 63.1-119 121.9-184.9 175.9-65.9 54-135.7 103-208.9 146.7-73.1 43.6-149.4 81.8-228.2 114.2-78.8 32.4-159.9 59-242.6 79.4-42.2 10.6-86.1 12.9-129.1 6.8-43.1-6.1-84.6-20.4-122.2-42.3-37.7-21.8-70.7-50.7-97.4-85-26.6-34.4-46.4-73.6-58.2-115.4-100.4-343-85.6-730.8 11.2-1075.3 51-180.9 221.3-294.5 396.7-252.7 324.8 77.4 629.6 276.7 862.6 528.4zm-457.3 356.2c61.2-48.4 61.2-142.7 0-192.6q-32.6-27.1-66.8-52.1-34.2-25.1-69.9-48-35.6-22.9-72.6-43.7-37-20.7-75.2-39.2c-70.3-33.6-148.8 13.3-160.1 93.3-17.3 122.3-20.4 245.6-9.1 362.8 7.6 81.1 85.1 129.5 156.5 98.4q39.9-17.2 78.6-37 38.7-19.8 76-42.2 37.3-22.4 73-47.2 35.7-24.8 69.6-52z"></path></svg></a></li><li class="Socials-item Socials-Odysee"><a href="https://www.odysee.com/@ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="Odysee" rel="noopener noreferrer"><svg fill="#888888" height="24px" class="Icon-root" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="isolation:isolate" viewBox="0 0 24 24" width="24pt"><g clip-path="url(#_clipPath_8FANzNdzAksNqe68wPUCLCPg4beKQ3ZI)"><path d=" M 18.499 1.921 C 16.629 0.704 14.396 0 12 0 C 5.377 0 0 5.377 0 12 C 0 12.51 0.032 13.012 0.1 13.503 C 0.094 13.509 0.095 13.514 0.102 13.517 C 0.117 13.692 0.143 13.865 0.176 14.035 C 0.192 14.152 0.214 14.268 0.246 14.38 C 0.299 14.688 0.372 14.988 0.461 15.282 C 0.376 14.985 0.303 14.684 0.246 14.38 C 0.219 14.266 0.198 14.15 0.176 14.035 C 0.149 13.862 0.123 13.69 0.102 13.517 C 0.101 13.512 0.1 13.508 0.1 13.503 C 0.1 13.503 0.1 13.503 0.1 13.503 C 0.531 12.861 2.182 11.465 3.796 10.597 C 5.1 9.895 6.533 9.609 6.914 9.242 C 6.243 7.007 5.032 3.538 7.746 1.912 C 9.881 0.634 12.69 -0.142 13.77 2.958 C 14.851 6.057 14.572 6.754 15.037 6.754 C 15.501 6.754 16.644 6.977 17.128 5.004 C 17.481 3.564 17.699 2.326 18.499 1.921 Z  M 20.791 3.837 C 22.782 5.978 24 8.848 24 12 C 24 18.623 18.623 24 12 24 C 6.727 24 2.244 20.592 0.641 15.858 C 0.661 15.925 0.685 15.992 0.709 16.059 C 0.804 16.147 0.912 16.222 1.029 16.28 C 1.794 16.635 2.918 16.026 3.982 14.923 C 4.301 14.606 4.657 14.331 5.044 14.103 C 5.894 13.555 6.814 13.123 7.779 12.818 C 7.779 12.818 8.822 14.419 9.788 16.317 C 10.755 18.215 8.745 18.847 8.522 18.847 C 8.299 18.847 5.132 18.552 5.839 21.231 C 6.545 23.909 10.415 22.943 12.388 21.639 C 14.361 20.336 13.877 16.094 13.877 16.094 C 15.813 15.796 16.407 17.843 16.593 18.882 C 16.779 19.92 16.361 21.746 18.306 21.786 C 18.579 21.79 18.852 21.747 19.112 21.66 C 19.859 21.108 20.541 20.471 21.142 19.762 C 21.205 19.664 21.241 19.551 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 C 21.173 19.295 19.748 17.111 19.572 15.276 C 19.442 14.005 17.78 12.595 16.784 11.854 C 16.614 11.725 16.51 11.528 16.499 11.315 C 16.489 11.102 16.572 10.895 16.728 10.75 C 17.711 9.821 19.444 8.009 19.992 7.051 C 20.502 6.055 20.776 4.955 20.791 3.837 Z  M 2.769 8.88 C 2.705 8.777 2.568 8.745 2.465 8.81 C 2.362 8.875 2.331 9.011 2.395 9.114 C 2.46 9.218 2.596 9.249 2.7 9.184 C 2.749 9.153 2.785 9.103 2.798 9.046 C 2.811 8.989 2.801 8.929 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 Z  M 15.669 3.106 C 15.604 3.003 15.468 2.972 15.364 3.037 C 15.261 3.101 15.23 3.238 15.295 3.341 C 15.359 3.444 15.496 3.475 15.599 3.411 C 15.648 3.38 15.684 3.33 15.697 3.273 C 15.71 3.216 15.7 3.156 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 Z  M 18.333 11.768 C 18.302 11.907 18.39 12.044 18.528 12.076 C 18.667 12.107 18.805 12.02 18.837 11.881 C 18.868 11.742 18.781 11.604 18.642 11.573 C 18.576 11.557 18.505 11.569 18.447 11.606 C 18.389 11.643 18.348 11.701 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 Z  M 14.486 20.364 C 14.468 20.443 14.499 20.526 14.566 20.573 C 14.633 20.62 14.721 20.621 14.789 20.577 C 14.858 20.532 14.892 20.451 14.877 20.371 C 14.861 20.291 14.798 20.228 14.718 20.213 C 14.613 20.193 14.51 20.259 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 Z  M 4.456 4.916 C 4.441 4.981 4.482 5.046 4.547 5.061 C 4.611 5.076 4.676 5.036 4.691 4.971 C 4.707 4.906 4.667 4.841 4.603 4.826 C 4.571 4.818 4.538 4.823 4.51 4.84 C 4.483 4.857 4.463 4.885 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 Z  M 5.079 16.254 C 5.062 16.162 4.974 16.101 4.882 16.118 C 4.79 16.134 4.728 16.222 4.745 16.315 C 4.762 16.407 4.85 16.468 4.942 16.452 C 4.986 16.444 5.026 16.418 5.051 16.381 C 5.077 16.344 5.087 16.298 5.079 16.254 L 5.079 16.254 L 5.079 16.254 L 5.079 16.254 L 5.079 16.254 L 5.079 16.254 Z  M 20.548 9.767 L 20.276 9.228 L 19.683 9.105 L 20.222 8.833 L 20.343 8.241 L 20.617 8.78 L 21.21 8.901 L 20.671 9.175 L 20.548 9.767 L 20.548 9.767 L 20.548 9.767 L 20.548 9.767 Z  M 12.692 5.59 L 12.644 5.59 C 12.507 5.563 12.418 5.431 12.444 5.295 C 12.503 5.061 12.478 4.814 12.372 4.598 C 12.334 4.473 12.396 4.34 12.516 4.29 C 12.636 4.24 12.774 4.288 12.836 4.403 C 12.98 4.709 13.016 5.056 12.939 5.385 C 12.915 5.503 12.813 5.589 12.692 5.59 L 12.692 5.59 L 12.692 5.59 L 12.692 5.59 L 12.692 5.59 Z  M 11.468 6.889 C 9.495 7.632 8.545 6.656 8.415 4.879 C 8.269 2.869 10.165 2.349 10.165 2.349 C 12.256 1.652 12.806 2.646 13.292 4.136 C 13.777 5.625 13.44 6.152 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 Z  M 12.165 3.636 C 12.069 3.64 11.979 3.59 11.933 3.506 C 11.89 3.424 11.84 3.346 11.784 3.274 C 11.69 3.175 11.69 3.019 11.784 2.92 C 11.88 2.827 12.034 2.827 12.13 2.92 C 12.222 3.025 12.301 3.141 12.362 3.267 C 12.401 3.341 12.401 3.43 12.361 3.504 C 12.322 3.578 12.248 3.627 12.165 3.636 L 12.165 3.636 Z " fill-rule="evenodd"></path></g></svg></a></li><li class="Socials-item Socials-XIcon"><a href="https://x.com/ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="XIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-x" fill="#888888" version="1.1" viewBox="0 0 24 24" width="18" height="18" xmlns="https://www.w3.org/2000/svg"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg></a></li><li class="Socials-item Socials-TelegramIcon"><a href="https://telegram.me/rtnoticias" class="Link-root Link-socials" target="_blank" aria-label="TelegramIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-telegram" height="16px" fill="#888888" version="1.1" viewBox="0 0 20 16" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -8)"><path d="m24.798 8.8742v-0.084507c0.021962-0.35088-0.19811-0.67117-0.53226-0.77465-0.12528-0.020023-0.25291-0.020023-0.37818 0-0.41728-0.009814-0.83209 0.066897-1.2186 0.22535-1.2186 0.45071-2.4232 0.92958-3.6278 1.4085l-2.4512 0.87324-1.1065 0.46479-1.3166 0.5493-1.2466 0.53521c-1.6341 0.68545-3.2589 1.4038-4.8744 2.1549-0.70034 0.33803-1.4007 0.67606-2.073 1.0563-0.10024 0.054347-0.19029 0.12584-0.26613 0.21127-0.068477 0.066368-0.10716 0.15789-0.10716 0.25352s0.038685 0.18715 0.10716 0.25352c0.071194 0.080837 0.15668 0.1477 0.25212 0.19718 0.14189 0.093286 0.29192 0.17343 0.44822 0.23944 0.66227 0.30344 1.3458 0.55764 2.045 0.76056 0.49383 0.17864 1.0059 0.30146 1.5267 0.3662 0.58774 0.065441 1.181-0.057813 1.6948-0.35211 0.75637-0.43193 1.4987-0.90141 2.2271-1.4085 1.2606-0.83099 2.5072-1.7183 3.7398-2.5916 0.44956-0.34416 0.91712-0.66387 1.4007-0.95775 0.14179-0.1018 0.29748-0.18245 0.46223-0.23944 0.0693-0.014425 0.1408-0.014425 0.2101 0 0.11205 0 0.16808 0 0.15408 0.16901-0.0049925 0.14954-0.059181 0.2932-0.15408 0.40845-0.4062 0.42254-0.8124 0.84507-1.2326 1.2535-0.84041 0.80282-1.7088 1.5634-2.5492 2.3521l-1.4007 1.2817c-0.24176 0.22419-0.43282 0.49797-0.56027 0.80282-0.087561 0.19393-0.12143 0.40804-0.098048 0.61972 0.032149 0.24791 0.16373 0.47181 0.36418 0.61972l0.71435 0.50704 5.1825 3.5211 0.30815 0.21127c0.43391 0.27815 0.97867 0.31543 1.4461 0.098957 0.46738-0.21647 0.79328-0.65701 0.86507-1.1694l0.42021-2.3944 0.42021-2.5634c0.15408-0.88733 0.29414-1.7747 0.43421-2.662 0.11205-0.64789 0.2101-1.2958 0.30815-1.9437l0.37818-2.7324c0-0.50704 0.056027-1.0141 0.084041-1.5211z"></path></g></g></svg></a></li><li class="Socials-item Socials-BlueSky"><a href="https://bsky.app/profile/actualidadrt.bsky.social" class="Link-root Link-socials" target="_blank" aria-label="BlueSky" rel="noopener noreferrer"><svg class="Icon-root Icon-blueSky" width="20" height="17.666666666667" fill="#888888" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" version="1.1"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"></path></svg></a></li><li class="Socials-item Socials-OkIcon"><a href="https://ok.ru/group/70000046273774" class="Link-root Link-socials" target="_blank" aria-label="OkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-ok" width="25" height="25" fill="#888888" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" version="1.1"><path d="M100.1 99.2C109.8 99.2 118.6 95.2 124.9 88.9C131.2 82.6 135.2 73.8 135.2 64.1C135.2 54.4 131.2 45.6 124.9 39.3C118.6 33 109.8 29 100.1 29C90.3999 29 81.5999 33 75.2999 39.3C68.9999 45.5 64.9999 54.3 64.9999 64.1C64.9999 73.9 68.9999 82.6 75.2999 88.9C81.5999 95.2 90.4999 99.2 100.1 99.2ZM88.8999 52.7C91.7999 49.8 95.7999 48 100.2 48C104.7 48 108.6 49.8 111.5 52.7C114.4 55.6 116.2 59.6 116.2 64C116.2 68.5 114.4 72.4 111.5 75.3C108.6 78.2 104.6 80 100.2 80C95.6999 80 91.7999 78.2 88.8999 75.3C85.9999 72.4 84.1999 68.4 84.1999 64C84.1999 59.6 86.0999 55.6 88.8999 52.7Z"></path><path d="M147.5 113.4L137.2 99.3C136.6 98.5 135.4 98.4 134.7 99.1C125 107.4 113 112.8 100.1 112.8C87.2 112.8 75.3 107.4 65.5 99.1C64.8 98.5 63.6 98.6 63 99.3L52.7 113.4C52.2 114.1 52.3 115 52.9 115.6C61.6 122.6 71.7 127.4 82.2 129.9L60.4 168.3C59.8 169.4 60.6 170.8 61.8 170.8H83.1C83.8 170.8 84.4 170.4 84.6 169.7L99.8 135.7L115 169.7C115.2 170.3 115.8 170.8 116.5 170.8H137.8C139.1 170.8 139.8 169.5 139.2 168.3L117.4 129.9C127.9 127.4 138 122.8 146.7 115.6C148 115 148.1 114.1 147.5 113.4Z"></path></svg></a></li><li class="Socials-item Socials-RssIcon"><a href="https://actualidad.rt.com/feeds/all.rss" class="Link-root Link-socials" target="_blank" aria-label="RssIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-rss" height="15px" width="16px" fill="#888888" version="1.1" viewBox="0 0 15 16" xmlns="http://www.w3.org/2000/svg"><g transform="translate(-1362 -24)"><g transform="translate(1228 18)"><g transform="translate(128)"><g transform="translate(6.5333 6.5333)"><path d="m2.2167 10.733c1.05 0 1.9833 0.93333 1.9833 1.9833 0 0.58333-0.23333 1.05-0.58333 1.4s-0.93333 0.58333-1.4 0.58333c-1.1667 0-1.9833-0.93333-1.9833-1.9833 0-1.1667 0.93333-1.9833 1.9833-1.9833zm-1.8667-5.6 0.2706 0.0037294c5.1229 0.14141 9.1774 4.2868 9.0627 9.4463h-2.6833l-0.0064615-0.29055c-0.073117-1.6399-0.76483-3.1641-1.9769-4.3761-1.2833-1.2833-2.9167-1.9833-4.6667-1.9833v-2.8zm0-4.9 0.38576 0.0053959c3.5959 0.10059 7.0568 1.6038 9.6476 4.1946 2.8 2.8 4.2 6.3 4.0833 10.033h-2.6833l-0.0036305-0.29523c-0.15459-6.2782-5.2266-11.255-11.43-11.255v-2.6833z"></path></g></g></g></g></svg></a></li><li class="Socials-item Socials-feedback"><div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022icon\u0022'),
+    };"></div></li></ul></div></div></div><div class="Footer-container"><div class="Footer-block Footer-is1to1-sm_is1to1-xs_is1to1"><div class="Footer-copyrightItem Footer-is1to1"><div class="Copyright-root Copyright-isRow-sm_isRow-xs_isColumn"><div class="Copyright-item"><div class="Copyright-logo Copyright-isRow-isCenter"><svg class="Icon-root Icon-rtLogo" width="54px" height="54px" fill="#D4D3D3" version="1.1" viewBox="0 0 56 56" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><rect width="56" height="56"></rect><path d="m1 0h54c0.55228-1.0145e-16 1 0.44772 1 1v54c0 0.55228-0.44772 1-1 1h-54c-0.55228 0-1-0.44772-1-1v-54c-6.7635e-17 -0.55228 0.44772-1 1-1z"></path><g transform="translate(8 20)" fill="#000"><polygon points="24.372 0.32996 24.372 2.3017 31.843 2.3017 31.843 17 40.53 17 40.53 2.3017 48 2.3017 48 0.32996"></polygon><path d="m12.907 7.8584c0.66346 0 1.2681-0.28214 1.7137-0.76234 0.47758-0.51014 0.76946-1.2094 0.76946-1.9264h-0.003977 0.003977c0-0.71699-0.29188-1.5059-0.76946-2.0165-0.44559-0.47895-1.0503-0.85143-1.7137-0.85143h-3.5163v5.5567h3.5163zm7.0223-7.5284c1.1876 0.046067 2.298 0.4535 3.0839 1.2933 0.81597 0.88441 1.3622 2.1124 1.3622 3.5464h0.0065706-0.0065706c0 1.2547-0.50646 2.4435-1.3223 3.3198-0.50923 0.54545-1.1267 0.93836-1.8244 1.1771l5.1548 7.3334h-9.4655l-4.592-6.9907h-2.9354v6.9907h-8.6456v-16.67h19.184z"></path></g></g></svg></div></div><div class="Copyright-item Copyright-xs_isColumn-isCenter pl-16 xs_pl-0 xs_pt-16"><div class="Copyright-langs Copyright-isFlex-isWrap-xs_isRow-isCenter"><span class="Copyright-lang"><a href="https://comparte.rt.com/" target="_blank" rel="noopener noreferrer">CompaRTe</a></span><span class="Copyright-lang"><a href="https://rtbrasil.com/" target="_blank" rel="noopener noreferrer">RT Brasil</a></span><span class="Copyright-lang"><a href="https://arabic.rt.com/" target="_blank" rel="noopener noreferrer">العربية</a></span><span class="Copyright-lang"><a href="https://de.rt.com/" target="_blank" rel="noopener noreferrer">Deutsch</a></span><span class="Copyright-lang"><a href="https://swentr.site/" target="_blank" rel="noopener noreferrer">English</a></span><span class="Copyright-lang"><a href="https://francais.rt.com/" target="_blank" rel="noopener noreferrer">Français</a></span><span class="Copyright-lang"><a href="https://rt.rs/" target="_blank" rel="noopener noreferrer">Српски</a></span><span class="Copyright-lang"><a href="https://russian.rt.com/" target="_blank" rel="noopener noreferrer">Русский</a></span><span class="Copyright-lang"><a href="https://rtd.rt.com/" target="_blank" rel="noopener noreferrer">RTД</a></span><span class="Copyright-lang"><a href="https://www.ruptly.agency/es" target="_blank" rel="noopener noreferrer">RUPTLY</a></span><span class="Copyright-lang"><a href="https://es.gw2ru.com/" target="_blank" rel="noopener noreferrer">Puerta a Rusia</a></span></div><div class="Copyright-text Copyright-isFlex-isWrap-xs_isRow-isCenter xs_pt-8">
+                © Organización Autónoma sin Fines de Lucro "TV-Novosti" 2005-2026. Todos los derechos reservados
+            </div></div><div class="Footer--notification">18+</div></div></div></div></div></div>				</div>
+					</div>
+
+
+		<div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022fixed\u0022'),
+    };"></div>		<div class="CookiesBanner-isReact" data-rtcomponent="CookiesBanner"></div>		<div style="display: none;">
+    <svg version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink">
+                <symbol id="RTLogoIcon" viewBox="0 0 56 56">
+            <g fill-rule="evenodd">
+                <path d="M0 0H56V56H0z"></path>
+                <path d="M1 0h54a1 1 0 011 1v54a1 1 0 01-1 1H1a1 1 0 01-1-1V1a1 1 0 011-1z"></path>
+                <g transform="translate(8 20)" fill="#000">
+                    <path d="M24.372 0.32996L24.372 2.3017 31.843 2.3017 31.843 17 40.53 17 40.53 2.3017 48 2.3017 48 0.32996z"></path>
+                    <path d="M12.907 7.858c.663 0 1.268-.282 1.714-.762.477-.51.77-1.21.77-1.926h-.005.004c0-.717-.292-1.506-.77-2.017-.445-.479-1.05-.851-1.713-.851H9.391v5.556h3.516zM19.929.33c1.188.046 2.298.453 3.084 1.293a5.189 5.189 0 011.362 3.547h.007-.007a4.908 4.908 0 01-1.322 3.32 4.433 4.433 0 01-1.824 1.177L26.384 17h-9.466l-4.592-6.99H9.391V17H.745V.33h19.184z"></path>
+                </g>
+            </g>
+        </symbol>
+
+                <symbol id="eye" viewBox="0 0 24 16">
+            <g stroke="none" stroke-width="1">
+                <g fill-rule="nonzero">
+                    <g>
+                        <path d="M11.9890675,0.0135048232 C6.70032154,0.0135048232 2.14212219,3.13118971 0.0482315113,7.63022508 C-0.0160771704,7.76655949 -0.0160771704,7.92604502 0.0482315113,8.06495177 C2.14212219,12.5639614 6.70034727,15.681672 11.9890675,15.681672 C17.2777878,15.681672 21.8360129,12.5639871 23.9299035,8.06495177 C23.9942122,7.92861736 23.9942122,7.76913183 23.9299035,7.63022508 C21.8360129,3.13118971 17.2778135,0.0135048232 11.9890675,0.0135048232 Z M11.9890675,13.2534019 C9.00257235,13.2534019 6.58456592,10.8327974 6.58456592,7.8488746 C6.58456592,4.86237942 9.00514469,2.44437299 11.9890675,2.44437299 C14.9755627,2.44437299 17.3935691,4.86495177 17.3935691,7.8488746 C17.3935691,10.8327974 14.9729904,13.2534019 11.9890675,13.2534019 Z"></path>
+                        <circle id="Oval" cx="11.9890675" cy="7.84630225" r="3.45980707"></circle>
+                    </g>
+                </g>
+            </g>
+        </symbol>
+
+                <symbol id="satellite" viewBox="0 0 612 612">
+            <path d="m394.46 187.09-24.007 24.007-109.69-109.69-159.77 159.77 109.69 109.69-23.594 23.594 26.864 26.863 23.593-23.594 13.979 13.979c6.954 6.954 18.23 6.954 25.185 0l53.861-53.861 23.889 23.89c-24.522 33.691-29.518 77.169-14.979 114.85 3.104 8.044 13.406 10.296 19.502 4.199l59.044-59.044 14.142 14.142c6.434 6.433 16.864 6.433 23.297 0s6.433-16.863 0-23.297l-14.142-14.142 59.044-59.044c6.097-6.097 3.845-16.399-4.199-19.502-37.676-14.539-81.155-9.542-114.85 14.979l-23.89-23.889 53.861-53.861c6.954-6.954 6.954-18.229 0-25.184l-13.979-13.979 24.007-24.007-26.862-26.866z"></path>
+            <path d="m5.216 532.32 73.874 73.874c3.477 3.477 8.035 5.216 12.592 5.216s9.115-1.738 12.592-5.216l120.88-120.88c6.954-6.954 6.954-18.229 0-25.184l-73.874-73.874c-3.477-3.478-8.035-5.216-12.592-5.216s-9.115 1.738-12.592 5.216l-120.88 120.88c-6.955 6.955-6.955 18.23 0 25.185z"></path>
+            <path d="m606.78 79.683-73.874-73.874c-3.477-3.477-8.035-5.216-12.592-5.216s-9.115 1.738-12.592 5.216l-120.88 120.88c-6.954 6.954-6.954 18.229 0 25.184l48.276 48.275 25.598 25.599c3.477 3.478 8.035 5.216 12.592 5.216s9.115-1.738 12.592-5.216l120.88-120.88c6.954-6.954 6.954-18.23 0-25.184z"></path>
+            <path d="m441.46 479.95v29.267c37.135 0 67.345-30.211 67.345-67.345h-29.267c0 20.996-17.082 38.078-38.078 38.078z"></path>
+            <path d="m439.06 559c65.91 0 119.53-53.622 119.53-119.53h-29.267c0 49.852-40.413 90.265-90.265 90.265v29.267z"></path>
+        </symbol>
+
+                <symbol id="arrowRight" viewBox="0 0 6 10">
+            <path d="M5.76087352,5.55732358 L1.39435851,9.76920649 C1.07497725,10.0769312 0.558507734,10.0769312 0.239126479,9.76920649 C-0.0797088262,9.46148181 -0.0797088262,8.96281003 0.239126479,8.65508535 L4.02857143,5.00026301 L0.239126479,1.34491465 C-0.0797088262,1.03718997 -0.0797088262,0.538518187 0.239126479,0.230793509 C0.558507734,-0.0769311696 1.07497725,-0.0769311696 1.39435851,0.230793509 L5.76087352,4.44320244 C6.07970883,4.75092712 6.07970883,5.24959891 5.76087352,5.55732358 L5.76087352,5.55732358 Z"></path>
+        </symbol>
+
+                <symbol id="FeedbackIcon" viewBox="0 0 22 16">
+            <g fill-rule="evenodd">
+                <path transform="translate(-9 -12)" d="M30.99967,17.4573953 L30.99967,26.2310663 C30.99967,26.7180481 30.8071729,27.1340325 30.4221787,27.4800195 C30.0371844,27.8270065 29.5751914,28 29.0350995,28 L29.0350995,28 L10.9634705,28 C10.4233786,28 9.96138558,27.8270065 9.57639135,27.4800195 C9.19249711,27.1340325 9,26.7180481 9,26.2310663 L9,26.2310663 L9,17.4573953 C9.3596946,17.8173818 9.7732884,18.1383698 10.2396814,18.4183593 C13.203037,20.2312913 15.2358065,21.5022437 16.3412899,22.2312163 C16.8076829,22.5402047 17.1860772,22.7821957 17.4764729,22.9551892 C17.7679685,23.1281827 18.1540627,23.3051761 18.6369554,23.4851693 C19.1198482,23.6661625 19.5697415,23.7561591 19.9877352,23.7561591 L19.9877352,23.7561591 L20.0119348,23.7561591 C20.4288286,23.7561591 20.8798218,23.6661625 21.3627146,23.4851693 C21.8456073,23.3051761 22.2317015,23.1281827 22.5220972,22.9551892 C22.8124928,22.7821957 23.1919871,22.5402047 23.6583801,22.2312163 C25.0498593,21.3252503 27.0870287,20.054298 29.7720884,18.4183593 C30.2384814,18.1313701 30.6476753,17.8103821 30.99967,17.4573953 L30.99967,17.4573953 Z M29.0343295,12 C29.5667215,12 30.0276146,12.1729935 30.4159088,12.5199805 C30.8053029,12.8659675 31,13.2819519 31,13.7689337 C31,14.3509118 30.798703,14.906891 30.398309,15.4378711 C29.996815,15.9678512 29.4974225,16.4208342 28.9001315,16.7968201 C25.8234776,18.718748 23.9073064,19.9167031 23.1549177,20.3876855 C23.0735189,20.4396835 22.8986215,20.5516793 22.6335255,20.7256728 C22.3673295,20.8986663 22.1462328,21.0386611 21.9702354,21.145657 C21.7942381,21.252653 21.5819413,21.3716486 21.332245,21.5046436 C21.0825488,21.6366386 20.8471523,21.7366349 20.6260556,21.8026324 C20.4049589,21.8686299 20.200362,21.9016287 20.0122648,21.9016287 L20.0122648,21.9016287 L19.9869652,21.9016287 C19.798868,21.9016287 19.5942711,21.8686299 19.3731744,21.8026324 C19.1531777,21.7366349 18.9166812,21.6366386 18.668085,21.5046436 C18.4183887,21.3716486 18.2049919,21.252653 18.0289946,21.145657 C17.8529972,21.0386611 17.6319005,20.8986663 17.3668045,20.7256728 C17.1006085,20.5516793 16.9268111,20.4396835 16.8443123,20.3876855 C16.0996235,19.9167031 15.0282396,19.2447283 13.6279606,18.3717611 C12.3933909,17.6014958 11.5947229,17.1021547 11.2327124,16.8737377 L11.1111983,16.7968201 C10.6041059,16.4868317 10.1256131,16.0618477 9.67461988,15.520868 C9.22472663,14.9788883 9.00033,14.4759072 9.00033,14.0119246 C9.00033,13.4369461 9.16972745,12.9579641 9.50852237,12.5749784 C9.84951726,12.1919928 10.33351,12 10.9638005,12 L10.9638005,12 Z"></path>
+            </g>
+        </symbol>
+
+                <symbol id="SearchIcon" viewBox="0 0 16 16">
+            <g stroke-width="2">
+                <circle r="5.8" cx="6.8" cy="6.8" fill="none" stroke-width="2"></circle>
+                <line x1="11" y1="11" x2="15.3" y2="15.3" stroke-width="2"></line>
+            </g>
+        </symbol>
+
+                <symbol id="ArrowTopIcon" viewBox="0 0 16 18">
+            <path fill-rule="nonzero" stroke="none" stroke-width="1" d="M218.988 83.564l.028.006h-12.044l3.786-3.795a.985.985 0 00.287-.7.983.983 0 00-.287-.698l-.59-.59a.977.977 0 00-.695-.287.977.977 0 00-.695.287l-6.491 6.49a.975.975 0 00-.287.697c0 .265.101.513.287.699l6.49 6.49a.977.977 0 00.696.288c.264 0 .51-.102.696-.287l.589-.59a.975.975 0 00.287-.695.946.946 0 00-.287-.683l-3.83-3.816h12.074c.542 0 .998-.467.998-1.01v-.833c0-.542-.47-.973-1.012-.973z" transform="translate(-16 -15) translate(-187 -61) rotate(90 211 84.975)"></path>
+        </symbol>
+
+                <symbol id="ArrowRightIcon" viewBox="0 0 18 16">
+            <path fill-rule="nonzero" d="M16.012 25.386l-.028-.006h12.045l-3.786 3.795c-.186.185-.288.436-.288.7s.102.512.288.698l.589.59a.977.977 0 00.695.287c.263 0 .51-.102.696-.287l6.49-6.49a.975.975 0 00.287-.698.975.975 0 00-.287-.698l-6.49-6.49a.977.977 0 00-.696-.288.977.977 0 00-.695.287l-.59.59a.975.975 0 00-.287.695c0 .263.102.497.288.682l3.829 3.816H15.999c-.543 0-.999.468-.999 1.01v.834c0 .542.47.973 1.012.973z" transform="translate(-15 -16)"></path>
+        </symbol>
+
+                <symbol id="ArrowLeftIcon" viewBox="0 0 18 16">
+            <path fill-rule="nonzero" d="M31.988 25.386l.028-.006H19.971l3.786 3.795c.186.185.288.436.288.7s-.102.512-.288.698l-.589.59a.977.977 0 01-.695.287.977.977 0 01-.696-.287l-6.49-6.49a.975.975 0 01-.287-.698c-.001-.265.1-.513.287-.698l6.49-6.49a.977.977 0 01.696-.288c.263 0 .51.102.695.287l.59.59a.975.975 0 01.287.695.946.946 0 01-.288.682l-3.829 3.816h12.073c.543 0 .999.468.999 1.01v.834c0 .542-.47.973-1.012.973z" transform="translate(-15 -16)"></path>
+        </symbol>
+
+                <symbol id="CloseIcon" viewBox="0 0 22 22">
+            <g fill-rule="evenodd" transform="translate(-1461 -21) translate(1456 16)">
+                <path d="M3.263 14.486H28.723V17.486H3.263z" transform="rotate(-135 15.993 15.986)"></path>
+                <path fill-rule="nonzero" d="M8 6.64L25.36 24l-1.42 1.42L6.64 8 8 6.64zM8 6L6 8l18 18 2-2L8 6z"></path>
+                <path d="M3.284 14.493H28.744V17.493000000000002H3.284z" transform="rotate(-45 16.014 15.993)"></path>
+                <path fill-rule="nonzero" d="M24 6.64l1.42 1.42L8 25.36 6.64 24 24 6.64zM24 6L6 24l2 2L26 8l-2-2z"></path>
+            </g>
+        </symbol>
+
+
+                        <symbol id="CopyLinkShareIcon" viewBox="0 0 22 21">
+            <path fillrule="evenodd" d="M2.585 9.723l1.862-1.862A1.056 1.056 0 015.94 7.85c.382.382.403.99.066 1.408l-.077.086-1.862 1.862c-1.773 1.772-1.794 4.528-.047 6.274 1.695 1.696 4.344 1.725 6.12.1l.154-.148 1.861-1.861a1.056 1.056 0 011.494-.012c.383.383.403.991.067 1.408l-.078.086-1.862 1.862c-2.616 2.617-6.685 2.648-9.262.07-2.521-2.52-2.547-6.47-.097-9.09l.167-.172 1.862-1.862zm7.637-7.637c2.617-2.618 6.687-2.648 9.264-.071 2.577 2.578 2.545 6.645-.072 9.263l-1.862 1.861a1.056 1.056 0 01-1.494.012 1.057 1.057 0 01.012-1.494l1.861-1.862c1.773-1.773 1.795-4.529.049-6.275-1.746-1.745-4.503-1.724-6.275.048L9.843 5.43a1.056 1.056 0 01-1.494.011 1.056 1.056 0 01.011-1.494zM6.44 13.578l7.638-7.638a1.056 1.056 0 011.494-.01c.382.382.403.99.066 1.407l-.078.086-7.637 7.638a1.056 1.056 0 01-1.494.011 1.054 1.054 0 01-.067-1.408l.078-.086 7.638-7.638z"></path>
+        </symbol>
+
+                <symbol id="MailToShareIcon" viewBox="0 0 22 16">
+            <path d="M22 5.457v8.774c0 .487-.193.903-.578 1.249a2 2 0 01-1.387.52H1.963a2 2 0 01-1.387-.52C.192 15.134 0 14.718 0 14.231V5.457a6.4 6.4 0 001.24.961c2.963 1.813 4.996 3.084 6.101 3.813.467.31.845.551 1.135.724.292.173.678.35 1.161.53.483.181.933.271 1.35.271h.025c.417 0 .868-.09 1.35-.27.484-.18.87-.358 1.16-.53.29-.174.67-.416 1.136-.725 1.392-.906 3.429-2.177 6.114-3.813A6.633 6.633 0 0022 5.458zM20.034 0c.533 0 .994.173 1.382.52.39.346.584.762.584 1.249 0 .582-.201 1.138-.602 1.669-.401.53-.9.983-1.498 1.359l-5.745 3.59c-.081.053-.256.165-.521.339-.267.173-.488.313-.664.42a13.17 13.17 0 01-.638.359 3.94 3.94 0 01-.706.298 2.156 2.156 0 01-.614.099h-.025c-.188 0-.393-.033-.614-.1a3.932 3.932 0 01-.705-.297 13.26 13.26 0 01-.639-.36 25.295 25.295 0 01-.662-.42c-.266-.173-.44-.285-.523-.337a620.674 620.674 0 00-3.216-2.016c-1.235-.77-2.033-1.27-2.395-1.498l-.122-.077c-.507-.31-.985-.735-1.436-1.276C.225 2.979 0 2.476 0 2.01 0 1.438.17.959.51.576.849.192 1.334 0 1.964 0z" fill-rule="evenodd"></path>
+        </symbol>
+
+                <symbol id="FBMessageShareIcon" viewBox="0 0 28 28">
+            <path d="M14 .667c7.5 0 13.167 5.5 13.167 13s-5.834 13-13.334 13c-1.333 0-2.666-.167-3.833-.5a.507.507 0 00-.667 0l-2.666 1.166c-.667.167-1.5-.166-1.5-1V24c0-.333-.167-.667-.334-.833-2.5-2.334-4.166-5.667-4.166-9.5 0-7.5 5.833-13 13.333-13zm8.167 10c.333-.667-.5-1.334-1-.834L17 13a1.062 1.062 0 01-1 0l-3.167-2.333c-.833-.667-2.166-.5-2.833.5l-4 6.166c-.333.667.333 1.334 1.167.834L11.333 15a1.063 1.063 0 011 0l3.167 2.333c.833.667 2.167.5 2.833-.5z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="WhatsAppShareIcon" viewBox="0 0 28 28">
+            <path d="M8.904 1.435A13.5 13.5 0 0123.6 4.35a13.334 13.334 0 013.884 9.483c0 7.45-6.035 13.491-13.484 13.5a13.683 13.683 0 01-6.317-1.566L.367 27.683l1.966-7.133a13.567 13.567 0 01-1.766-6.667A13.5 13.5 0 018.904 1.435zm12.88 4.882A10.833 10.833 0 004.95 19.65l.317.483L4.15 24l3.983-1 .467.283a10.733 10.733 0 005.517 1.517l.288-.004c5.846-.162 10.536-4.946 10.545-10.83a10.717 10.717 0 00-3.167-7.65zM10.05 7.567c.283 0 .6.05.867.7l.333.833c.283.717.683 1.567.683 1.667a.817.817 0 010 .766v.1a2.467 2.467 0 01-.316.5l-.167.2a4 4 0 01-.35.384c-.1.166-.217.233-.1.433a9.683 9.683 0 001.8 2.25 8.333 8.333 0 002.383 1.5l.234.117c.3.166.216.283.466 0 .25-.284.834-.984 1.034-1.284a.717.717 0 011-.25c.333.117 2.05.967 2.283 1.084l.183.1c.207.073.391.2.534.366.138.592.08 1.212-.167 1.767a3.6 3.6 0 01-2.4 1.667 6.05 6.05 0 01-.833 0 4.083 4.083 0 01-1.35-.2 16.667 16.667 0 01-1.917-.7 14.767 14.767 0 01-5.7-5l.017-.117a6.483 6.483 0 01-1.4-3.55 3.967 3.967 0 011.15-2.85l.103-.106c.253-.232.583-.368.93-.377z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="TelegramShareIcon" viewBox="0 0 24 20">
+            <path d="M23.998 1.093V.987a.95.95 0 00-.665-.968 1.498 1.498 0 00-.473 0A3.78 3.78 0 0021.337.3c-1.523.564-3.03 1.162-4.535 1.761l-3.064 1.092-1.383.58-1.646.687-1.558.67a174.913 174.913 0 00-6.093 2.693c-.876.422-1.751.845-2.591 1.32a1.227 1.227 0 00-.333.264.441.441 0 000 .634c.089.101.196.185.315.247.177.116.365.216.56.299.828.38 1.683.697 2.557.95a8.801 8.801 0 001.908.458 3.486 3.486 0 002.119-.44 36.892 36.892 0 002.783-1.76c1.576-1.039 3.134-2.148 4.675-3.24a19.78 19.78 0 011.751-1.197c.177-.127.372-.228.578-.3a.644.644 0 01.263 0c.14 0 .21 0 .192.212a.848.848 0 01-.192.51 64.839 64.839 0 01-1.541 1.568c-1.05 1.003-2.136 1.954-3.187 2.94l-1.75 1.602c-.303.28-.542.622-.701 1.003-.11.243-.152.51-.123.775.04.31.205.59.456.775l.893.633 6.478 4.402.385.264a1.882 1.882 0 001.808.124 1.9 1.9 0 001.08-1.462l.526-2.993.525-3.204c.193-1.11.368-2.219.543-3.328.14-.81.263-1.62.385-2.43l.473-3.415c0-.634.07-1.267.105-1.901z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="TwitterShareIcon" viewBox="0 0 26 22">
+            <path d="M24.883 1.133a11.133 11.133 0 01-3.333 1.284A5.1 5.1 0 0017.783.75a5.167 5.167 0 00-5.1 5.25c.01.398.06.795.15 1.183A14.717 14.717 0 012.183 1.7 5.167 5.167 0 003.85 8.6a4.9 4.9 0 01-2.333-.65 5.183 5.183 0 004.133 5c-.44.115-.895.17-1.35.167a4.383 4.383 0 01-.95 0A5.133 5.133 0 008.167 16.7 10.283 10.283 0 01.5 18.817a14.768 14.768 0 007.85 2.35A14.584 14.584 0 0023 6.467v-.684a10 10 0 002.55-2.666c-.94.411-1.933.686-2.95.816a4.817 4.817 0 002.283-2.8z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="XTwitterShareIcon" viewBox="0 0 28 28">
+            <g transform="translate(2 2)">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
+            </g>
+        </symbol>
+
+                <symbol id="FacebookShareIcon" viewBox="0 0 15 28">
+            <path d="M4.518 28V15.38H0v-4.688h4.518v-4.06C4.518 2.482 6.988 0 11.145 0c1.291.013 2.58.12 3.855.321v3.973h-2.093a2.871 2.871 0 00-2.287.738 2.687 2.687 0 00-.861 2.183v3.477h4.985l-.738 4.688H9.789V28H4.52z" fill-rule="nonzero"></path>
+        </symbol>
+
+        		<symbol id="CheckMark" viewBox="0 0 100 100" fill="none">
+			<path d="M50 0C22.4308 0 0 22.4288 0 50C0 77.5712 22.4308 100 50 100C77.5692 100 100 77.5712 100 50C100 22.4288 77.5692 0 50 0ZM50 96.1538C24.5519 96.1538 3.84615 75.4481 3.84615 50C3.84615 24.5519 24.5519 3.84615 50 3.84615C75.4481 3.84615 96.1538 24.5519 96.1538 50C96.1538 75.4481 75.4481 96.1538 50 96.1538Z" fill="#6EC601"></path>
+			<path d="M73.5616 29.4923L44.0058 62.7423L26.2 48.4981C25.3731 47.8346 24.1596 47.9711 23.4981 48.7981C22.8346 49.6288 22.9693 50.8384 23.7981 51.5019L43.0289 66.8865C43.3827 67.1692 43.8077 67.3077 44.2308 67.3077C44.7616 67.3077 45.2904 67.0884 45.6693 66.6615L76.4385 32.0461C77.1443 31.2538 77.0731 30.0365 76.2789 29.3327C75.4827 28.625 74.2693 28.6961 73.5616 29.4923Z" fill="#6EC601"></path>
+		</symbol>
+
+				<symbol id="FailMark" viewBox="0 0 100 100" fill="none">
+			<circle cx="50" cy="50" r="49" stroke="#E61E0A" stroke-width="2"></circle>
+			<path d="M29 71.8545L71.8544 29.0001" stroke="#E61E0A" stroke-width="2" stroke-linecap="round"></path>
+			<path d="M71.8545 71.8545L29.0001 29.0001" stroke="#E61E0A" stroke-width="2" stroke-linecap="round"></path>
+		</symbol>
+
+                <symbol id="DownloadNew" viewBox="0 0 16 15" fill="none">
+            <path d="M1.33333 13.1667H14.6667C14.8877 13.1667 15.0996 13.2414 15.2559 13.3742C15.4122 13.5071 15.5 13.6872 15.5 13.8751C15.5 14.0629 15.4122 14.2431 15.2559 14.3759C15.0996 14.5088 14.8877 14.5834 14.6667 14.5834H1.33333C1.11232 14.5834 0.900358 14.5088 0.744078 14.3759C0.587797 14.2431 0.5 14.0629 0.5 13.8751C0.5 13.6872 0.587797 13.5071 0.744078 13.3742C0.900358 13.2414 1.11232 13.1667 1.33333 13.1667ZM8 0.416748C7.77899 0.416748 7.56702 0.491376 7.41074 0.624214C7.25446 0.757052 7.16667 0.93722 7.16667 1.12508V9.33183L5.25583 7.70762C5.17896 7.63997 5.08701 7.58601 4.98534 7.54888C4.88367 7.51176 4.77432 7.49222 4.66367 7.4914C4.55302 7.49059 4.44329 7.50851 4.34087 7.54412C4.23846 7.57974 4.14541 7.63234 4.06717 7.69884C3.98893 7.76535 3.92705 7.84444 3.88515 7.93149C3.84325 8.01854 3.82216 8.11181 3.82312 8.20586C3.82409 8.29992 3.84707 8.39286 3.89075 8.47928C3.93442 8.5657 3.99791 8.64386 4.0775 8.70921L7.41083 11.5425C7.48841 11.6082 7.58044 11.6602 7.68167 11.6955C7.78245 11.7315 7.89068 11.7501 8 11.7501C8.10932 11.7501 8.21755 11.7315 8.31833 11.6955C8.41956 11.6602 8.51159 11.6082 8.58917 11.5425L11.9225 8.70921C12.0743 8.57561 12.1583 8.39669 12.1564 8.21096C12.1545 8.02524 12.0669 7.84758 11.9123 7.71625C11.7578 7.58492 11.5488 7.51043 11.3303 7.50881C11.1118 7.5072 10.9013 7.57859 10.7442 7.70762L8.83333 9.33183V1.12508C8.83333 0.93722 8.74554 0.757052 8.58926 0.624214C8.43297 0.491376 8.22101 0.416748 8 0.416748Z" fill="white"></path>
+        </symbol>
+
+                <symbol id="ShareNew" viewBox="0 0 17 17" fill="none">
+            <path d="M13.4587 6.37492C14.0191 6.37492 14.5669 6.20875 15.0328 5.89742C15.4987 5.58609 15.8619 5.14358 16.0763 4.62586C16.2908 4.10813 16.3469 3.53844 16.2376 2.98883C16.1282 2.43922 15.8584 1.93437 15.4621 1.53812C15.0659 1.14187 14.561 0.87202 14.0114 0.762695C13.4618 0.65337 12.8921 0.70948 12.3744 0.923928C11.8567 1.13838 11.4142 1.50153 11.1028 1.96747C10.7915 2.43341 10.6253 2.98121 10.6253 3.54159C10.6291 3.8088 10.6713 4.07407 10.7507 4.32925L5.71022 6.69792C5.33905 6.24757 4.83788 5.92282 4.27519 5.76805C3.7125 5.61327 3.11574 5.63603 2.56647 5.83321C2.0172 6.03038 1.54221 6.39236 1.20642 6.86967C0.870637 7.34698 0.69043 7.91633 0.69043 8.49992C0.69043 9.08351 0.870637 9.65286 1.20642 10.1302C1.54221 10.6075 2.0172 10.9695 2.56647 11.1666C3.11574 11.3638 3.7125 11.3866 4.27519 11.2318C4.83788 11.077 5.33905 10.7523 5.71022 10.3019L10.7507 12.6706C10.6713 12.9258 10.6291 13.191 10.6253 13.4583C10.6237 14.1149 10.8496 14.7517 11.2647 15.2606C11.6797 15.7694 12.2582 16.1187 12.9017 16.2491C13.5452 16.3795 14.2141 16.2829 14.7944 15.9758C15.3748 15.6686 15.8308 15.1699 16.0849 14.5644C16.339 13.959 16.3754 13.2842 16.1881 12.6549C16.0008 12.0256 15.6012 11.4806 15.0574 11.1127C14.5135 10.7447 13.859 10.5766 13.2052 10.6368C12.5513 10.697 11.9386 10.9819 11.4711 11.443L6.32222 9.02409C6.39305 8.67847 6.39305 8.32208 6.32222 7.97646L11.4711 5.55679C12 6.08068 12.7142 6.37469 13.4587 6.37492ZM13.4587 2.12492C13.7389 2.12492 14.0128 2.20801 14.2457 2.36367C14.4787 2.51934 14.6603 2.74059 14.7675 2.99945C14.8747 3.25831 14.9028 3.54316 14.8481 3.81796C14.7935 4.09277 14.6585 4.3452 14.4604 4.54332C14.2623 4.74145 14.0099 4.87637 13.7351 4.93103C13.4602 4.98569 13.1754 4.95764 12.9165 4.85042C12.6577 4.74319 12.4364 4.56161 12.2808 4.32864C12.1251 4.09567 12.042 3.82178 12.042 3.54159C12.042 3.16586 12.1913 2.80553 12.4569 2.53985C12.7226 2.27418 13.083 2.12492 13.4587 2.12492ZM3.54201 9.91659C3.26182 9.91659 2.98792 9.8335 2.75495 9.67783C2.52198 9.52217 2.3404 9.30092 2.23318 9.04205C2.12595 8.78319 2.0979 8.49835 2.15256 8.22354C2.20722 7.94874 2.34215 7.69631 2.54027 7.49819C2.7384 7.30006 2.99082 7.16514 3.26563 7.11047C3.54044 7.05581 3.82528 7.08387 4.08414 7.19109C4.343 7.29831 4.56426 7.47989 4.71992 7.71286C4.87559 7.94583 4.95867 8.21973 4.95867 8.49992C4.95867 8.87564 4.80942 9.23598 4.54374 9.50165C4.27807 9.76733 3.91773 9.91659 3.54201 9.91659ZM13.4587 12.0416C13.7389 12.0416 14.0128 12.1247 14.2457 12.2803C14.4787 12.436 14.6603 12.6573 14.7675 12.9161C14.8747 13.175 14.9028 13.4598 14.8481 13.7346C14.7935 14.0094 14.6585 14.2619 14.4604 14.46C14.2623 14.6581 14.0099 14.793 13.7351 14.8477C13.4602 14.9024 13.1754 14.8743 12.9165 14.7671C12.6577 14.6599 12.4364 14.4783 12.2808 14.2453C12.1251 14.0123 12.042 13.7384 12.042 13.4583C12.042 13.0825 12.1913 12.7222 12.4569 12.4565C12.7226 12.1908 13.083 12.0416 13.4587 12.0416Z" fill="white"></path>
+        </symbol>
+
+        <symbol id="Volume" viewBox="0 0 19 16" fill="none">
+            <path d="M1.15838 9.93063C0.445373 8.74229 0.445373 7.25771 1.15838 6.06937C1.37596 5.70674 1.73641 5.45272 2.1511 5.36978L3.84413 5.03117C3.94499 5.011 4.03591 4.95691 4.10176 4.87788L6.17085 2.39498C7.3534 0.975916 7.94468 0.266384 8.47234 0.457422C9 0.648462 9 1.57207 9 3.41928L9 12.5807C9 14.4279 9 15.3515 8.47234 15.5426C7.94468 15.7336 7.3534 15.0241 6.17085 13.605L4.10176 11.1221C4.03591 11.0431 3.94499 10.989 3.84413 10.9688L2.1511 10.6302C1.73641 10.5473 1.37596 10.2933 1.15838 9.93063Z" fill="white"></path>
+            <path d="M11.5355 4.46447C12.4684 5.39732 12.9948 6.66105 13 7.9803C13.0052 9.29955 12.4888 10.5674 11.5633 11.5076" stroke="white" stroke-width="2" stroke-linecap="round"></path>
+            <path d="M15.6569 2.34314C17.1494 3.83572 17.9916 5.85769 17.9999 7.96848C18.0083 10.0793 17.182 12.1078 15.7012 13.6121" stroke="white" stroke-width="2" stroke-linecap="round"></path>
+        </symbol>
+    </svg>
+</div>
+
+				
+				
+
+					    <noscript><div><img src="https://mc.yandex.ru/watch/1641813" style="display: none; position:absolute; left:-9999px;" alt=""/></div></noscript><noscript><div><img src="https://mc.yandex.ru/watch/1641813" style="position:absolute; left:-9999px;" alt=""/></div></noscript><div style="position: fixed; left: -9999px;"><a href="https://www.liveinternet.ru/click;RTNEWS" target="_blank"><img id="licntD91E" width="31" height="31" style="border:0" title="LiveInternet" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7" alt=""></a></div>		
+				
+					
+		
+		
+				
+
+
+						
+		
+		
+		
+
+				
+        
+
+
+		
+				
+		
+			
+			
+		
+		
+
+						
+
+			
+
+</body></html>

--- a/fixtures/actualidad.rt.com/1781469971715.html
+++ b/fixtures/actualidad.rt.com/1781469971715.html
@@ -1,0 +1,836 @@
+<!DOCTYPE html><html prefix="og: http://ogp.me/ns#" lang="es"><head>
+		
+		<meta charset="UTF-8">
+		<meta name="viewport" value="width=device-width, initial-scale=1.0, user-scalable=yes">
+		<meta http-equiv="X-UA-Compatible" value="ie=edge">
+		<meta name="apple-mobile-web-app-capable" value="no">
+		<meta name="format-detection" value="telephone=yes">
+		<meta name="HandheldFriendly" value="true">
+		<meta name="MobileOptimzied" value="width">
+		<meta http-equiv="Content-Security-Policy" value="upgrade-insecure-requests">
+		<meta http-equiv="cleartype" value="on">
+		<meta name="navigation" value="tabbed">
+		<meta value="RT en Español" name="og:site_name">
+		<meta value="1208719029" name="fb:admins">
+		<meta value="272487402772119" name="fb:app_id">
+		<meta value="296334033272,1617180398564925,137254146931398,517943768564992,438569186541152,983067238497760,748645601988049" name="fb:pages">
+		<meta name="robots" value="max-snippet:-1, max-image-preview:large">
+		<meta name="theme-color" media="(prefers-color-scheme: light)" value="#ffffff">
+		<meta name="theme-color" media="(prefers-color-scheme: dark)" value="#161618">
+
+		<title>El almuerzo que salvó al mundo de un desastre nuclear en 1962 - RT</title>
+
+					<meta name="description" value="Un funcionario de inteligencia soviético y un periodista de televisión estadounidense establecieron comunicación entre Jruschov y Kennedy para solucionar la Crisis de los Misiles de Cuba.">
+		
+		<meta name="google-site-verification" value="NSXcARMfqMVdr_6SIvsk-wyen25_5U-zwm4EJqv5bKM">
+		<meta name="apple-itunes-app" value="app-id=649316948, app-argument=spanishrtnews://articles/610168">
+
+
+		
+		<link rel="preconnect" href="https://graph.facebook.com/" crossorigin="anonymous">
+<link rel="preconnect" href="https://mc.yandex.ru/" crossorigin="anonymous">
+<link rel="preconnect" href="https://counter.yadro.ru/" crossorigin="anonymous">		<link as="style" href="https://sf.esrt.site/static/build/css/main.9e55aa80.chunk.css" rel="preload">
+<link as="script" href="https://sf.esrt.site/static/build/js/35.65cf0274.chunk.js" rel="preload">
+<link as="script" href="https://sf.esrt.site/static/build/js/main.701fc6da.chunk.js" rel="preload"><link rel="dns-prefetch" href="https://connect.ok.ru/">
+					<meta value="article" name="og:type">
+					<meta value="https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear" name="og:url">
+					<meta value="El almuerzo que salvó al mundo de un desastre nuclear en 1962" name="og:title">
+		
+					<meta value="RT en Español" name="article:author">
+							<meta value="Un funcionario de inteligencia soviético y un periodista de televisión estadounidense establecieron comunicación entre Jruschov y Kennedy para solucionar la Crisis de los Misiles de Cuba." name="og:description">
+										<meta value="2026-06-13T13:12:13Z" name="article:modified_time">
+										<meta value="A fondo" name="article:section">
+					
+		
+									<meta name="publish-date" value="2026-06-13 13:12:13">
+					
+		
+		        <link rel="amphtml" href="https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear/amp">
+    
+									<link rel="canonical" href="https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear">
+					
+		    <meta name="twitter:site" value="@ActualidadRT">
+    <meta name="twitter:card" value="summary_large_image">
+    <meta name="twitter:description" value="Un funcionario de inteligencia soviético y un periodista de televisión estadounidense establecieron comunicación entre Jruschov y Kennedy para solucionar la Crisis de los Misiles de Cuba.">
+    <meta name="twitter:image:width" value="630">
+    <meta name="twitter:image:height" value="354">
+            <meta name="twitter:image" value="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29850ce9ff7112e83c19ea.jpg">
+                <meta name="published_time_telegram" value="2026-06-13T13:12:13+00:00">
+    
+									<meta name="mediator_published_time" value="2026-06-13T13:12:13+00:00">
+					
+					<meta value="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29850ce9ff7112e83c19ea.jpg" name="og:image">
+		
+						
+
+		<link rel="manifest" href="https://actualidad.rt.com/manifest.webmanifest">
+		<link href="https://plus.google.com/117205813728682314068" rel="publisher">
+		<link rel="shortcut icon" href="https://actualidad.rt.com/favicon.ico" type="image/x-icon">
+		<link rel="icon" href="https://actualidad.rt.com/favicon.ico" type="image/x-icon">
+		<link rel="apple-touch-icon" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-precomposed.png">
+		<link rel="apple-touch-icon" sizes="72x72" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-72x72-precomposed.png">
+		<link rel="apple-touch-icon" sizes="114x114" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-114x114-precomposed.png">
+		<link rel="apple-touch-icon" sizes="144x144" href="https://actualidad.rt.com/static/img/head/apple-touch-icon-144x144-precomposed.png">
+
+
+				    <link as="style" href="https://sf.esrt.site/static/css/custom.css?v=2" rel="preload">
+    <link href="https://sf.esrt.site/static/css/custom.css?v=2" rel="stylesheet">
+    
+    <link href="https://sf.esrt.site/static/build/css/main.9e55aa80.chunk.css" rel="stylesheet">
+
+		
+
+				
+				    
+    
+    
+
+			
+
+			
+			
+
+			
+	</head>
+
+
+		<body class="Theme-isDefault" data-nav="false"> 				
+
+		    <div class="ReadLine-isReact" data-rtcomponent="ReadLine"></div>
+
+		<div class="App-root App-isColumn-isCenter">
+							<div class="App-header App-isColumn-isCenter" id="app-header">
+					
+
+<header class="Header-root Header-white" id="header-root" data-module="Header" data-color="true"><div class="Header-logo"><a href="https://actualidad.rt.com/" class="Header-RT" aria-label="Home"><span class="Header-logoImage"><svg class="Icon-root Icon-rtLogo" width="64px" height="64px" fill="#77BC1F" version="1.1" viewBox="0 0 56 56" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><rect width="56" height="56"></rect><path d="m1 0h54c0.55228-1.0145e-16 1 0.44772 1 1v54c0 0.55228-0.44772 1-1 1h-54c-0.55228 0-1-0.44772-1-1v-54c-6.7635e-17 -0.55228 0.44772-1 1-1z"></path><g transform="translate(8 20)" fill="#000"><polygon points="24.372 0.32996 24.372 2.3017 31.843 2.3017 31.843 17 40.53 17 40.53 2.3017 48 2.3017 48 0.32996"></polygon><path d="m12.907 7.8584c0.66346 0 1.2681-0.28214 1.7137-0.76234 0.47758-0.51014 0.76946-1.2094 0.76946-1.9264h-0.003977 0.003977c0-0.71699-0.29188-1.5059-0.76946-2.0165-0.44559-0.47895-1.0503-0.85143-1.7137-0.85143h-3.5163v5.5567h3.5163zm7.0223-7.5284c1.1876 0.046067 2.298 0.4535 3.0839 1.2933 0.81597 0.88441 1.3622 2.1124 1.3622 3.5464h0.0065706-0.0065706c0 1.2547-0.50646 2.4435-1.3223 3.3198-0.50923 0.54545-1.1267 0.93836-1.8244 1.1771l5.1548 7.3334h-9.4655l-4.592-6.9907h-2.9354v6.9907h-8.6456v-16.67h19.184z"></path></g></g></svg></span></a></div><div class="header--notification">El canal internacional<br>de noticias en español<br>más visto en el mundo</div><div class="Header-enVivo"><a href="https://actualidad.rt.com/en_vivo" class="Link-root Link-isEnVivo">En vivo</a></div><div class="Header-nav"><nav class="MainMenu-root"><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/todas_las_noticias" class="Link-root Link-isHover">Noticias</a></div><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/viral" class="Link-root Link-isHover">Viral</a></div><div class="MainMenu-itemMenu MainMenu-itemSubMenu" tabindex="0"><a href="https://actualidad.rt.com/programas" class="Link-root Link-hasDownIcon MainMenu-linkDesktop">
+                        Programas
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></a><input type="checkbox" name="menu" class="MainMenu-input" id="programas" aria-label="programas"><label class="Link-root Link-hasDownIcon MainMenu-linkMobile" for="programas">
+                        Programas
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></label><div class="MainMenu-subMenu"><div class="MainMenu-subList"><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/rt_reporta" class="Link-root Link-isNoHover">RT reporta</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://www.ahilesva.info/" class="Link-root Link-isNoHover">Ahí les Va</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/conversando-correa" class="Link-root Link-isNoHover">Conversando con Correa</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/cartas-mesa" class="Link-root Link-isNoHover">Cartas sobre la mesa</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/documentales" class="Link-root Link-isNoHover">Documentales</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/africa-lumumba" class="Link-root Link-isNoHover">El África de Lumumba</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/zoom" class="Link-root Link-isNoHover">El Zoom</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/zoom_plus" class="Link-root Link-isNoHover">ZOOM+</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/entrevista" class="Link-root Link-isNoHover">Entrevista</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/codigo-abierto" class="Link-root Link-isNoHover">Código Abierto</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/impacto-directo" class="Link-root Link-isNoHover">Impacto Directo</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/la_lista_de_erick" class="Link-root Link-isNoHover">La lista de Erick</a></div></div></div></div></div><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/opinion" class="Link-root Link-isHover">Opinión</a></div><div class="MainMenu-itemMenu MainMenu-itemSubMenu" tabindex="0"><a href="https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear#" class="Link-root Link-hasDownIcon MainMenu-linkDesktop">
+                        Multimedia
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></a><input type="checkbox" name="menu" class="MainMenu-input" id="multimedia" aria-label="multimedia"><label class="Link-root Link-hasDownIcon MainMenu-linkMobile" for="multimedia">
+                        Multimedia
+                        <svg class="Icon-root Icon-down" width="10px" height="6px" fill="#141414" version="1.1" viewBox="0 0 10 6" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-480 -30)"><g transform="translate(216 12)"><path transform="translate(269 21) rotate(90) translate(-269 -21)" d="m271.76 21.557-4.3665 4.2119c-0.31938 0.30772-0.83585 0.30772-1.1552 0-0.31884-0.30772-0.31884-0.8064 0-1.1141l3.7894-3.6548-3.7894-3.6553c-0.31884-0.30772-0.31884-0.8064 0-1.1141 0.31938-0.30772 0.83585-0.30772 1.1552 0l4.3665 4.2124c0.31884 0.30772 0.31884 0.8064 0 1.1141z"></path></g></g></g></svg></label><div class="MainMenu-subMenu"><div class="MainMenu-subList"><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/video" class="Link-root Link-isNoHover">Videos</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/programas/promo" class="Link-root Link-isNoHover">Promo</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/comics" class="Link-root Link-isNoHover">Osografía</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/falso-real-ia" class="Link-root Link-isNoHover">Falso o real</a></div></div><div class="MainMenu-subItem"><div class="MainMenu-subMenuLink" tabindex="0"><a href="https://actualidad.rt.com/palabra_secreta" class="Link-root Link-isNoHover">Palabra secreta</a></div></div></div></div></div><div class="MainMenu-itemMenu" tabindex="0"><a href="https://actualidad.rt.com/acerca/equipo" class="Link-root Link-isHover">Equipo de RT</a></div></nav><div class="MainMenu-mobile MainMenu-socials"><ul class="Socials-root"><li class="Socials-item Socials-VkIcon"><a href="https://vk.com/actualidadrt" class="Link-root Link-socials" target="_blank" aria-label="VkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-vk" height="13px" fill="#141414" version="1.1" viewBox="0 0 22 13" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -10)"><path d="m26.16 11.013c0.16-0.49333 0-0.85333-0.69333-0.85333h-2.32c-0.44243-0.020208-0.84913 0.242-1.0133 0.65333-0.72722 1.7134-1.6923 3.3159-2.8667 4.76-0.53333 0.53333-0.78667 0.72-1.08 0.72-0.29333 0-0.36-0.18667-0.36-0.68v-4.6133c0-0.58667-0.18667-0.85333-0.68-0.85333h-3.6533c-0.14856-0.0072434-0.29391 0.044915-0.40397 0.14497s-0.17579 0.23978-0.1827 0.38836c0 0.56 0.84 0.70667 0.93333 2.28v3.4267c0 0.74667-0.13333 0.88-0.42667 0.88-0.8 0-2.6667-2.9067-3.8533-6.2267-0.22667-0.65333-0.45333-0.89333-1.04-0.89333h-2.3467c-0.68 0-0.78667 0.30667-0.78667 0.65333 0 0.6 0.78667 3.6667 3.6667 7.72 1.5436 2.4836 4.1889 4.0718 7.1067 4.2667 1.48 0 1.6667-0.34667 1.6667-0.90667v-2.0933c0-0.68 0.13333-0.78667 0.61333-0.78667s0.94667 0.17333 2.32 1.5067c1.5733 1.5733 1.84 2.2933 2.6667 2.2933h2.32c0.68 0 1-0.33333 0.81333-0.98667-0.50005-0.99197-1.1625-1.8933-1.96-2.6667-0.54667-0.64-1.3333-1.3333-1.6-1.68-0.26667-0.34667-0.25333-0.62667 0-1.0267 0 0 2.8133-4 3.1067-5.3333"></path></g></g></svg></a></li><li class="Socials-item Socials-Rumble"><a href="https://rumble.com/c/RTES" class="Link-root Link-socials" target="_blank" aria-label="Rumble" rel="noopener noreferrer"><svg class="Icon-root Icon-rumble" width="18" height="19.773768216516" fill="#141414" xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="0 0 1441 1583"><path id="Layer" fill-rule="evenodd" d="m1339.3 537.2c32.1 35.2 57.5 75.9 74.8 120.3 17.2 44.4 26.1 91.5 26.2 139.2 0.1 47.6-8.6 94.8-25.7 139.2-17.1 44.4-42.3 85.3-74.3 120.6-57.2 63.1-119 121.9-184.9 175.9-65.9 54-135.7 103-208.9 146.7-73.1 43.6-149.4 81.8-228.2 114.2-78.8 32.4-159.9 59-242.6 79.4-42.2 10.6-86.1 12.9-129.1 6.8-43.1-6.1-84.6-20.4-122.2-42.3-37.7-21.8-70.7-50.7-97.4-85-26.6-34.4-46.4-73.6-58.2-115.4-100.4-343-85.6-730.8 11.2-1075.3 51-180.9 221.3-294.5 396.7-252.7 324.8 77.4 629.6 276.7 862.6 528.4zm-457.3 356.2c61.2-48.4 61.2-142.7 0-192.6q-32.6-27.1-66.8-52.1-34.2-25.1-69.9-48-35.6-22.9-72.6-43.7-37-20.7-75.2-39.2c-70.3-33.6-148.8 13.3-160.1 93.3-17.3 122.3-20.4 245.6-9.1 362.8 7.6 81.1 85.1 129.5 156.5 98.4q39.9-17.2 78.6-37 38.7-19.8 76-42.2 37.3-22.4 73-47.2 35.7-24.8 69.6-52z"></path></svg></a></li><li class="Socials-item Socials-XIcon"><a href="https://x.com/ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="XIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-x" fill="#141414" version="1.1" viewBox="0 0 24 24" width="18" height="18" xmlns="https://www.w3.org/2000/svg"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg></a></li><li class="Socials-item Socials-TelegramIcon"><a href="https://telegram.me/rtnoticias" class="Link-root Link-socials" target="_blank" aria-label="TelegramIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-telegram" height="16px" fill="#141414" version="1.1" viewBox="0 0 20 16" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -8)"><path d="m24.798 8.8742v-0.084507c0.021962-0.35088-0.19811-0.67117-0.53226-0.77465-0.12528-0.020023-0.25291-0.020023-0.37818 0-0.41728-0.009814-0.83209 0.066897-1.2186 0.22535-1.2186 0.45071-2.4232 0.92958-3.6278 1.4085l-2.4512 0.87324-1.1065 0.46479-1.3166 0.5493-1.2466 0.53521c-1.6341 0.68545-3.2589 1.4038-4.8744 2.1549-0.70034 0.33803-1.4007 0.67606-2.073 1.0563-0.10024 0.054347-0.19029 0.12584-0.26613 0.21127-0.068477 0.066368-0.10716 0.15789-0.10716 0.25352s0.038685 0.18715 0.10716 0.25352c0.071194 0.080837 0.15668 0.1477 0.25212 0.19718 0.14189 0.093286 0.29192 0.17343 0.44822 0.23944 0.66227 0.30344 1.3458 0.55764 2.045 0.76056 0.49383 0.17864 1.0059 0.30146 1.5267 0.3662 0.58774 0.065441 1.181-0.057813 1.6948-0.35211 0.75637-0.43193 1.4987-0.90141 2.2271-1.4085 1.2606-0.83099 2.5072-1.7183 3.7398-2.5916 0.44956-0.34416 0.91712-0.66387 1.4007-0.95775 0.14179-0.1018 0.29748-0.18245 0.46223-0.23944 0.0693-0.014425 0.1408-0.014425 0.2101 0 0.11205 0 0.16808 0 0.15408 0.16901-0.0049925 0.14954-0.059181 0.2932-0.15408 0.40845-0.4062 0.42254-0.8124 0.84507-1.2326 1.2535-0.84041 0.80282-1.7088 1.5634-2.5492 2.3521l-1.4007 1.2817c-0.24176 0.22419-0.43282 0.49797-0.56027 0.80282-0.087561 0.19393-0.12143 0.40804-0.098048 0.61972 0.032149 0.24791 0.16373 0.47181 0.36418 0.61972l0.71435 0.50704 5.1825 3.5211 0.30815 0.21127c0.43391 0.27815 0.97867 0.31543 1.4461 0.098957 0.46738-0.21647 0.79328-0.65701 0.86507-1.1694l0.42021-2.3944 0.42021-2.5634c0.15408-0.88733 0.29414-1.7747 0.43421-2.662 0.11205-0.64789 0.2101-1.2958 0.30815-1.9437l0.37818-2.7324c0-0.50704 0.056027-1.0141 0.084041-1.5211z"></path></g></g></svg></a></li><li class="Socials-item Socials-BlueSky"><a href="https://bsky.app/profile/actualidadrt.bsky.social" class="Link-root Link-socials" target="_blank" aria-label="BlueSky" rel="noopener noreferrer"><svg class="Icon-root Icon-blueSky" width="20" height="17.666666666667" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" version="1.1"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"></path></svg></a></li><li class="Socials-item Socials-OkIcon"><a href="https://ok.ru/group/70000046273774" class="Link-root Link-socials" target="_blank" aria-label="OkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-ok" width="25" height="25" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" version="1.1"><path d="M100.1 99.2C109.8 99.2 118.6 95.2 124.9 88.9C131.2 82.6 135.2 73.8 135.2 64.1C135.2 54.4 131.2 45.6 124.9 39.3C118.6 33 109.8 29 100.1 29C90.3999 29 81.5999 33 75.2999 39.3C68.9999 45.5 64.9999 54.3 64.9999 64.1C64.9999 73.9 68.9999 82.6 75.2999 88.9C81.5999 95.2 90.4999 99.2 100.1 99.2ZM88.8999 52.7C91.7999 49.8 95.7999 48 100.2 48C104.7 48 108.6 49.8 111.5 52.7C114.4 55.6 116.2 59.6 116.2 64C116.2 68.5 114.4 72.4 111.5 75.3C108.6 78.2 104.6 80 100.2 80C95.6999 80 91.7999 78.2 88.8999 75.3C85.9999 72.4 84.1999 68.4 84.1999 64C84.1999 59.6 86.0999 55.6 88.8999 52.7Z"></path><path d="M147.5 113.4L137.2 99.3C136.6 98.5 135.4 98.4 134.7 99.1C125 107.4 113 112.8 100.1 112.8C87.2 112.8 75.3 107.4 65.5 99.1C64.8 98.5 63.6 98.6 63 99.3L52.7 113.4C52.2 114.1 52.3 115 52.9 115.6C61.6 122.6 71.7 127.4 82.2 129.9L60.4 168.3C59.8 169.4 60.6 170.8 61.8 170.8H83.1C83.8 170.8 84.4 170.4 84.6 169.7L99.8 135.7L115 169.7C115.2 170.3 115.8 170.8 116.5 170.8H137.8C139.1 170.8 139.8 169.5 139.2 168.3L117.4 129.9C127.9 127.4 138 122.8 146.7 115.6C148 115 148.1 114.1 147.5 113.4Z"></path></svg></a></li><li class="Socials-item Socials-feedback"><div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022icon\u0022'),
+    };"></div></li></ul></div><div class="MainMenu-mobile MainMenu-onTv"><a href="https://actualidad.rt.com/satelites" class="Link-root Link-isOnTv">Véanos en TV</a></div></div><div class="Header-search"><div class="Search-isReact" data-rtcomponent="Search"></div></div><div class="Header-onTv"><a href="https://actualidad.rt.com/satelites" class="Link-root Link-isOnTv">Véanos en TV</a></div><div class="Header-socials"><ul class="Socials-root"><li class="Socials-item Socials-VkIcon"><a href="https://vk.com/actualidadrt" class="Link-root Link-socials" target="_blank" aria-label="VkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-vk" height="13px" fill="#141414" version="1.1" viewBox="0 0 22 13" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -10)"><path d="m26.16 11.013c0.16-0.49333 0-0.85333-0.69333-0.85333h-2.32c-0.44243-0.020208-0.84913 0.242-1.0133 0.65333-0.72722 1.7134-1.6923 3.3159-2.8667 4.76-0.53333 0.53333-0.78667 0.72-1.08 0.72-0.29333 0-0.36-0.18667-0.36-0.68v-4.6133c0-0.58667-0.18667-0.85333-0.68-0.85333h-3.6533c-0.14856-0.0072434-0.29391 0.044915-0.40397 0.14497s-0.17579 0.23978-0.1827 0.38836c0 0.56 0.84 0.70667 0.93333 2.28v3.4267c0 0.74667-0.13333 0.88-0.42667 0.88-0.8 0-2.6667-2.9067-3.8533-6.2267-0.22667-0.65333-0.45333-0.89333-1.04-0.89333h-2.3467c-0.68 0-0.78667 0.30667-0.78667 0.65333 0 0.6 0.78667 3.6667 3.6667 7.72 1.5436 2.4836 4.1889 4.0718 7.1067 4.2667 1.48 0 1.6667-0.34667 1.6667-0.90667v-2.0933c0-0.68 0.13333-0.78667 0.61333-0.78667s0.94667 0.17333 2.32 1.5067c1.5733 1.5733 1.84 2.2933 2.6667 2.2933h2.32c0.68 0 1-0.33333 0.81333-0.98667-0.50005-0.99197-1.1625-1.8933-1.96-2.6667-0.54667-0.64-1.3333-1.3333-1.6-1.68-0.26667-0.34667-0.25333-0.62667 0-1.0267 0 0 2.8133-4 3.1067-5.3333"></path></g></g></svg></a></li><li class="Socials-item Socials-Rumble"><a href="https://rumble.com/c/RTES" class="Link-root Link-socials" target="_blank" aria-label="Rumble" rel="noopener noreferrer"><svg class="Icon-root Icon-rumble" width="18" height="19.773768216516" fill="#141414" xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="0 0 1441 1583"><path id="Layer" fill-rule="evenodd" d="m1339.3 537.2c32.1 35.2 57.5 75.9 74.8 120.3 17.2 44.4 26.1 91.5 26.2 139.2 0.1 47.6-8.6 94.8-25.7 139.2-17.1 44.4-42.3 85.3-74.3 120.6-57.2 63.1-119 121.9-184.9 175.9-65.9 54-135.7 103-208.9 146.7-73.1 43.6-149.4 81.8-228.2 114.2-78.8 32.4-159.9 59-242.6 79.4-42.2 10.6-86.1 12.9-129.1 6.8-43.1-6.1-84.6-20.4-122.2-42.3-37.7-21.8-70.7-50.7-97.4-85-26.6-34.4-46.4-73.6-58.2-115.4-100.4-343-85.6-730.8 11.2-1075.3 51-180.9 221.3-294.5 396.7-252.7 324.8 77.4 629.6 276.7 862.6 528.4zm-457.3 356.2c61.2-48.4 61.2-142.7 0-192.6q-32.6-27.1-66.8-52.1-34.2-25.1-69.9-48-35.6-22.9-72.6-43.7-37-20.7-75.2-39.2c-70.3-33.6-148.8 13.3-160.1 93.3-17.3 122.3-20.4 245.6-9.1 362.8 7.6 81.1 85.1 129.5 156.5 98.4q39.9-17.2 78.6-37 38.7-19.8 76-42.2 37.3-22.4 73-47.2 35.7-24.8 69.6-52z"></path></svg></a></li><li class="Socials-item Socials-XIcon"><a href="https://x.com/ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="XIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-x" fill="#141414" version="1.1" viewBox="0 0 24 24" width="18" height="18" xmlns="https://www.w3.org/2000/svg"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg></a></li><li class="Socials-item Socials-TelegramIcon"><a href="https://telegram.me/rtnoticias" class="Link-root Link-socials" target="_blank" aria-label="TelegramIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-telegram" height="16px" fill="#141414" version="1.1" viewBox="0 0 20 16" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -8)"><path d="m24.798 8.8742v-0.084507c0.021962-0.35088-0.19811-0.67117-0.53226-0.77465-0.12528-0.020023-0.25291-0.020023-0.37818 0-0.41728-0.009814-0.83209 0.066897-1.2186 0.22535-1.2186 0.45071-2.4232 0.92958-3.6278 1.4085l-2.4512 0.87324-1.1065 0.46479-1.3166 0.5493-1.2466 0.53521c-1.6341 0.68545-3.2589 1.4038-4.8744 2.1549-0.70034 0.33803-1.4007 0.67606-2.073 1.0563-0.10024 0.054347-0.19029 0.12584-0.26613 0.21127-0.068477 0.066368-0.10716 0.15789-0.10716 0.25352s0.038685 0.18715 0.10716 0.25352c0.071194 0.080837 0.15668 0.1477 0.25212 0.19718 0.14189 0.093286 0.29192 0.17343 0.44822 0.23944 0.66227 0.30344 1.3458 0.55764 2.045 0.76056 0.49383 0.17864 1.0059 0.30146 1.5267 0.3662 0.58774 0.065441 1.181-0.057813 1.6948-0.35211 0.75637-0.43193 1.4987-0.90141 2.2271-1.4085 1.2606-0.83099 2.5072-1.7183 3.7398-2.5916 0.44956-0.34416 0.91712-0.66387 1.4007-0.95775 0.14179-0.1018 0.29748-0.18245 0.46223-0.23944 0.0693-0.014425 0.1408-0.014425 0.2101 0 0.11205 0 0.16808 0 0.15408 0.16901-0.0049925 0.14954-0.059181 0.2932-0.15408 0.40845-0.4062 0.42254-0.8124 0.84507-1.2326 1.2535-0.84041 0.80282-1.7088 1.5634-2.5492 2.3521l-1.4007 1.2817c-0.24176 0.22419-0.43282 0.49797-0.56027 0.80282-0.087561 0.19393-0.12143 0.40804-0.098048 0.61972 0.032149 0.24791 0.16373 0.47181 0.36418 0.61972l0.71435 0.50704 5.1825 3.5211 0.30815 0.21127c0.43391 0.27815 0.97867 0.31543 1.4461 0.098957 0.46738-0.21647 0.79328-0.65701 0.86507-1.1694l0.42021-2.3944 0.42021-2.5634c0.15408-0.88733 0.29414-1.7747 0.43421-2.662 0.11205-0.64789 0.2101-1.2958 0.30815-1.9437l0.37818-2.7324c0-0.50704 0.056027-1.0141 0.084041-1.5211z"></path></g></g></svg></a></li><li class="Socials-item Socials-BlueSky"><a href="https://bsky.app/profile/actualidadrt.bsky.social" class="Link-root Link-socials" target="_blank" aria-label="BlueSky" rel="noopener noreferrer"><svg class="Icon-root Icon-blueSky" width="20" height="17.666666666667" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" version="1.1"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"></path></svg></a></li><li class="Socials-item Socials-OkIcon"><a href="https://ok.ru/group/70000046273774" class="Link-root Link-socials" target="_blank" aria-label="OkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-ok" width="25" height="25" fill="#141414" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" version="1.1"><path d="M100.1 99.2C109.8 99.2 118.6 95.2 124.9 88.9C131.2 82.6 135.2 73.8 135.2 64.1C135.2 54.4 131.2 45.6 124.9 39.3C118.6 33 109.8 29 100.1 29C90.3999 29 81.5999 33 75.2999 39.3C68.9999 45.5 64.9999 54.3 64.9999 64.1C64.9999 73.9 68.9999 82.6 75.2999 88.9C81.5999 95.2 90.4999 99.2 100.1 99.2ZM88.8999 52.7C91.7999 49.8 95.7999 48 100.2 48C104.7 48 108.6 49.8 111.5 52.7C114.4 55.6 116.2 59.6 116.2 64C116.2 68.5 114.4 72.4 111.5 75.3C108.6 78.2 104.6 80 100.2 80C95.6999 80 91.7999 78.2 88.8999 75.3C85.9999 72.4 84.1999 68.4 84.1999 64C84.1999 59.6 86.0999 55.6 88.8999 52.7Z"></path><path d="M147.5 113.4L137.2 99.3C136.6 98.5 135.4 98.4 134.7 99.1C125 107.4 113 112.8 100.1 112.8C87.2 112.8 75.3 107.4 65.5 99.1C64.8 98.5 63.6 98.6 63 99.3L52.7 113.4C52.2 114.1 52.3 115 52.9 115.6C61.6 122.6 71.7 127.4 82.2 129.9L60.4 168.3C59.8 169.4 60.6 170.8 61.8 170.8H83.1C83.8 170.8 84.4 170.4 84.6 169.7L99.8 135.7L115 169.7C115.2 170.3 115.8 170.8 116.5 170.8H137.8C139.1 170.8 139.8 169.5 139.2 168.3L117.4 129.9C127.9 127.4 138 122.8 146.7 115.6C148 115 148.1 114.1 147.5 113.4Z"></path></svg></a></li><li class="Socials-item Socials-feedback"><div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022icon\u0022'),
+    };"></div></li></ul></div><div class="Header-langSelect"><div class="LangSelect-root" tabindex="0"><div class="LangSelect-selected">
+            Esp
+        </div><ul class="LangSelect-options"><li class="LangSelect-option "><a href="https://rtbrasil.com/" target="_blank" rel="noopener noreferrer">Br</a></li><li class="LangSelect-option "><a href="https://arabic.rt.com/" target="_blank" rel="noopener noreferrer">Ar</a></li><li class="LangSelect-option "><a href="https://de.rt.com/" target="_blank" rel="noopener noreferrer">De</a></li><li class="LangSelect-option "><a href="https://swentr.site/" target="_blank" rel="noopener noreferrer">En</a></li><li class="LangSelect-option LangSelect-isSelect"><a href="https://actualidad.rt.com/" target="_blank" rel="noopener noreferrer">Esp</a></li><li class="LangSelect-option "><a href="https://francais.rt.com/" target="_blank" rel="noopener noreferrer">Fr</a></li><li class="LangSelect-option "><a href="https://rt.rs/" target="_blank" rel="noopener noreferrer">Rs</a></li><li class="LangSelect-option "><a href="https://russian.rt.com/" target="_blank" rel="noopener noreferrer">Ru</a></li></ul></div></div><div class="Header-menuToggle"><button class="Header-item" type="button" id="nav-close" aria-label="Burger"><svg class="Icon-root Icon-burger Icon-burger_open" width="16px" height="16px" fill="#141414" version="1.1" viewBox="0 0 16 12" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-382 -18)"><g transform="translate(382 18)"><rect width="16" height="1.7143"></rect><rect y="5.1429" width="16" height="1.7143"></rect><rect y="10.286" width="16" height="1.7143"></rect></g></g></g></svg><svg class="Icon-root Icon-burger Icon-burger_close" width="16px" height="16px" fill="#141414" version="1.1" viewBox="0 0 12 12" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-384 -16)"><g transform="translate(384 16)"><polygon transform="translate(5.996 5.9918) rotate(225) translate(-5.996 -5.9918)" points="-1.1646 5.1481 13.157 5.1481 13.157 6.8356 -1.1646 6.8356"></polygon><polygon transform="translate(6.0082 5.996) rotate(-45) translate(-6.0082 -5.996)" points="-1.1525 5.1523 13.169 5.1523 13.169 6.8398 -1.1525 6.8398"></polygon></g></g></g></svg></button></div></header>					
+											
+
+									</div>
+			
+			
+
+						    <div class="TopBanner-root top-banners-with-mobile">
+                
+                    <div id="adfox_163033544650936060" style="margin: 0 auto; max-width: 1488px; width: 100%;"></div>
+        <div id="adfox_163033548998539595" style="margin: 0 auto; max-width: 1488px; width: 100%;"></div>
+        
+    
+    
+        </div>
+			
+
+			    <main class="App-content">
+        <div class="Grid-root">
+            <div class="Grid-title Grid-isSticky">
+                        
+                                                                                
+            
+                                                                        
+            
+            <div class="HeaderVertical-root HeaderVertical-type_1 ColorTxt-WhiteSmoke">
+                A fondo
+            </div>
+            
+            </div>
+            <section class="Grid-container Grid-isWrap">
+                <div class="Grid-block Grid-is3to4-sm_is1to1-xs_is1to1">
+                                        <div class="Section-root Section-is1to1">
+                        <div class="Section-container Section-isRow-isTop">
+                            <div class="Section-block Section-is1to1 pr-24 pl-24 pt-24 pb-4">
+                                
+<div class="Breadcrumbs-root"><span class="Breadcrumbs-item"><a class="RTLink-root RTLink-breadcrumb RTLink-size_1" href="https://actualidad.rt.com/"><span>Portada</span></a></span><span class="Breadcrumbs-item Breadcrumbs-arrow"><svg width="6px" height="10px" fill="#888"><use xlink:href="https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear#arrowRight"></use></svg></span><span class="Breadcrumbs-item"><a class="RTLink-root RTLink-breadcrumb RTLink-size_1" href="https://actualidad.rt.com/a-fondo/"><span>A fondo</span></a></span></div>                            </div>
+                        </div>
+                    </div>
+
+                    <div class="Section-root Section-is1to1">
+                        <div class="Section-container Section-isRow-isTop">
+                            <div class="Section-block Section-is1to1">
+                                                                
+
+
+
+
+
+
+
+
+
+
+<div class="ArticleView-root ArticleView-is1to1"><div class="ArticleView-container" data-counterurl="https://nbc.rt.com/nbc/es/" data-counterpublicid="610168"><div class="ArticleView-block ArticleView-is1to1-sm_is1to1-xs_is1to1 p-24"><div class="ArticleView-title"><h1 class="HeadLine-root HeadLine-type_2 ">
+                El almuerzo que salvó al mundo de un desastre nuclear en 1962
+            </h1></div><div class="ArticleView-timestamp-and-authors"><div class="ArticleView-authors"></div><div class="ArticleView-timestamp"><span>Publicado:</span><time class="Timestamp-root Timestamp-isBlackColor " datetime="2026-06-13T13:12:13+00:00">
+        13 jun 2026 13:12 GMT
+    </time></div></div><div class="ArticleView-shares"><div class="ShareBlock-isReact" data-rtcomponent="ShareBlock" onload="return {
+        socials: JSON.parse('\u005B\u0022facebook\u0022,\u0022xtwitter\u0022,\u0022whatsapp\u0022,\u0022telegram\u0022,\u0022mailto\u0022,\u0022copylink\u0022\u005D'),
+        direction: JSON.parse('\u0022column\u0022'),
+        type: JSON.parse('\u0022hasFull\u0022'),
+        params: JSON.parse('\u007B\u0022counters\u0022\u003Atrue,\u0022href\u0022\u003A\u0022https\u003A\\\/\\\/actualidad.rt.com\\\/a\u002Dfondo\\\/610168\u002Dalmuerzo\u002Dsalvo\u002Dmundo\u002Ddesastre\u002Dnuclear\u0022,\u0022shortUrl\u0022\u003A\u0022https\u003A\\\/\\\/es\u002Drt.com\\\/d2t4\u0022\u007D'),
+    };"></div></div><div class="ArticleView-summary"><div class="Text-root Text-type_1 ">
+                Un funcionario de inteligencia soviético y un periodista de televisión estadounidense establecieron comunicación entre Jruschov y Kennedy para solucionar la Crisis de los Misiles de Cuba.
+            </div></div><div class="ArticleView-coverWrap"><figure class="Cover-root"><div class="Cover-image"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29850ce9ff7112e83c19ea.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29850ce9ff7112e83c19ea.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29850ce9ff7112e83c19ea.jpg 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29850ce9ff7112e83c19ea.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29850ce9ff7112e83c19ea.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29850ce9ff7112e83c19ea.jpg" alt="El almuerzo que salvó al mundo de un desastre nuclear en 1962"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29850ce9ff7112e83c19ea.jpg" alt="El almuerzo que salvó al mundo de un desastre nuclear en 1962" /></noscript></div><figcaption class="Cover-footer"><span class="Cover-caption"><span class="Cover-captionItem">John A. Scali, periodista de la ABC (derecha), y Alexánder Feklísov, responsable de la inteligencia soviética en Estados Unidos</span></span><span class="Cover-source"><span class="Cover-captionItem">Servicio de Inteligencia Exterior de Rusia.</span><span class="Cover-captionItem"> /  Gettyimages.ru </span></span></figcaption></figure></div><div itemprop="articleBody"><div class="Text-root Text-type_5 ArticleView-text ViewText-root "><p>La Crisis de los Misiles de Cuba&nbsp;<strong>en 1962 estuvo a punto de desencadenar una guerra nuclear</strong>&nbsp;en plena escalada entre la URSS y Estados Unidos que hubiera conllevado&nbsp;el fin de la civilización. La catástrofe se evitó gracias al diálogo entre Moscú y Washington.</p><p>Pero los líderes de las superpotencias <strong>difícilmente habrían podido llegar a un acuerdo de no ser por un hombre que asumió esta iniciativa:</strong> el coronel de los servicios secretos soviéticos Alexánder Semiónovich Feklísov.</p><figure class="RTImage-root"><div class="RTImage-image RTImage-original"><picture class="Picture-root Picture-original"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29821159bf5b5a9256bcee.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29821159bf5b5a9256bcee.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29821159bf5b5a9256bcee.jpg 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29821159bf5b5a9256bcee.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29821159bf5b5a9256bcee.jpg" class="Picture-root Picture-original lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a29821159bf5b5a9256bcee.jpg" alt=""></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29821159bf5b5a9256bcee.jpg" alt="" /></noscript></div><figcaption class="RTImage-footer"><span class="RTImage-caption"><span class="RTImage-captionItem">El buque soviético Fizik Kurchatov, una de las naves que llevaron misiles a la isla, en el puerto de Casilda. En el muelle se aprecia la sombra del avión de reconocimiento F-101 que tomó la fotografía</span></span><span class="RTImage-source"><span class="RTImage-captionItem">CIA / Public Domain</span></span></figcaption></figure><p>Por extraño que parezca, el primer paso para resolver el casi inevitable conflicto&nbsp;fue dado por dos personas que no tenían nada que ver con los misiles en Cuba: el responsable de la inteligencia soviética en EE.UU. y un periodista estadounidense.</p><p>Se trataba de John A. Scali,&nbsp;periodista de la ABC, y Alexánder Feklísov, oficial de inteligencia soviético que oficialmente desempeñaba funciones de consejero en la Embajada de la URSS bajo el&nbsp;seudónimo de&nbsp;'Fomín'.</p><figure class="RTImage-root"><div class="RTImage-image RTImage-original"><picture class="Picture-root Picture-original"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814c59bf5b0ef26e82c7.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29814c59bf5b0ef26e82c7.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814c59bf5b0ef26e82c7.jpg 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29814c59bf5b0ef26e82c7.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814c59bf5b0ef26e82c7.jpg" class="Picture-root Picture-original lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814c59bf5b0ef26e82c7.jpg" alt=""></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a29814c59bf5b0ef26e82c7.jpg" alt="" /></noscript></div><figcaption class="RTImage-footer"><span class="RTImage-caption"><span class="RTImage-captionItem">Alexánder Feklísov con su libro de memorias</span></span><span class="RTImage-source"><span class="RTImage-captionItem"> AP </span></span></figcaption></figure><h3>Los servicios secretos soviéticos asumen el liderazgo en la solución&nbsp;</h3><p>En su calidad de jefe de la&nbsp;estación del KGB en Washington,&nbsp;<strong>Feklísov mantuvo al Kremlin informado detalladamente sobre cómo Washington buscaba una salida a la crisis</strong>&nbsp;tras la instalación de los misiles soviéticos en Cuba,&nbsp;<a href="http://svr.gov.ru/smi/2002/11/gudok20021105.htm" target="_blank" rel="noopener noreferrer">explicó</a>&nbsp;el Servicio de Inteligencia Exterior de Rusia.</p><p>Gracias a él, se supo que&nbsp;<strong>el presidente John F. Kennedy se resistía a las exigencias de los 'halcones' de un bombardeo masivo e inmediato</strong>&nbsp;de Cuba. El 21 de octubre de 1962, 'Fomín' envió un telegrama al mando del KGB informando sobre una reunión de emergencia del gobierno de Kennedy. Al día siguiente, en su discurso a la nación, el presidente estadounidense declaró una amenaza a la seguridad de Estados Unidos, y Nikita Jruschov&nbsp;le respondió con un mensaje, describiendo el bloqueo naval de Cuba como "acciones agresivas sin precedentes".</p><figure class="RTImage-root"><div class="RTImage-image RTImage-original"><picture class="Picture-root Picture-original"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg" class="Picture-root Picture-original lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg" alt=""></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29815059bf5b0ef26e82cc.jpg" alt="" /></noscript></div><figcaption class="RTImage-footer"><span class="RTImage-caption"><span class="RTImage-captionItem">Personal del Comando Aéreo Estratégico de EE.UU. interpretando una fotografía de reconocimiento durante la Crisis de los Misiles de Cuba, 1962</span></span><span class="RTImage-source"><span class="RTImage-captionItem"> AP </span></span></figcaption></figure><p>La situación se volvía cada vez más explosiva con el paso de las horas. La mañana del viernes 26 de octubre, <strong>Feklísov invitó al comentarista de política exterior de la ABC, John Scali, presentador de televisión y buen amigo de los hermanos Kennedy</strong>, a una reunión.</p>
+    <div class="ReadMore-root Section-root Section-is1to3-xs_is1to1" data-widgets="ReadMore">
+        <div class="Section-container Section-isRow-isTop-isWrap">
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<article class="Card-root Card-is1to1 Card-default">
+    
+                    
+            <div class="Card-imageWrap">
+                            
+    
+            
+        
+            
+    <div class="Card-picture">
+        
+<picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/634aebd459bf5b71ec25bd2f.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2022.10/article/634aebd459bf5b71ec25bd2f.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/634aebd459bf5b71ec25bd2f.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2022.10/article/634aebd459bf5b71ec25bd2f.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/634aebd459bf5b71ec25bd2f.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/634aebd459bf5b71ec25bd2f.jpg" alt="¿En qué se parecen y se diferencian la crisis de Ucrania con la de los misiles de Cuba?"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2022.10/article/634aebd459bf5b71ec25bd2f.jpg" alt="¿En qué se parecen y se diferencian la crisis de Ucrania con la de los misiles de Cuba?" /></noscript>    </div>
+
+                                            
+                    </div>
+        <div class="Card-contentWrap">
+        <div class="Card-content">
+                            
+                
+    <div class="Card-title">
+                        
+                                                                                            
+            
+                                                                        
+            
+            <div class="HeaderNews-root HeaderNews-type_6 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/actualidad/444898-armagedon-expertos-crisis-misiles-cuba" class="Link-root Link-isFullCard ">
+                ¿En qué se parecen y se diferencian la crisis de Ucrania con la de los misiles de Cuba?
+            </a>
+            
+            </div>
+            
+    </div>
+
+                
+        </div>
+            
+    
+            
+    
+    </div>
+</article>
+        </div>
+    </div>
+
+<p>Años más tarde, Scali recordó que Feklísov lo llamó y lo invitó a almorzar [no fue su primera reunión y la iniciativa de su encuentro anterior perteneció a&nbsp;<strong>Scali, quien estaba al tanto del verdadero papel de 'Fomín' en EE.UU.]</strong>: "Ya había almorzado cuando me llamó, pero su voz era tan urgente e insistente que decidí ir de inmediato",&nbsp;<a href="https://www.nytimes.com/1995/10/10/us/john-a-scali-77-abc-reporter-who-helped-ease-missile-crisis.html" target="_blank" rel="noopener noreferrer">señaló</a>&nbsp;el periodista estadounidense.</p><figure class="RTImage-root"><div class="RTImage-image RTImage-original"><picture class="Picture-root Picture-original"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg" class="Picture-root Picture-original lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg" alt=""></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29814f59bf5b0ef26e82ca.jpg" alt="" /></noscript></div><figcaption class="RTImage-footer"><span class="RTImage-caption"><span class="RTImage-captionItem">Nikita Khrushchev y John F. Kennedy: Feklísov y Scali se comunicaban en nombre de ambos</span></span><span class="RTImage-source"><span class="RTImage-captionItem"> AP </span></span></figcaption></figure><p>Los dos hombres se reunieron en el restaurante Occidental, a dos cuadras de la Casa Blanca, y después de pedir la comida, fueron directos al grano: la guerra, al parecer, estaba a punto de estallar.</p><h3>La amenaza 'no autorizada' del interlocutor soviético</h3><p>"<strong>El Pentágono le asegura al presidente que, si acepta, eliminarán los misiles soviéticos y el régimen de Castro en 48 horas</strong>", señaló Scali.</p><p>"Primero, respondí, que yo sepa, la cúpula soviética considera a Kennedy un estadista capaz y con visión de futuro. Creo que es un hombre razonable y que detendrá a los generales y almirantes belicosos que planean arrastrarlo a una gran aventura plagada de consecuencias catastróficas. Segundo, el pueblo cubano defenderá su libertad a vida o muerte. Tercero, el presidente debe ser plenamente consciente de que invadir Cuba equivaldría a darle rienda suelta a Jruschov. La <strong>Unión Soviética podría tomar represalias contra un punto vulnerable [de EE.UU.] en otra parte del mundo que tiene importancia militar y política para Washington</strong>.</p>
+    <div class="ReadMore-root Section-root Section-is1to3-xs_is1to1" data-widgets="ReadMore">
+        <div class="Section-container Section-isRow-isTop-isWrap">
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<article class="Card-root Card-is1to1 Card-default">
+    
+                    
+            <div class="Card-imageWrap">
+                            
+    
+            
+        
+            
+    <div class="Card-picture">
+        
+<picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.02/thumbnail/699ef21e59bf5b7d885252c1.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.02/article/699ef21e59bf5b7d885252c1.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.02/thumbnail/699ef21e59bf5b7d885252c1.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.02/article/699ef21e59bf5b7d885252c1.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.02/thumbnail/699ef21e59bf5b7d885252c1.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.02/thumbnail/699ef21e59bf5b7d885252c1.jpg" alt="&quot;El helado para ti es más importante que el comunismo&quot;: Mikoyán, el autor de la 'revolución culinaria' en la URSS"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.02/article/699ef21e59bf5b7d885252c1.jpg" alt="&quot;El helado para ti es más importante que el comunismo&quot;: Mikoyán, el autor de la &#039;revolución culinaria&#039; en la URSS" /></noscript>    </div>
+
+                                            
+                    </div>
+        <div class="Card-contentWrap">
+        <div class="Card-content">
+                            
+                
+    <div class="Card-title">
+                        
+                                                                                            
+            
+                                                                        
+            
+            <div class="HeaderNews-root HeaderNews-type_6 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/a-fondo/588825-mikoyan-crisis-misiles-stalin" class="Link-root Link-isFullCard ">
+                "El helado para ti es más importante que el comunismo": Mikoyán, el autor de la 'revolución culinaria' en la URSS
+            </a>
+            
+            </div>
+            
+    </div>
+
+                
+        </div>
+            
+    
+            
+    
+    </div>
+</article>
+        </div>
+    </div>
+
+<p>Al parecer, Scali no esperaba esa respuesta. Me miró fijamente a los ojos durante un largo rato y luego preguntó: '¿Crees, Alexánder, que <strong>será Berlín Occidental</strong>?'. 'Como contramedida, es totalmente posible', dije", <a href="https://coollib.cc/b/449631/read" target="_blank" rel="noopener noreferrer">recordó</a> Feklísov en su libro de memorias.</p><p>El resto de la comida transcurrió en silencio. Scali&nbsp;<a href="https://www.nytimes.com/1995/10/10/us/john-a-scali-77-abc-reporter-who-helped-ease-missile-crisis.html">recordó</a>&nbsp;que Feklísov estaba <strong>tan absorto en sus pensamientos que, sin querer, tomó los pasteles de cangrejo de Scali</strong>, y este último se terminó comiendo la chuleta de cerdo que Feklísov había pedido.</p><figure class="RTImage-root"><div class="RTImage-image RTImage-original"><picture class="Picture-root Picture-original"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png 460w,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png" class="Picture-root Picture-original lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png" alt=""></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/original/6a29823de9ff71266852b641.png" alt="" /></noscript></div><figcaption class="RTImage-footer"><span class="RTImage-caption"><span class="RTImage-captionItem">Retrato de John Scali en el restaurante Occidental y la placa de bronce que conmemora su reunión con Alexánder Feklísov</span></span><span class="RTImage-source"><span class="RTImage-captionItem"> Redes sociales </span></span></figcaption></figure><p>"Nadie me autorizó a hablar sobre la posible toma de Berlín Occidental como respuesta soviética a la invasión estadounidense de Cuba", recordó Alexánder Feklísov más tarde. "Actué bajo mi propio riesgo. Ahora está perfectamente claro: corrí un riesgo, pero tuve razón".</p><p>Los interlocutores en el restaurante Occidental jamás imaginaron que se encontrarían entre los <strong>mediadores de la solución global a la Crisis de los Misiles Cubanos</strong>. 'Fomín' fue a informar al embajador soviético sobre el contenido de la conversación, y Scali se dirigió a la Casa Blanca.</p>
+    <div class="ReadMore-root Section-root Section-is1to3-xs_is1to1" data-widgets="ReadMore">
+        <div class="Section-container Section-isRow-isTop-isWrap">
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<article class="Card-root Card-is1to1 Card-default">
+    
+                    
+            <div class="Card-imageWrap">
+                            
+    
+            
+        
+            
+    <div class="Card-picture">
+        
+<picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/635d04ea59bf5b72cb3fa145.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2022.10/article/635d04ea59bf5b72cb3fa145.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/635d04ea59bf5b72cb3fa145.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2022.10/article/635d04ea59bf5b72cb3fa145.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/635d04ea59bf5b72cb3fa145.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2022.10/thumbnail/635d04ea59bf5b72cb3fa145.jpg" alt="Lavrov explica en qué se asemejan y se diferencian la crisis de los misiles de Cuba y la situación en Ucrania"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2022.10/article/635d04ea59bf5b72cb3fa145.jpg" alt="Lavrov explica en qué se asemejan y se diferencian la crisis de los misiles de Cuba y la situación en Ucrania" /></noscript>    </div>
+
+                                            
+                    </div>
+        <div class="Card-contentWrap">
+        <div class="Card-content">
+                            
+                
+    <div class="Card-title">
+                        
+                                                                                            
+            
+                                                                        
+            
+            <div class="HeaderNews-root HeaderNews-type_6 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/actualidad/446373-lavrov-crisis-misiles-cuba-ucrania" class="Link-root Link-isFullCard ">
+                Lavrov explica en qué se asemejan y se diferencian la crisis de los misiles de Cuba y la situación en Ucrania
+            </a>
+            
+            </div>
+            
+    </div>
+
+                
+        </div>
+            
+    
+            
+    
+    </div>
+</article>
+        </div>
+    </div>
+
+<h3>El resultado del almuerzo</h3><p>Poco después de la conversación, el fiscal general de Estados Unidos, <strong>Robert Kennedy</strong>, a quien el líder estadounidense había encomendado la mediación en las negociaciones secretas con representantes soviéticos, <strong>transmitió a 'Fomín'</strong>, a través de Scali, propuestas de compromiso para resolver la crisis.</p><p>Para John F. Kennedy,&nbsp;<strong>la amenaza de un ataque a Berlín Occidental resultó ser un argumento</strong>&nbsp;decisivo durante las negociaciones. Propuso que Estados Unidos retiraría sus misiles emplazados en Turquía y dejaría a Cuba en paz,&nbsp;siempre y cuando&nbsp;la URSS retirara sus armas nucleares de la isla.</p><p>Y años después, una placa de bronce apareció en el interior del restaurante Occidental en Washington: "<strong>En esta mesa, durante los tensos momentos de la Crisis de los Misiles Cubanos, el misterioso ruso 'Sr. X' le transmitió al corresponsal de ABC-TV, John Scali, una oferta rusa para retirar los misiles de Cuba</strong>. Gracias a esta reunión, se evitó la amenaza de una posible guerra nuclear".</p></div></div><div class="ArticleView-sharesInline"><span>Compartir:</span><div class="ShareBlock-isReact" data-rtcomponent="ShareBlock" onload="return {
+        socials: JSON.parse('\u005B\u0022facebook\u0022,\u0022xtwitter\u0022,\u0022whatsapp\u0022,\u0022telegram\u0022,\u0022mailto\u0022,\u0022copylink\u0022\u005D'),
+        direction: JSON.parse('\u0022column\u0022'),
+        type: JSON.parse('\u0022hasFull\u0022'),
+        params: JSON.parse('\u007B\u0022counters\u0022\u003Atrue,\u0022href\u0022\u003A\u0022https\u003A\\\/\\\/actualidad.rt.com\\\/a\u002Dfondo\\\/610168\u002Dalmuerzo\u002Dsalvo\u002Dmundo\u002Ddesastre\u002Dnuclear\u0022,\u0022shortUrl\u0022\u003A\u0022https\u003A\\\/\\\/es\u002Drt.com\\\/d2t4\u0022\u007D'),
+    };"></div></div><div class="ArticleView-tags"><div class="Tags-wrapper"><div id="tags-left-arrow-js" class="Tags-arrow Tags-arrow_left Tags-arrow__none"></div><div id="tags-js" class="Tags-root Tags-default"><ul class="Tags-list Tags-default"><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/estados_unidos">Estados Unidos</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/Historia">Historia</a></li><li class="Tags-item"><a class="Tags-link" rel="tag" href="https://actualidad.rt.com/tag/URSS">URSS</a></li></ul></div><div id="tags-right-arrow-js" class="Tags-arrow Tags-arrow_right"></div></div></div><div class="ArticleView-rotatorBanners"><div class="CookiesBanner-isReact" data-rtcomponent="RotatorBanner" onload="return {
+        socials: JSON.parse('\u005B\u0022telegramRtlatam\u0022,\u0022telegramRtreporteros\u0022,\u0022rtVkact\u0022,\u0022telegramAhilesva\u0022,\u0022rumble\u0022,\u0022whatsapp\u0022\u005D')
+    }"></div></div><div class="ArticleView-comments"><div data-rtcomponent="Comments" onload="return {
+            title: `El almuerzo que salvó al mundo de un desastre nuclear en 1962`,
+            host: `https://actualidad.b37m.ru`,
+            url: `https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear`,
+            theme: `light`,
+            hasButton: `1`,
+          };"></div><noscript>You use your browser with disabled JavaScript. Please enable JavaScript for comments.</noscript></div>            
+    <div class="Section-root Section-isNoAnchor" data-listing="LastNews">
+        <div class="Section-container Section-isRow-isTop-isWrap Listing-root" data-count="6">
+                        
+                                                                                    
+                                                                        
+                    
+                    
+<div class="Section-block  Section-isColumn-isTop Section-is1to3-sm_is1to2-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2ae4b8e9ff71022e2a5a18.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2ae4b8e9ff71022e2a5a18.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2ae4b8e9ff71022e2a5a18.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2ae4b8e9ff71022e2a5a18.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2ae4b8e9ff71022e2a5a18.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2ae4b8e9ff71022e2a5a18.jpg" alt="Imagen ilustrativa"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2ae4b8e9ff71022e2a5a18.jpg" alt="Imagen ilustrativa" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/actualidad/610471-beneficios-depender-como-tomar-te" class="Link-root Link-isFullCard ">
+                Té verde, 'bubble tea' y tés embotellados: qué es lo que realmente ayuda a tu salud
+            </a></div></div></div></div></article></div>                            
+                                                                                    
+                                                                        
+                    
+                    
+<div class="Section-block  Section-isColumn-isTop Section-is1to3-sm_is1to2-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a26ed69e9ff717f3210ca3f.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a26ed67e9ff717f3210ca3e.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a26ed69e9ff717f3210ca3f.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a26ed67e9ff717f3210ca3e.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a26ed69e9ff717f3210ca3f.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a26ed69e9ff717f3210ca3f.jpg" alt="Imagen ilustrativa"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a26ed67e9ff717f3210ca3e.jpg" alt="Imagen ilustrativa" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/a-fondo/609821-guerra-campo-futbol-mundial-paises-conflicto" class="Link-root Link-isFullCard ">
+                De la guerra al campo de fútbol: las veces que el Mundial enfrentó a dos países en conflicto
+            </a></div></div></div></div></article></div>                            
+                                                                                    
+                                                                        
+                    
+                    
+<div class="Section-block  Section-isColumn-isTop Section-is1to3-sm_is1to2-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22a08059bf5b3978508ae2.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a22a08059bf5b3978508ae2.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22a08059bf5b3978508ae2.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a22a08059bf5b3978508ae2.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22a08059bf5b3978508ae2.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22a08059bf5b3978508ae2.jpg" alt="El día en que el avistamiento masivo de un ovni deslumbró a un templo del fútbol en Brasil"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a22a08059bf5b3978508ae2.jpg" alt="El día en que el avistamiento masivo de un ovni deslumbró a un templo del fútbol en Brasil" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/a-fondo/608977-24000-personas-ovni-brasil-partido-futbol" class="Link-root Link-isFullCard ">
+                El día en que el avistamiento masivo de un ovni deslumbró a un templo del fútbol en Brasil
+            </a></div></div></div></div></article></div>                            
+                                                                                    
+                                                                        
+                    
+                    
+<div class="Section-block  Section-isColumn-isTop Section-is1to3-sm_is1to2-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22c45559bf5b4dd85a6744.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a22c45559bf5b4dd85a6744.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22c45559bf5b4dd85a6744.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a22c45559bf5b4dd85a6744.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22c45559bf5b4dd85a6744.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a22c45559bf5b4dd85a6744.jpg" alt="Minas, trenes y guerra invisible: la historia del saboteador más temido de la URSS"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a22c45559bf5b4dd85a6744.jpg" alt="Minas, trenes y guerra invisible: la historia del saboteador más temido de la URSS" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/a-fondo/609181-starinov-saboteador-fuerzas-especiales-minas" class="Link-root Link-isFullCard ">
+                Minas, trenes y guerra invisible: la historia del saboteador más temido de la URSS
+            </a></div></div></div></div></article></div>                            
+                                                                                    
+                                                                        
+                    
+                    
+<div class="Section-block  Section-isColumn-isTop Section-is1to3-sm_is1to2-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a21abe2e9ff7168c807f181.png 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a21abe2e9ff7168c807f181.png 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a21abe2e9ff7168c807f181.png 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a21abe2e9ff7168c807f181.png 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a21abe2e9ff7168c807f181.png" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a21abe2e9ff7168c807f181.png" alt="La doctrina 'Donroe' golpea el tablero electoral en Latinoamérica"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a21abe2e9ff7168c807f181.png" alt="La doctrina &#039;Donroe&#039; golpea el tablero electoral en Latinoamérica" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/a-fondo/608980-doctrina-donroe-golpear-tablero-electoral-latam" class="Link-root Link-isFullCard ">
+                La doctrina 'Donroe' golpea el tablero electoral en Latinoamérica
+            </a></div></div></div></div></article></div>                            
+                                                                                    
+                                                                        
+                    
+                    
+<div class="Section-block  Section-isColumn-isTop Section-is1to3-sm_is1to2-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/6a1c0e5b59bf5b35d15c9514.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/6a1c0e5a59bf5b35d15c9513.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/6a1c0e5b59bf5b35d15c9514.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/6a1c0e5a59bf5b35d15c9513.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/6a1c0e5b59bf5b35d15c9514.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/thumbnail/6a1c0e5b59bf5b35d15c9514.jpg" alt="Imagen ilustrativa"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/6a1c0e5a59bf5b35d15c9513.jpg" alt="Imagen ilustrativa" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/a-fondo/608028-supernino-acabo-4-poblacion-mundial" class="Link-root Link-isFullCard ">
+                Qué es el 'SuperNiño', que acabó con el 4 % de la población mundial en 1877 y amenaza con repetirse
+            </a></div></div></div></div></article></div>                                    </div>
+
+                    <div class="Listing-isReact" data-rtcomponent="Listing" onload="return {
+                page: '1',
+                limit: '6',
+                listing: '/listing/type.News.category.a-fondo.xid.6a294332e9ff7126af5937f7/noprepare/news-recommendations/6/1',
+            };"></div>
+            </div>
+</div></div></div>                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="Grid-block Grid-is1to4-sm_is1to1-xs_is1to1">
+                                                            
+    <div class="Section-root">
+        <div class="Section-container Section-isRow-isTop">
+            <div class="Section-block Section-is1to1 p-24">
+                <div class="Banners-root">
+                                                                                                        <div style="width: 100%;margin-bottom: 10px;border-radius: 3px;overflow:hidden;">
+    
+    <div id="banner--player" style="width: 100%;border-radius: 4px;overflow: hidden;margin-bottom: 12px;"></div>
+    <a href="https://actualidad.rt.com/en_vivo" target="_blank" class="ac_youtube_video--title">
+        RT en Español en vivo - TELEVISIÓN GRATIS 24/7
+    </a>
+    
+    
+</div>
+                                                    
+                                    </div>
+            </div>
+        </div>
+    </div>
+<div class="Section-root Section-isSticky"><div class="Section-root"><div class="Section-container Section-isRow-isTop"><div class="Section-block Section-is1to1 p-24"><div class="Advertisings-root Advertisings-topRight" id="right_banner_2"><div id="adfox_163033562334623855"></div><div id="adfox_163033558617098540"></div></div></div></div></div>
+<div class="Section-root" data-widgets="PopularNews"><div class="Section-title p-24 pb-0"><h2 class="HeaderNews-root HeaderNews-type_1 ">
+                Lo más popular
+            </h2></div><div class="Section-container Section-isRow-isTop-isWrap"><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610941-nuevo-video-caida-mortal-vacio-mujer-puenting" class="Link-root Link-isFullCard ">
+                Nuevo VIDEO de la caída mortal al vacío de una mujer a la que los instructores de 'puenting' olvidaron atar
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T12:39:32+00:00">
+        14 jun 2026 | 12:39 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610969-tiene-puto-criterio-furioso-comentario-trump-netanyahu" class="Link-root Link-isFullCard ">
+                "No tiene puto criterio": Furioso comentario de Trump sobre Netanyahu tras el ataque contra el Líbano
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T16:24:06+00:00">
+        14 jun 2026 | 16:24 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610957-clara-advertencia-trump-israel-iran-libano" class="Link-root Link-isFullCard ">
+                La clara advertencia de Trump a Israel en medio de las negociaciones con Irán
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T14:52:39+00:00">
+        14 jun 2026 | 14:52 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 "><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610966-kremlin-revela-detalles-conversacion-putin-trump" class="Link-root Link-isFullCard ">
+                El Kremlin revela detalles de la conversación entre Putin y Trump
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T15:52:27+00:00">
+        14 jun 2026 | 15:52 GMT
+    </time></div></div></div></div></div></div><div class="Section-block Section-is1to1 pt-24 pl-24 pr-24 pb-24"><div class="SimpleCard-root SimpleCard-is1to1 "><div class="SimpleCard-contentWrap SimpleCard-is1to1"><div class="SimpleCard-content"><div class="SimpleCard-title"><div class="HeaderNews-root HeaderNews-type_6 "><a href="https://actualidad.rt.com/actualidad/610965-putin-felicita-trump-cumpleanos-conversacion" class="Link-root Link-isFullCard ">
+                Putin felicita a Trump por su cumpleaños en una conversación que duró cerca de una hora
+            </a></div></div></div><div class="SimpleCard-meta"><div class="Meta-root Meta-jcsb"><div class="MetaItem-root"><time class="Timestamp-root Timestamp-default " datetime="2026-06-14T15:47:11+00:00">
+        14 jun 2026 | 15:47 GMT
+    </time></div></div></div></div></div></div></div></div><div class="Section-root"><div class="Section-container Section-isRow-isTop"><div class="Section-block Section-is1to1 p-24"><div class="Subscription-isReact" data-rtcomponent="Subscription" onload="return {
+        elements: JSON.parse('\u005B\u0022blockInput\u0022,\u0022blockButton\u0022,\u0022blockButtonCircle\u0022,\u0022blockCheckbox\u0022,\u0022blockInfoText\u0022\u005D'),
+        id: JSON.parse('\u0022sidebar\u0022'),
+    };"></div></div></div></div>        
+    <div class="Section-root">
+        <div class="Section-container Section-isRow-isTop">
+            <div class="Section-block Section-is1to1 p-24">
+                <div class="Banners-root">
+                                                                        <a class="Link-root Link-isInline videoLink" id="" href="https://esrt.space/actualidad/610026-europa-militarizacion-impacto-economico">
+                                <video class="Banners-image lazyload" autoplay="" loop="" muted="" playsinline="">
+                                    <source type="video/mp4" src="https://mf.b37mrtl.ru/actualidad/public_video/2026.06/6a2b055659bf5b20671ba918.mp4">
+                                </video>
+                            </a>
+                        
+                                    </div>
+            </div>
+        </div>
+    </div>
+
+            
+    <div class="Section-root Section-isNoAnchor" data-listing="Comics">
+        <div class="Section-title p-24 pb-0">
+                            
+                                                                                            
+            
+                                                                        
+            
+            <h2 class="HeaderNews-root HeaderNews-type_1 ">
+                        
+                                                                                                        
+            
+            
+            
+            <a href="https://actualidad.rt.com/comics" class="Link-root ">
+                Osografía
+            </a>
+            
+            </h2>
+            
+        </div>
+        <div class="Section-container Section-isRow-isTop-isWrap Listing-root" data-count="1">
+                            
+<div class="Section-block  Section-is1to1-sm_is1to1-xs_is1to1  p-24  Listing-item "><article class="Card-root Card-isHoverScale Card-default"><div class="Card-imageWrap"><div class="Card-picture"><picture class="Picture-root Picture-default"><source media="(-webkit-min-device-pixel-ratio: 2) and (min-resolution: 120dpi)" data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg 850w,
+                                    https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2993d7e9ff714dd00eb1af.jpg 1960w,            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><source data-srcset="
+                                            https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg 460,
+                                  https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2993d7e9ff714dd00eb1af.jpg 980w,
+            " srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEElEQVR42mNkIAAYRxWAAQAG9gAKqv6+AwAAAABJRU5ErkJggg=="><img data-sizes="auto" src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg" class="Picture-root Picture-default lazyload" data-src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/thumbnail/6a2993d7e9ff714dd00eb1af.jpg" alt="Doble incertidumbre en el Perú: resultados… y duración en el cargo"></picture><noscript><img src="https://mf.b37mrtl.ru/actualidad/public_images/2026.06/article/6a2993d7e9ff714dd00eb1af.jpg" alt="Doble incertidumbre en el Perú: resultados… y duración en el cargo" /></noscript></div></div><div class="Card-contentWrap"><div class="Card-content"><div class="Card-title"><div class="HeaderNews-root HeaderNews-type_4 "><a href="https://actualidad.rt.com/comics/610225-doble-incertidumbre-peru-resultados-duracion" class="Link-root Link-isFullCard ">
+                Doble incertidumbre en el Perú: resultados… y duración en el cargo
+            </a></div></div></div></div></article></div>                    </div>
+    </div>
+<div class="Section-root"><div class="Section-container Section-isRow-isTop"><div class="Section-block Section-is1to1 p-24"><div class="Advertisings-root Advertisings-bottomRight" id="right_banner_3"><div id="adfox_163033564640081029"></div><div id="adfox_163033560186651459"></div></div></div></div></div></div>                </div>
+            </section>
+        </div>
+    </main>
+
+							<div class="App-footer">
+					
+
+
+
+
+
+
+
+
+<div class="Footer-root Footer-expanded"><div class="Footer-container Footer-containerWithLine"><div class="Footer-block Footer-is1to4-sm_is1to1-xs_is1to1"><div class="Footer-subscription p-24"><div class="Subscription-isReact" data-rtcomponent="Subscription" onload="return {
+        elements: JSON.parse('\u005B\u0022blockTitle\u0022,\u0022blockInput\u0022,\u0022blockButton\u0022,\u0022blockButtonCircle\u0022,\u0022blockCheckbox\u0022,\u0022blockInfoText\u0022\u005D'),
+        id: JSON.parse('\u0022footer\u0022'),
+    };"></div></div><div class="Footer-telegram p-24"><a class="Button-root Button-is1to1 Button-type_xl Button-fill_dark " href="https://x.com/ActualidadRT" target="_blank" rel="noopener noreferrer" aria-label="Button">
+                RT en X
+            </a></div></div><div class="Footer-block Footer-is1to2-sm_is1to1-xs_is1to1"><div class="Footer-nav"><div class="Footer-group Footer-is1to3-sm_is1to3-xs_is1to1 p-24"><ul class="Footer-groupList"><li><a href="https://actualidad.rt.com/todas_las_noticias" class="Link-root Link-isInFooterLink">Noticias</a></li><li><a href="https://actualidad.rt.com/viral" class="Link-root Link-isInFooterLink">Viral</a></li><li><a href="https://actualidad.rt.com/programas" class="Link-root Link-isInFooterLink">Programas</a></li><li><a href="https://actualidad.rt.com/video" class="Link-root Link-isInFooterLink">Videos</a></li><li><a href="https://actualidad.rt.com/opinion" class="Link-root Link-isInFooterLink">Opinión</a></li><li><a href="https://actualidad.rt.com/rtpedia" class="Link-root Link-isInFooterLink">RTpedia</a></li><li><a href="https://actualidad.rt.com/sp/lideres" class="Link-root Link-isInFooterLink">Líderes Mundiales</a></li></ul></div><div class="Footer-group Footer-is1to3-sm_is1to3-xs_is1to1 p-24"><h3 class="Footer-groupTitle">Acerca de RT</h3><ul class="Footer-groupList"><li><a href="https://actualidad.rt.com/acerca/quienes_somos" class="Link-root Link-isInFooterLink">Quiénes somos</a></li><li><a href="https://actualidad.rt.com/acerca/contactos" class="Link-root Link-isInFooterLink">Contactos</a></li><li><a href="https://actualidad.rt.com/acerca/equipo" class="Link-root Link-isInFooterLink">Equipo</a></li><li><a href="https://actualidad.rt.com/acerca/cobertura" class="Link-root Link-isInFooterLink">Cobertura</a></li><li><a href="https://actualidad.rt.com/acerca/carrera" class="Link-root Link-isInFooterLink">Carrera en RT</a></li><li><a href="https://actualidad.rt.com/acerca/condiciones_de_uso" class="Link-root Link-isInFooterLink">Condiciones de uso</a></li></ul></div><div class="Footer-group Footer-is1to3-sm_is1to3-xs_is1to1 p-24"><h3 class="Footer-groupTitle">Aplicación móvil</h3><ul class="Footer-groupList"><li><a href="https://cdn.rt.com/app/rtnews.apk" class="Link-root Link-isInFooterLink" target="_blank" rel="noopener noreferrer">Android</a></li></ul></div></div></div><div class="Footer-block Footer-is1to4-sm_is1to1-xs_is1to1"><div class="Footer-search p-24"><div class="Search-field"><div class="Search-input Search-is1to1"></div><div class="Search-buttonCircle Search-isAbsoluteToRight"><button class="IconButton-root IconButton-size_m IconButton-fill_transparent " aria-label="Button"><svg class="Icon-root Icon-search" width="16px" stroke="#888888" version="1.1" viewBox="0 0 16 16" xmlns="https://www.w3.org/2000/svg"><g stroke-width="2"><circle cx="6.8" cy="6.8" r="5.8" fill="none"></circle><line x1="11" x2="15.3" y1="11" y2="15.3"></line></g></svg></button></div></div></div><div class="Footer-groupSocials p-24 pt-0"><ul class="Socials-root"><li class="Socials-item Socials-VkIcon"><a href="https://vk.com/actualidadrt" class="Link-root Link-socials" target="_blank" aria-label="VkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-vk" height="13px" fill="#888888" version="1.1" viewBox="0 0 22 13" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -10)"><path d="m26.16 11.013c0.16-0.49333 0-0.85333-0.69333-0.85333h-2.32c-0.44243-0.020208-0.84913 0.242-1.0133 0.65333-0.72722 1.7134-1.6923 3.3159-2.8667 4.76-0.53333 0.53333-0.78667 0.72-1.08 0.72-0.29333 0-0.36-0.18667-0.36-0.68v-4.6133c0-0.58667-0.18667-0.85333-0.68-0.85333h-3.6533c-0.14856-0.0072434-0.29391 0.044915-0.40397 0.14497s-0.17579 0.23978-0.1827 0.38836c0 0.56 0.84 0.70667 0.93333 2.28v3.4267c0 0.74667-0.13333 0.88-0.42667 0.88-0.8 0-2.6667-2.9067-3.8533-6.2267-0.22667-0.65333-0.45333-0.89333-1.04-0.89333h-2.3467c-0.68 0-0.78667 0.30667-0.78667 0.65333 0 0.6 0.78667 3.6667 3.6667 7.72 1.5436 2.4836 4.1889 4.0718 7.1067 4.2667 1.48 0 1.6667-0.34667 1.6667-0.90667v-2.0933c0-0.68 0.13333-0.78667 0.61333-0.78667s0.94667 0.17333 2.32 1.5067c1.5733 1.5733 1.84 2.2933 2.6667 2.2933h2.32c0.68 0 1-0.33333 0.81333-0.98667-0.50005-0.99197-1.1625-1.8933-1.96-2.6667-0.54667-0.64-1.3333-1.3333-1.6-1.68-0.26667-0.34667-0.25333-0.62667 0-1.0267 0 0 2.8133-4 3.1067-5.3333"></path></g></g></svg></a></li><li class="Socials-item Socials-Rumble"><a href="https://rumble.com/c/RTES" class="Link-root Link-socials" target="_blank" aria-label="Rumble" rel="noopener noreferrer"><svg class="Icon-root Icon-rumble" width="18" height="19.773768216516" fill="#888888" xmlns="http://www.w3.org/2000/svg" version="1.2" viewBox="0 0 1441 1583"><path id="Layer" fill-rule="evenodd" d="m1339.3 537.2c32.1 35.2 57.5 75.9 74.8 120.3 17.2 44.4 26.1 91.5 26.2 139.2 0.1 47.6-8.6 94.8-25.7 139.2-17.1 44.4-42.3 85.3-74.3 120.6-57.2 63.1-119 121.9-184.9 175.9-65.9 54-135.7 103-208.9 146.7-73.1 43.6-149.4 81.8-228.2 114.2-78.8 32.4-159.9 59-242.6 79.4-42.2 10.6-86.1 12.9-129.1 6.8-43.1-6.1-84.6-20.4-122.2-42.3-37.7-21.8-70.7-50.7-97.4-85-26.6-34.4-46.4-73.6-58.2-115.4-100.4-343-85.6-730.8 11.2-1075.3 51-180.9 221.3-294.5 396.7-252.7 324.8 77.4 629.6 276.7 862.6 528.4zm-457.3 356.2c61.2-48.4 61.2-142.7 0-192.6q-32.6-27.1-66.8-52.1-34.2-25.1-69.9-48-35.6-22.9-72.6-43.7-37-20.7-75.2-39.2c-70.3-33.6-148.8 13.3-160.1 93.3-17.3 122.3-20.4 245.6-9.1 362.8 7.6 81.1 85.1 129.5 156.5 98.4q39.9-17.2 78.6-37 38.7-19.8 76-42.2 37.3-22.4 73-47.2 35.7-24.8 69.6-52z"></path></svg></a></li><li class="Socials-item Socials-Odysee"><a href="https://www.odysee.com/@ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="Odysee" rel="noopener noreferrer"><svg fill="#888888" height="24px" class="Icon-root" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="isolation:isolate" viewBox="0 0 24 24" width="24pt"><g clip-path="url(#_clipPath_8FANzNdzAksNqe68wPUCLCPg4beKQ3ZI)"><path d=" M 18.499 1.921 C 16.629 0.704 14.396 0 12 0 C 5.377 0 0 5.377 0 12 C 0 12.51 0.032 13.012 0.1 13.503 C 0.094 13.509 0.095 13.514 0.102 13.517 C 0.117 13.692 0.143 13.865 0.176 14.035 C 0.192 14.152 0.214 14.268 0.246 14.38 C 0.299 14.688 0.372 14.988 0.461 15.282 C 0.376 14.985 0.303 14.684 0.246 14.38 C 0.219 14.266 0.198 14.15 0.176 14.035 C 0.149 13.862 0.123 13.69 0.102 13.517 C 0.101 13.512 0.1 13.508 0.1 13.503 C 0.1 13.503 0.1 13.503 0.1 13.503 C 0.531 12.861 2.182 11.465 3.796 10.597 C 5.1 9.895 6.533 9.609 6.914 9.242 C 6.243 7.007 5.032 3.538 7.746 1.912 C 9.881 0.634 12.69 -0.142 13.77 2.958 C 14.851 6.057 14.572 6.754 15.037 6.754 C 15.501 6.754 16.644 6.977 17.128 5.004 C 17.481 3.564 17.699 2.326 18.499 1.921 Z  M 20.791 3.837 C 22.782 5.978 24 8.848 24 12 C 24 18.623 18.623 24 12 24 C 6.727 24 2.244 20.592 0.641 15.858 C 0.661 15.925 0.685 15.992 0.709 16.059 C 0.804 16.147 0.912 16.222 1.029 16.28 C 1.794 16.635 2.918 16.026 3.982 14.923 C 4.301 14.606 4.657 14.331 5.044 14.103 C 5.894 13.555 6.814 13.123 7.779 12.818 C 7.779 12.818 8.822 14.419 9.788 16.317 C 10.755 18.215 8.745 18.847 8.522 18.847 C 8.299 18.847 5.132 18.552 5.839 21.231 C 6.545 23.909 10.415 22.943 12.388 21.639 C 14.361 20.336 13.877 16.094 13.877 16.094 C 15.813 15.796 16.407 17.843 16.593 18.882 C 16.779 19.92 16.361 21.746 18.306 21.786 C 18.579 21.79 18.852 21.747 19.112 21.66 C 19.859 21.108 20.541 20.471 21.142 19.762 C 21.205 19.664 21.241 19.551 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 L 21.247 19.435 C 21.173 19.295 19.748 17.111 19.572 15.276 C 19.442 14.005 17.78 12.595 16.784 11.854 C 16.614 11.725 16.51 11.528 16.499 11.315 C 16.489 11.102 16.572 10.895 16.728 10.75 C 17.711 9.821 19.444 8.009 19.992 7.051 C 20.502 6.055 20.776 4.955 20.791 3.837 Z  M 2.769 8.88 C 2.705 8.777 2.568 8.745 2.465 8.81 C 2.362 8.875 2.331 9.011 2.395 9.114 C 2.46 9.218 2.596 9.249 2.7 9.184 C 2.749 9.153 2.785 9.103 2.798 9.046 C 2.811 8.989 2.801 8.929 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 L 2.769 8.88 Z  M 15.669 3.106 C 15.604 3.003 15.468 2.972 15.364 3.037 C 15.261 3.101 15.23 3.238 15.295 3.341 C 15.359 3.444 15.496 3.475 15.599 3.411 C 15.648 3.38 15.684 3.33 15.697 3.273 C 15.71 3.216 15.7 3.156 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 L 15.669 3.106 Z  M 18.333 11.768 C 18.302 11.907 18.39 12.044 18.528 12.076 C 18.667 12.107 18.805 12.02 18.837 11.881 C 18.868 11.742 18.781 11.604 18.642 11.573 C 18.576 11.557 18.505 11.569 18.447 11.606 C 18.389 11.643 18.348 11.701 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 L 18.333 11.768 Z  M 14.486 20.364 C 14.468 20.443 14.499 20.526 14.566 20.573 C 14.633 20.62 14.721 20.621 14.789 20.577 C 14.858 20.532 14.892 20.451 14.877 20.371 C 14.861 20.291 14.798 20.228 14.718 20.213 C 14.613 20.193 14.51 20.259 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 L 14.486 20.364 Z  M 4.456 4.916 C 4.441 4.981 4.482 5.046 4.547 5.061 C 4.611 5.076 4.676 5.036 4.691 4.971 C 4.707 4.906 4.667 4.841 4.603 4.826 C 4.571 4.818 4.538 4.823 4.51 4.84 C 4.483 4.857 4.463 4.885 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 L 4.456 4.916 Z  M 5.079 16.254 C 5.062 16.162 4.974 16.101 4.882 16.118 C 4.79 16.134 4.728 16.222 4.745 16.315 C 4.762 16.407 4.85 16.468 4.942 16.452 C 4.986 16.444 5.026 16.418 5.051 16.381 C 5.077 16.344 5.087 16.298 5.079 16.254 L 5.079 16.254 L 5.079 16.254 L 5.079 16.254 L 5.079 16.254 L 5.079 16.254 Z  M 20.548 9.767 L 20.276 9.228 L 19.683 9.105 L 20.222 8.833 L 20.343 8.241 L 20.617 8.78 L 21.21 8.901 L 20.671 9.175 L 20.548 9.767 L 20.548 9.767 L 20.548 9.767 L 20.548 9.767 Z  M 12.692 5.59 L 12.644 5.59 C 12.507 5.563 12.418 5.431 12.444 5.295 C 12.503 5.061 12.478 4.814 12.372 4.598 C 12.334 4.473 12.396 4.34 12.516 4.29 C 12.636 4.24 12.774 4.288 12.836 4.403 C 12.98 4.709 13.016 5.056 12.939 5.385 C 12.915 5.503 12.813 5.589 12.692 5.59 L 12.692 5.59 L 12.692 5.59 L 12.692 5.59 L 12.692 5.59 Z  M 11.468 6.889 C 9.495 7.632 8.545 6.656 8.415 4.879 C 8.269 2.869 10.165 2.349 10.165 2.349 C 12.256 1.652 12.806 2.646 13.292 4.136 C 13.777 5.625 13.44 6.152 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 L 11.468 6.889 Z  M 12.165 3.636 C 12.069 3.64 11.979 3.59 11.933 3.506 C 11.89 3.424 11.84 3.346 11.784 3.274 C 11.69 3.175 11.69 3.019 11.784 2.92 C 11.88 2.827 12.034 2.827 12.13 2.92 C 12.222 3.025 12.301 3.141 12.362 3.267 C 12.401 3.341 12.401 3.43 12.361 3.504 C 12.322 3.578 12.248 3.627 12.165 3.636 L 12.165 3.636 Z " fill-rule="evenodd"></path></g></svg></a></li><li class="Socials-item Socials-XIcon"><a href="https://x.com/ActualidadRT" class="Link-root Link-socials" target="_blank" aria-label="XIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-x" fill="#888888" version="1.1" viewBox="0 0 24 24" width="18" height="18" xmlns="https://www.w3.org/2000/svg"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg></a></li><li class="Socials-item Socials-TelegramIcon"><a href="https://telegram.me/rtnoticias" class="Link-root Link-socials" target="_blank" aria-label="TelegramIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-telegram" height="16px" fill="#888888" version="1.1" viewBox="0 0 20 16" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><g transform="translate(-5 -8)"><path d="m24.798 8.8742v-0.084507c0.021962-0.35088-0.19811-0.67117-0.53226-0.77465-0.12528-0.020023-0.25291-0.020023-0.37818 0-0.41728-0.009814-0.83209 0.066897-1.2186 0.22535-1.2186 0.45071-2.4232 0.92958-3.6278 1.4085l-2.4512 0.87324-1.1065 0.46479-1.3166 0.5493-1.2466 0.53521c-1.6341 0.68545-3.2589 1.4038-4.8744 2.1549-0.70034 0.33803-1.4007 0.67606-2.073 1.0563-0.10024 0.054347-0.19029 0.12584-0.26613 0.21127-0.068477 0.066368-0.10716 0.15789-0.10716 0.25352s0.038685 0.18715 0.10716 0.25352c0.071194 0.080837 0.15668 0.1477 0.25212 0.19718 0.14189 0.093286 0.29192 0.17343 0.44822 0.23944 0.66227 0.30344 1.3458 0.55764 2.045 0.76056 0.49383 0.17864 1.0059 0.30146 1.5267 0.3662 0.58774 0.065441 1.181-0.057813 1.6948-0.35211 0.75637-0.43193 1.4987-0.90141 2.2271-1.4085 1.2606-0.83099 2.5072-1.7183 3.7398-2.5916 0.44956-0.34416 0.91712-0.66387 1.4007-0.95775 0.14179-0.1018 0.29748-0.18245 0.46223-0.23944 0.0693-0.014425 0.1408-0.014425 0.2101 0 0.11205 0 0.16808 0 0.15408 0.16901-0.0049925 0.14954-0.059181 0.2932-0.15408 0.40845-0.4062 0.42254-0.8124 0.84507-1.2326 1.2535-0.84041 0.80282-1.7088 1.5634-2.5492 2.3521l-1.4007 1.2817c-0.24176 0.22419-0.43282 0.49797-0.56027 0.80282-0.087561 0.19393-0.12143 0.40804-0.098048 0.61972 0.032149 0.24791 0.16373 0.47181 0.36418 0.61972l0.71435 0.50704 5.1825 3.5211 0.30815 0.21127c0.43391 0.27815 0.97867 0.31543 1.4461 0.098957 0.46738-0.21647 0.79328-0.65701 0.86507-1.1694l0.42021-2.3944 0.42021-2.5634c0.15408-0.88733 0.29414-1.7747 0.43421-2.662 0.11205-0.64789 0.2101-1.2958 0.30815-1.9437l0.37818-2.7324c0-0.50704 0.056027-1.0141 0.084041-1.5211z"></path></g></g></svg></a></li><li class="Socials-item Socials-BlueSky"><a href="https://bsky.app/profile/actualidadrt.bsky.social" class="Link-root Link-socials" target="_blank" aria-label="BlueSky" rel="noopener noreferrer"><svg class="Icon-root Icon-blueSky" width="20" height="17.666666666667" fill="#888888" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" version="1.1"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"></path></svg></a></li><li class="Socials-item Socials-OkIcon"><a href="https://ok.ru/group/70000046273774" class="Link-root Link-socials" target="_blank" aria-label="OkIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-ok" width="25" height="25" fill="#888888" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" version="1.1"><path d="M100.1 99.2C109.8 99.2 118.6 95.2 124.9 88.9C131.2 82.6 135.2 73.8 135.2 64.1C135.2 54.4 131.2 45.6 124.9 39.3C118.6 33 109.8 29 100.1 29C90.3999 29 81.5999 33 75.2999 39.3C68.9999 45.5 64.9999 54.3 64.9999 64.1C64.9999 73.9 68.9999 82.6 75.2999 88.9C81.5999 95.2 90.4999 99.2 100.1 99.2ZM88.8999 52.7C91.7999 49.8 95.7999 48 100.2 48C104.7 48 108.6 49.8 111.5 52.7C114.4 55.6 116.2 59.6 116.2 64C116.2 68.5 114.4 72.4 111.5 75.3C108.6 78.2 104.6 80 100.2 80C95.6999 80 91.7999 78.2 88.8999 75.3C85.9999 72.4 84.1999 68.4 84.1999 64C84.1999 59.6 86.0999 55.6 88.8999 52.7Z"></path><path d="M147.5 113.4L137.2 99.3C136.6 98.5 135.4 98.4 134.7 99.1C125 107.4 113 112.8 100.1 112.8C87.2 112.8 75.3 107.4 65.5 99.1C64.8 98.5 63.6 98.6 63 99.3L52.7 113.4C52.2 114.1 52.3 115 52.9 115.6C61.6 122.6 71.7 127.4 82.2 129.9L60.4 168.3C59.8 169.4 60.6 170.8 61.8 170.8H83.1C83.8 170.8 84.4 170.4 84.6 169.7L99.8 135.7L115 169.7C115.2 170.3 115.8 170.8 116.5 170.8H137.8C139.1 170.8 139.8 169.5 139.2 168.3L117.4 129.9C127.9 127.4 138 122.8 146.7 115.6C148 115 148.1 114.1 147.5 113.4Z"></path></svg></a></li><li class="Socials-item Socials-RssIcon"><a href="https://actualidad.rt.com/feeds/all.rss" class="Link-root Link-socials" target="_blank" aria-label="RssIcon" rel="noopener noreferrer"><svg class="Icon-root Icon-rss" height="15px" width="16px" fill="#888888" version="1.1" viewBox="0 0 15 16" xmlns="http://www.w3.org/2000/svg"><g transform="translate(-1362 -24)"><g transform="translate(1228 18)"><g transform="translate(128)"><g transform="translate(6.5333 6.5333)"><path d="m2.2167 10.733c1.05 0 1.9833 0.93333 1.9833 1.9833 0 0.58333-0.23333 1.05-0.58333 1.4s-0.93333 0.58333-1.4 0.58333c-1.1667 0-1.9833-0.93333-1.9833-1.9833 0-1.1667 0.93333-1.9833 1.9833-1.9833zm-1.8667-5.6 0.2706 0.0037294c5.1229 0.14141 9.1774 4.2868 9.0627 9.4463h-2.6833l-0.0064615-0.29055c-0.073117-1.6399-0.76483-3.1641-1.9769-4.3761-1.2833-1.2833-2.9167-1.9833-4.6667-1.9833v-2.8zm0-4.9 0.38576 0.0053959c3.5959 0.10059 7.0568 1.6038 9.6476 4.1946 2.8 2.8 4.2 6.3 4.0833 10.033h-2.6833l-0.0036305-0.29523c-0.15459-6.2782-5.2266-11.255-11.43-11.255v-2.6833z"></path></g></g></g></g></svg></a></li><li class="Socials-item Socials-feedback"><div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022icon\u0022'),
+    };"></div></li></ul></div></div></div><div class="Footer-container"><div class="Footer-block Footer-is1to1-sm_is1to1-xs_is1to1"><div class="Footer-copyrightItem Footer-is1to1"><div class="Copyright-root Copyright-isRow-sm_isRow-xs_isColumn"><div class="Copyright-item"><div class="Copyright-logo Copyright-isRow-isCenter"><svg class="Icon-root Icon-rtLogo" width="54px" height="54px" fill="#D4D3D3" version="1.1" viewBox="0 0 56 56" xmlns="https://www.w3.org/2000/svg"><g fill-rule="evenodd"><rect width="56" height="56"></rect><path d="m1 0h54c0.55228-1.0145e-16 1 0.44772 1 1v54c0 0.55228-0.44772 1-1 1h-54c-0.55228 0-1-0.44772-1-1v-54c-6.7635e-17 -0.55228 0.44772-1 1-1z"></path><g transform="translate(8 20)" fill="#000"><polygon points="24.372 0.32996 24.372 2.3017 31.843 2.3017 31.843 17 40.53 17 40.53 2.3017 48 2.3017 48 0.32996"></polygon><path d="m12.907 7.8584c0.66346 0 1.2681-0.28214 1.7137-0.76234 0.47758-0.51014 0.76946-1.2094 0.76946-1.9264h-0.003977 0.003977c0-0.71699-0.29188-1.5059-0.76946-2.0165-0.44559-0.47895-1.0503-0.85143-1.7137-0.85143h-3.5163v5.5567h3.5163zm7.0223-7.5284c1.1876 0.046067 2.298 0.4535 3.0839 1.2933 0.81597 0.88441 1.3622 2.1124 1.3622 3.5464h0.0065706-0.0065706c0 1.2547-0.50646 2.4435-1.3223 3.3198-0.50923 0.54545-1.1267 0.93836-1.8244 1.1771l5.1548 7.3334h-9.4655l-4.592-6.9907h-2.9354v6.9907h-8.6456v-16.67h19.184z"></path></g></g></svg></div></div><div class="Copyright-item Copyright-xs_isColumn-isCenter pl-16 xs_pl-0 xs_pt-16"><div class="Copyright-langs Copyright-isFlex-isWrap-xs_isRow-isCenter"><span class="Copyright-lang"><a href="https://comparte.rt.com/" target="_blank" rel="noopener noreferrer">CompaRTe</a></span><span class="Copyright-lang"><a href="https://rtbrasil.com/" target="_blank" rel="noopener noreferrer">RT Brasil</a></span><span class="Copyright-lang"><a href="https://arabic.rt.com/" target="_blank" rel="noopener noreferrer">العربية</a></span><span class="Copyright-lang"><a href="https://de.rt.com/" target="_blank" rel="noopener noreferrer">Deutsch</a></span><span class="Copyright-lang"><a href="https://swentr.site/" target="_blank" rel="noopener noreferrer">English</a></span><span class="Copyright-lang"><a href="https://francais.rt.com/" target="_blank" rel="noopener noreferrer">Français</a></span><span class="Copyright-lang"><a href="https://rt.rs/" target="_blank" rel="noopener noreferrer">Српски</a></span><span class="Copyright-lang"><a href="https://russian.rt.com/" target="_blank" rel="noopener noreferrer">Русский</a></span><span class="Copyright-lang"><a href="https://rtd.rt.com/" target="_blank" rel="noopener noreferrer">RTД</a></span><span class="Copyright-lang"><a href="https://www.ruptly.agency/es" target="_blank" rel="noopener noreferrer">RUPTLY</a></span><span class="Copyright-lang"><a href="https://es.gw2ru.com/" target="_blank" rel="noopener noreferrer">Puerta a Rusia</a></span></div><div class="Copyright-text Copyright-isFlex-isWrap-xs_isRow-isCenter xs_pt-8">
+                © Organización Autónoma sin Fines de Lucro "TV-Novosti" 2005-2026. Todos los derechos reservados
+            </div></div><div class="Footer--notification">18+</div></div></div></div></div></div>				</div>
+					</div>
+
+
+		<div class="FeedbackForm-isReact" data-rtcomponent="FeedbackForm" onload="return {
+        displayAs: JSON.parse('\u0022fixed\u0022'),
+    };"></div>		<div class="CookiesBanner-isReact" data-rtcomponent="CookiesBanner"></div>		<div style="display: none;">
+    <svg version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink">
+                <symbol id="RTLogoIcon" viewBox="0 0 56 56">
+            <g fill-rule="evenodd">
+                <path d="M0 0H56V56H0z"></path>
+                <path d="M1 0h54a1 1 0 011 1v54a1 1 0 01-1 1H1a1 1 0 01-1-1V1a1 1 0 011-1z"></path>
+                <g transform="translate(8 20)" fill="#000">
+                    <path d="M24.372 0.32996L24.372 2.3017 31.843 2.3017 31.843 17 40.53 17 40.53 2.3017 48 2.3017 48 0.32996z"></path>
+                    <path d="M12.907 7.858c.663 0 1.268-.282 1.714-.762.477-.51.77-1.21.77-1.926h-.005.004c0-.717-.292-1.506-.77-2.017-.445-.479-1.05-.851-1.713-.851H9.391v5.556h3.516zM19.929.33c1.188.046 2.298.453 3.084 1.293a5.189 5.189 0 011.362 3.547h.007-.007a4.908 4.908 0 01-1.322 3.32 4.433 4.433 0 01-1.824 1.177L26.384 17h-9.466l-4.592-6.99H9.391V17H.745V.33h19.184z"></path>
+                </g>
+            </g>
+        </symbol>
+
+                <symbol id="eye" viewBox="0 0 24 16">
+            <g stroke="none" stroke-width="1">
+                <g fill-rule="nonzero">
+                    <g>
+                        <path d="M11.9890675,0.0135048232 C6.70032154,0.0135048232 2.14212219,3.13118971 0.0482315113,7.63022508 C-0.0160771704,7.76655949 -0.0160771704,7.92604502 0.0482315113,8.06495177 C2.14212219,12.5639614 6.70034727,15.681672 11.9890675,15.681672 C17.2777878,15.681672 21.8360129,12.5639871 23.9299035,8.06495177 C23.9942122,7.92861736 23.9942122,7.76913183 23.9299035,7.63022508 C21.8360129,3.13118971 17.2778135,0.0135048232 11.9890675,0.0135048232 Z M11.9890675,13.2534019 C9.00257235,13.2534019 6.58456592,10.8327974 6.58456592,7.8488746 C6.58456592,4.86237942 9.00514469,2.44437299 11.9890675,2.44437299 C14.9755627,2.44437299 17.3935691,4.86495177 17.3935691,7.8488746 C17.3935691,10.8327974 14.9729904,13.2534019 11.9890675,13.2534019 Z"></path>
+                        <circle id="Oval" cx="11.9890675" cy="7.84630225" r="3.45980707"></circle>
+                    </g>
+                </g>
+            </g>
+        </symbol>
+
+                <symbol id="satellite" viewBox="0 0 612 612">
+            <path d="m394.46 187.09-24.007 24.007-109.69-109.69-159.77 159.77 109.69 109.69-23.594 23.594 26.864 26.863 23.593-23.594 13.979 13.979c6.954 6.954 18.23 6.954 25.185 0l53.861-53.861 23.889 23.89c-24.522 33.691-29.518 77.169-14.979 114.85 3.104 8.044 13.406 10.296 19.502 4.199l59.044-59.044 14.142 14.142c6.434 6.433 16.864 6.433 23.297 0s6.433-16.863 0-23.297l-14.142-14.142 59.044-59.044c6.097-6.097 3.845-16.399-4.199-19.502-37.676-14.539-81.155-9.542-114.85 14.979l-23.89-23.889 53.861-53.861c6.954-6.954 6.954-18.229 0-25.184l-13.979-13.979 24.007-24.007-26.862-26.866z"></path>
+            <path d="m5.216 532.32 73.874 73.874c3.477 3.477 8.035 5.216 12.592 5.216s9.115-1.738 12.592-5.216l120.88-120.88c6.954-6.954 6.954-18.229 0-25.184l-73.874-73.874c-3.477-3.478-8.035-5.216-12.592-5.216s-9.115 1.738-12.592 5.216l-120.88 120.88c-6.955 6.955-6.955 18.23 0 25.185z"></path>
+            <path d="m606.78 79.683-73.874-73.874c-3.477-3.477-8.035-5.216-12.592-5.216s-9.115 1.738-12.592 5.216l-120.88 120.88c-6.954 6.954-6.954 18.229 0 25.184l48.276 48.275 25.598 25.599c3.477 3.478 8.035 5.216 12.592 5.216s9.115-1.738 12.592-5.216l120.88-120.88c6.954-6.954 6.954-18.23 0-25.184z"></path>
+            <path d="m441.46 479.95v29.267c37.135 0 67.345-30.211 67.345-67.345h-29.267c0 20.996-17.082 38.078-38.078 38.078z"></path>
+            <path d="m439.06 559c65.91 0 119.53-53.622 119.53-119.53h-29.267c0 49.852-40.413 90.265-90.265 90.265v29.267z"></path>
+        </symbol>
+
+                <symbol id="arrowRight" viewBox="0 0 6 10">
+            <path d="M5.76087352,5.55732358 L1.39435851,9.76920649 C1.07497725,10.0769312 0.558507734,10.0769312 0.239126479,9.76920649 C-0.0797088262,9.46148181 -0.0797088262,8.96281003 0.239126479,8.65508535 L4.02857143,5.00026301 L0.239126479,1.34491465 C-0.0797088262,1.03718997 -0.0797088262,0.538518187 0.239126479,0.230793509 C0.558507734,-0.0769311696 1.07497725,-0.0769311696 1.39435851,0.230793509 L5.76087352,4.44320244 C6.07970883,4.75092712 6.07970883,5.24959891 5.76087352,5.55732358 L5.76087352,5.55732358 Z"></path>
+        </symbol>
+
+                <symbol id="FeedbackIcon" viewBox="0 0 22 16">
+            <g fill-rule="evenodd">
+                <path transform="translate(-9 -12)" d="M30.99967,17.4573953 L30.99967,26.2310663 C30.99967,26.7180481 30.8071729,27.1340325 30.4221787,27.4800195 C30.0371844,27.8270065 29.5751914,28 29.0350995,28 L29.0350995,28 L10.9634705,28 C10.4233786,28 9.96138558,27.8270065 9.57639135,27.4800195 C9.19249711,27.1340325 9,26.7180481 9,26.2310663 L9,26.2310663 L9,17.4573953 C9.3596946,17.8173818 9.7732884,18.1383698 10.2396814,18.4183593 C13.203037,20.2312913 15.2358065,21.5022437 16.3412899,22.2312163 C16.8076829,22.5402047 17.1860772,22.7821957 17.4764729,22.9551892 C17.7679685,23.1281827 18.1540627,23.3051761 18.6369554,23.4851693 C19.1198482,23.6661625 19.5697415,23.7561591 19.9877352,23.7561591 L19.9877352,23.7561591 L20.0119348,23.7561591 C20.4288286,23.7561591 20.8798218,23.6661625 21.3627146,23.4851693 C21.8456073,23.3051761 22.2317015,23.1281827 22.5220972,22.9551892 C22.8124928,22.7821957 23.1919871,22.5402047 23.6583801,22.2312163 C25.0498593,21.3252503 27.0870287,20.054298 29.7720884,18.4183593 C30.2384814,18.1313701 30.6476753,17.8103821 30.99967,17.4573953 L30.99967,17.4573953 Z M29.0343295,12 C29.5667215,12 30.0276146,12.1729935 30.4159088,12.5199805 C30.8053029,12.8659675 31,13.2819519 31,13.7689337 C31,14.3509118 30.798703,14.906891 30.398309,15.4378711 C29.996815,15.9678512 29.4974225,16.4208342 28.9001315,16.7968201 C25.8234776,18.718748 23.9073064,19.9167031 23.1549177,20.3876855 C23.0735189,20.4396835 22.8986215,20.5516793 22.6335255,20.7256728 C22.3673295,20.8986663 22.1462328,21.0386611 21.9702354,21.145657 C21.7942381,21.252653 21.5819413,21.3716486 21.332245,21.5046436 C21.0825488,21.6366386 20.8471523,21.7366349 20.6260556,21.8026324 C20.4049589,21.8686299 20.200362,21.9016287 20.0122648,21.9016287 L20.0122648,21.9016287 L19.9869652,21.9016287 C19.798868,21.9016287 19.5942711,21.8686299 19.3731744,21.8026324 C19.1531777,21.7366349 18.9166812,21.6366386 18.668085,21.5046436 C18.4183887,21.3716486 18.2049919,21.252653 18.0289946,21.145657 C17.8529972,21.0386611 17.6319005,20.8986663 17.3668045,20.7256728 C17.1006085,20.5516793 16.9268111,20.4396835 16.8443123,20.3876855 C16.0996235,19.9167031 15.0282396,19.2447283 13.6279606,18.3717611 C12.3933909,17.6014958 11.5947229,17.1021547 11.2327124,16.8737377 L11.1111983,16.7968201 C10.6041059,16.4868317 10.1256131,16.0618477 9.67461988,15.520868 C9.22472663,14.9788883 9.00033,14.4759072 9.00033,14.0119246 C9.00033,13.4369461 9.16972745,12.9579641 9.50852237,12.5749784 C9.84951726,12.1919928 10.33351,12 10.9638005,12 L10.9638005,12 Z"></path>
+            </g>
+        </symbol>
+
+                <symbol id="SearchIcon" viewBox="0 0 16 16">
+            <g stroke-width="2">
+                <circle r="5.8" cx="6.8" cy="6.8" fill="none" stroke-width="2"></circle>
+                <line x1="11" y1="11" x2="15.3" y2="15.3" stroke-width="2"></line>
+            </g>
+        </symbol>
+
+                <symbol id="ArrowTopIcon" viewBox="0 0 16 18">
+            <path fill-rule="nonzero" stroke="none" stroke-width="1" d="M218.988 83.564l.028.006h-12.044l3.786-3.795a.985.985 0 00.287-.7.983.983 0 00-.287-.698l-.59-.59a.977.977 0 00-.695-.287.977.977 0 00-.695.287l-6.491 6.49a.975.975 0 00-.287.697c0 .265.101.513.287.699l6.49 6.49a.977.977 0 00.696.288c.264 0 .51-.102.696-.287l.589-.59a.975.975 0 00.287-.695.946.946 0 00-.287-.683l-3.83-3.816h12.074c.542 0 .998-.467.998-1.01v-.833c0-.542-.47-.973-1.012-.973z" transform="translate(-16 -15) translate(-187 -61) rotate(90 211 84.975)"></path>
+        </symbol>
+
+                <symbol id="ArrowRightIcon" viewBox="0 0 18 16">
+            <path fill-rule="nonzero" d="M16.012 25.386l-.028-.006h12.045l-3.786 3.795c-.186.185-.288.436-.288.7s.102.512.288.698l.589.59a.977.977 0 00.695.287c.263 0 .51-.102.696-.287l6.49-6.49a.975.975 0 00.287-.698.975.975 0 00-.287-.698l-6.49-6.49a.977.977 0 00-.696-.288.977.977 0 00-.695.287l-.59.59a.975.975 0 00-.287.695c0 .263.102.497.288.682l3.829 3.816H15.999c-.543 0-.999.468-.999 1.01v.834c0 .542.47.973 1.012.973z" transform="translate(-15 -16)"></path>
+        </symbol>
+
+                <symbol id="ArrowLeftIcon" viewBox="0 0 18 16">
+            <path fill-rule="nonzero" d="M31.988 25.386l.028-.006H19.971l3.786 3.795c.186.185.288.436.288.7s-.102.512-.288.698l-.589.59a.977.977 0 01-.695.287.977.977 0 01-.696-.287l-6.49-6.49a.975.975 0 01-.287-.698c-.001-.265.1-.513.287-.698l6.49-6.49a.977.977 0 01.696-.288c.263 0 .51.102.695.287l.59.59a.975.975 0 01.287.695.946.946 0 01-.288.682l-3.829 3.816h12.073c.543 0 .999.468.999 1.01v.834c0 .542-.47.973-1.012.973z" transform="translate(-15 -16)"></path>
+        </symbol>
+
+                <symbol id="CloseIcon" viewBox="0 0 22 22">
+            <g fill-rule="evenodd" transform="translate(-1461 -21) translate(1456 16)">
+                <path d="M3.263 14.486H28.723V17.486H3.263z" transform="rotate(-135 15.993 15.986)"></path>
+                <path fill-rule="nonzero" d="M8 6.64L25.36 24l-1.42 1.42L6.64 8 8 6.64zM8 6L6 8l18 18 2-2L8 6z"></path>
+                <path d="M3.284 14.493H28.744V17.493000000000002H3.284z" transform="rotate(-45 16.014 15.993)"></path>
+                <path fill-rule="nonzero" d="M24 6.64l1.42 1.42L8 25.36 6.64 24 24 6.64zM24 6L6 24l2 2L26 8l-2-2z"></path>
+            </g>
+        </symbol>
+
+
+                        <symbol id="CopyLinkShareIcon" viewBox="0 0 22 21">
+            <path fillrule="evenodd" d="M2.585 9.723l1.862-1.862A1.056 1.056 0 015.94 7.85c.382.382.403.99.066 1.408l-.077.086-1.862 1.862c-1.773 1.772-1.794 4.528-.047 6.274 1.695 1.696 4.344 1.725 6.12.1l.154-.148 1.861-1.861a1.056 1.056 0 011.494-.012c.383.383.403.991.067 1.408l-.078.086-1.862 1.862c-2.616 2.617-6.685 2.648-9.262.07-2.521-2.52-2.547-6.47-.097-9.09l.167-.172 1.862-1.862zm7.637-7.637c2.617-2.618 6.687-2.648 9.264-.071 2.577 2.578 2.545 6.645-.072 9.263l-1.862 1.861a1.056 1.056 0 01-1.494.012 1.057 1.057 0 01.012-1.494l1.861-1.862c1.773-1.773 1.795-4.529.049-6.275-1.746-1.745-4.503-1.724-6.275.048L9.843 5.43a1.056 1.056 0 01-1.494.011 1.056 1.056 0 01.011-1.494zM6.44 13.578l7.638-7.638a1.056 1.056 0 011.494-.01c.382.382.403.99.066 1.407l-.078.086-7.637 7.638a1.056 1.056 0 01-1.494.011 1.054 1.054 0 01-.067-1.408l.078-.086 7.638-7.638z"></path>
+        </symbol>
+
+                <symbol id="MailToShareIcon" viewBox="0 0 22 16">
+            <path d="M22 5.457v8.774c0 .487-.193.903-.578 1.249a2 2 0 01-1.387.52H1.963a2 2 0 01-1.387-.52C.192 15.134 0 14.718 0 14.231V5.457a6.4 6.4 0 001.24.961c2.963 1.813 4.996 3.084 6.101 3.813.467.31.845.551 1.135.724.292.173.678.35 1.161.53.483.181.933.271 1.35.271h.025c.417 0 .868-.09 1.35-.27.484-.18.87-.358 1.16-.53.29-.174.67-.416 1.136-.725 1.392-.906 3.429-2.177 6.114-3.813A6.633 6.633 0 0022 5.458zM20.034 0c.533 0 .994.173 1.382.52.39.346.584.762.584 1.249 0 .582-.201 1.138-.602 1.669-.401.53-.9.983-1.498 1.359l-5.745 3.59c-.081.053-.256.165-.521.339-.267.173-.488.313-.664.42a13.17 13.17 0 01-.638.359 3.94 3.94 0 01-.706.298 2.156 2.156 0 01-.614.099h-.025c-.188 0-.393-.033-.614-.1a3.932 3.932 0 01-.705-.297 13.26 13.26 0 01-.639-.36 25.295 25.295 0 01-.662-.42c-.266-.173-.44-.285-.523-.337a620.674 620.674 0 00-3.216-2.016c-1.235-.77-2.033-1.27-2.395-1.498l-.122-.077c-.507-.31-.985-.735-1.436-1.276C.225 2.979 0 2.476 0 2.01 0 1.438.17.959.51.576.849.192 1.334 0 1.964 0z" fill-rule="evenodd"></path>
+        </symbol>
+
+                <symbol id="FBMessageShareIcon" viewBox="0 0 28 28">
+            <path d="M14 .667c7.5 0 13.167 5.5 13.167 13s-5.834 13-13.334 13c-1.333 0-2.666-.167-3.833-.5a.507.507 0 00-.667 0l-2.666 1.166c-.667.167-1.5-.166-1.5-1V24c0-.333-.167-.667-.334-.833-2.5-2.334-4.166-5.667-4.166-9.5 0-7.5 5.833-13 13.333-13zm8.167 10c.333-.667-.5-1.334-1-.834L17 13a1.062 1.062 0 01-1 0l-3.167-2.333c-.833-.667-2.166-.5-2.833.5l-4 6.166c-.333.667.333 1.334 1.167.834L11.333 15a1.063 1.063 0 011 0l3.167 2.333c.833.667 2.167.5 2.833-.5z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="WhatsAppShareIcon" viewBox="0 0 28 28">
+            <path d="M8.904 1.435A13.5 13.5 0 0123.6 4.35a13.334 13.334 0 013.884 9.483c0 7.45-6.035 13.491-13.484 13.5a13.683 13.683 0 01-6.317-1.566L.367 27.683l1.966-7.133a13.567 13.567 0 01-1.766-6.667A13.5 13.5 0 018.904 1.435zm12.88 4.882A10.833 10.833 0 004.95 19.65l.317.483L4.15 24l3.983-1 .467.283a10.733 10.733 0 005.517 1.517l.288-.004c5.846-.162 10.536-4.946 10.545-10.83a10.717 10.717 0 00-3.167-7.65zM10.05 7.567c.283 0 .6.05.867.7l.333.833c.283.717.683 1.567.683 1.667a.817.817 0 010 .766v.1a2.467 2.467 0 01-.316.5l-.167.2a4 4 0 01-.35.384c-.1.166-.217.233-.1.433a9.683 9.683 0 001.8 2.25 8.333 8.333 0 002.383 1.5l.234.117c.3.166.216.283.466 0 .25-.284.834-.984 1.034-1.284a.717.717 0 011-.25c.333.117 2.05.967 2.283 1.084l.183.1c.207.073.391.2.534.366.138.592.08 1.212-.167 1.767a3.6 3.6 0 01-2.4 1.667 6.05 6.05 0 01-.833 0 4.083 4.083 0 01-1.35-.2 16.667 16.667 0 01-1.917-.7 14.767 14.767 0 01-5.7-5l.017-.117a6.483 6.483 0 01-1.4-3.55 3.967 3.967 0 011.15-2.85l.103-.106c.253-.232.583-.368.93-.377z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="TelegramShareIcon" viewBox="0 0 24 20">
+            <path d="M23.998 1.093V.987a.95.95 0 00-.665-.968 1.498 1.498 0 00-.473 0A3.78 3.78 0 0021.337.3c-1.523.564-3.03 1.162-4.535 1.761l-3.064 1.092-1.383.58-1.646.687-1.558.67a174.913 174.913 0 00-6.093 2.693c-.876.422-1.751.845-2.591 1.32a1.227 1.227 0 00-.333.264.441.441 0 000 .634c.089.101.196.185.315.247.177.116.365.216.56.299.828.38 1.683.697 2.557.95a8.801 8.801 0 001.908.458 3.486 3.486 0 002.119-.44 36.892 36.892 0 002.783-1.76c1.576-1.039 3.134-2.148 4.675-3.24a19.78 19.78 0 011.751-1.197c.177-.127.372-.228.578-.3a.644.644 0 01.263 0c.14 0 .21 0 .192.212a.848.848 0 01-.192.51 64.839 64.839 0 01-1.541 1.568c-1.05 1.003-2.136 1.954-3.187 2.94l-1.75 1.602c-.303.28-.542.622-.701 1.003-.11.243-.152.51-.123.775.04.31.205.59.456.775l.893.633 6.478 4.402.385.264a1.882 1.882 0 001.808.124 1.9 1.9 0 001.08-1.462l.526-2.993.525-3.204c.193-1.11.368-2.219.543-3.328.14-.81.263-1.62.385-2.43l.473-3.415c0-.634.07-1.267.105-1.901z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="TwitterShareIcon" viewBox="0 0 26 22">
+            <path d="M24.883 1.133a11.133 11.133 0 01-3.333 1.284A5.1 5.1 0 0017.783.75a5.167 5.167 0 00-5.1 5.25c.01.398.06.795.15 1.183A14.717 14.717 0 012.183 1.7 5.167 5.167 0 003.85 8.6a4.9 4.9 0 01-2.333-.65 5.183 5.183 0 004.133 5c-.44.115-.895.17-1.35.167a4.383 4.383 0 01-.95 0A5.133 5.133 0 008.167 16.7 10.283 10.283 0 01.5 18.817a14.768 14.768 0 007.85 2.35A14.584 14.584 0 0023 6.467v-.684a10 10 0 002.55-2.666c-.94.411-1.933.686-2.95.816a4.817 4.817 0 002.283-2.8z" fill-rule="nonzero"></path>
+        </symbol>
+
+                <symbol id="XTwitterShareIcon" viewBox="0 0 28 28">
+            <g transform="translate(2 2)">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
+            </g>
+        </symbol>
+
+                <symbol id="FacebookShareIcon" viewBox="0 0 15 28">
+            <path d="M4.518 28V15.38H0v-4.688h4.518v-4.06C4.518 2.482 6.988 0 11.145 0c1.291.013 2.58.12 3.855.321v3.973h-2.093a2.871 2.871 0 00-2.287.738 2.687 2.687 0 00-.861 2.183v3.477h4.985l-.738 4.688H9.789V28H4.52z" fill-rule="nonzero"></path>
+        </symbol>
+
+        		<symbol id="CheckMark" viewBox="0 0 100 100" fill="none">
+			<path d="M50 0C22.4308 0 0 22.4288 0 50C0 77.5712 22.4308 100 50 100C77.5692 100 100 77.5712 100 50C100 22.4288 77.5692 0 50 0ZM50 96.1538C24.5519 96.1538 3.84615 75.4481 3.84615 50C3.84615 24.5519 24.5519 3.84615 50 3.84615C75.4481 3.84615 96.1538 24.5519 96.1538 50C96.1538 75.4481 75.4481 96.1538 50 96.1538Z" fill="#6EC601"></path>
+			<path d="M73.5616 29.4923L44.0058 62.7423L26.2 48.4981C25.3731 47.8346 24.1596 47.9711 23.4981 48.7981C22.8346 49.6288 22.9693 50.8384 23.7981 51.5019L43.0289 66.8865C43.3827 67.1692 43.8077 67.3077 44.2308 67.3077C44.7616 67.3077 45.2904 67.0884 45.6693 66.6615L76.4385 32.0461C77.1443 31.2538 77.0731 30.0365 76.2789 29.3327C75.4827 28.625 74.2693 28.6961 73.5616 29.4923Z" fill="#6EC601"></path>
+		</symbol>
+
+				<symbol id="FailMark" viewBox="0 0 100 100" fill="none">
+			<circle cx="50" cy="50" r="49" stroke="#E61E0A" stroke-width="2"></circle>
+			<path d="M29 71.8545L71.8544 29.0001" stroke="#E61E0A" stroke-width="2" stroke-linecap="round"></path>
+			<path d="M71.8545 71.8545L29.0001 29.0001" stroke="#E61E0A" stroke-width="2" stroke-linecap="round"></path>
+		</symbol>
+
+                <symbol id="DownloadNew" viewBox="0 0 16 15" fill="none">
+            <path d="M1.33333 13.1667H14.6667C14.8877 13.1667 15.0996 13.2414 15.2559 13.3742C15.4122 13.5071 15.5 13.6872 15.5 13.8751C15.5 14.0629 15.4122 14.2431 15.2559 14.3759C15.0996 14.5088 14.8877 14.5834 14.6667 14.5834H1.33333C1.11232 14.5834 0.900358 14.5088 0.744078 14.3759C0.587797 14.2431 0.5 14.0629 0.5 13.8751C0.5 13.6872 0.587797 13.5071 0.744078 13.3742C0.900358 13.2414 1.11232 13.1667 1.33333 13.1667ZM8 0.416748C7.77899 0.416748 7.56702 0.491376 7.41074 0.624214C7.25446 0.757052 7.16667 0.93722 7.16667 1.12508V9.33183L5.25583 7.70762C5.17896 7.63997 5.08701 7.58601 4.98534 7.54888C4.88367 7.51176 4.77432 7.49222 4.66367 7.4914C4.55302 7.49059 4.44329 7.50851 4.34087 7.54412C4.23846 7.57974 4.14541 7.63234 4.06717 7.69884C3.98893 7.76535 3.92705 7.84444 3.88515 7.93149C3.84325 8.01854 3.82216 8.11181 3.82312 8.20586C3.82409 8.29992 3.84707 8.39286 3.89075 8.47928C3.93442 8.5657 3.99791 8.64386 4.0775 8.70921L7.41083 11.5425C7.48841 11.6082 7.58044 11.6602 7.68167 11.6955C7.78245 11.7315 7.89068 11.7501 8 11.7501C8.10932 11.7501 8.21755 11.7315 8.31833 11.6955C8.41956 11.6602 8.51159 11.6082 8.58917 11.5425L11.9225 8.70921C12.0743 8.57561 12.1583 8.39669 12.1564 8.21096C12.1545 8.02524 12.0669 7.84758 11.9123 7.71625C11.7578 7.58492 11.5488 7.51043 11.3303 7.50881C11.1118 7.5072 10.9013 7.57859 10.7442 7.70762L8.83333 9.33183V1.12508C8.83333 0.93722 8.74554 0.757052 8.58926 0.624214C8.43297 0.491376 8.22101 0.416748 8 0.416748Z" fill="white"></path>
+        </symbol>
+
+                <symbol id="ShareNew" viewBox="0 0 17 17" fill="none">
+            <path d="M13.4587 6.37492C14.0191 6.37492 14.5669 6.20875 15.0328 5.89742C15.4987 5.58609 15.8619 5.14358 16.0763 4.62586C16.2908 4.10813 16.3469 3.53844 16.2376 2.98883C16.1282 2.43922 15.8584 1.93437 15.4621 1.53812C15.0659 1.14187 14.561 0.87202 14.0114 0.762695C13.4618 0.65337 12.8921 0.70948 12.3744 0.923928C11.8567 1.13838 11.4142 1.50153 11.1028 1.96747C10.7915 2.43341 10.6253 2.98121 10.6253 3.54159C10.6291 3.8088 10.6713 4.07407 10.7507 4.32925L5.71022 6.69792C5.33905 6.24757 4.83788 5.92282 4.27519 5.76805C3.7125 5.61327 3.11574 5.63603 2.56647 5.83321C2.0172 6.03038 1.54221 6.39236 1.20642 6.86967C0.870637 7.34698 0.69043 7.91633 0.69043 8.49992C0.69043 9.08351 0.870637 9.65286 1.20642 10.1302C1.54221 10.6075 2.0172 10.9695 2.56647 11.1666C3.11574 11.3638 3.7125 11.3866 4.27519 11.2318C4.83788 11.077 5.33905 10.7523 5.71022 10.3019L10.7507 12.6706C10.6713 12.9258 10.6291 13.191 10.6253 13.4583C10.6237 14.1149 10.8496 14.7517 11.2647 15.2606C11.6797 15.7694 12.2582 16.1187 12.9017 16.2491C13.5452 16.3795 14.2141 16.2829 14.7944 15.9758C15.3748 15.6686 15.8308 15.1699 16.0849 14.5644C16.339 13.959 16.3754 13.2842 16.1881 12.6549C16.0008 12.0256 15.6012 11.4806 15.0574 11.1127C14.5135 10.7447 13.859 10.5766 13.2052 10.6368C12.5513 10.697 11.9386 10.9819 11.4711 11.443L6.32222 9.02409C6.39305 8.67847 6.39305 8.32208 6.32222 7.97646L11.4711 5.55679C12 6.08068 12.7142 6.37469 13.4587 6.37492ZM13.4587 2.12492C13.7389 2.12492 14.0128 2.20801 14.2457 2.36367C14.4787 2.51934 14.6603 2.74059 14.7675 2.99945C14.8747 3.25831 14.9028 3.54316 14.8481 3.81796C14.7935 4.09277 14.6585 4.3452 14.4604 4.54332C14.2623 4.74145 14.0099 4.87637 13.7351 4.93103C13.4602 4.98569 13.1754 4.95764 12.9165 4.85042C12.6577 4.74319 12.4364 4.56161 12.2808 4.32864C12.1251 4.09567 12.042 3.82178 12.042 3.54159C12.042 3.16586 12.1913 2.80553 12.4569 2.53985C12.7226 2.27418 13.083 2.12492 13.4587 2.12492ZM3.54201 9.91659C3.26182 9.91659 2.98792 9.8335 2.75495 9.67783C2.52198 9.52217 2.3404 9.30092 2.23318 9.04205C2.12595 8.78319 2.0979 8.49835 2.15256 8.22354C2.20722 7.94874 2.34215 7.69631 2.54027 7.49819C2.7384 7.30006 2.99082 7.16514 3.26563 7.11047C3.54044 7.05581 3.82528 7.08387 4.08414 7.19109C4.343 7.29831 4.56426 7.47989 4.71992 7.71286C4.87559 7.94583 4.95867 8.21973 4.95867 8.49992C4.95867 8.87564 4.80942 9.23598 4.54374 9.50165C4.27807 9.76733 3.91773 9.91659 3.54201 9.91659ZM13.4587 12.0416C13.7389 12.0416 14.0128 12.1247 14.2457 12.2803C14.4787 12.436 14.6603 12.6573 14.7675 12.9161C14.8747 13.175 14.9028 13.4598 14.8481 13.7346C14.7935 14.0094 14.6585 14.2619 14.4604 14.46C14.2623 14.6581 14.0099 14.793 13.7351 14.8477C13.4602 14.9024 13.1754 14.8743 12.9165 14.7671C12.6577 14.6599 12.4364 14.4783 12.2808 14.2453C12.1251 14.0123 12.042 13.7384 12.042 13.4583C12.042 13.0825 12.1913 12.7222 12.4569 12.4565C12.7226 12.1908 13.083 12.0416 13.4587 12.0416Z" fill="white"></path>
+        </symbol>
+
+        <symbol id="Volume" viewBox="0 0 19 16" fill="none">
+            <path d="M1.15838 9.93063C0.445373 8.74229 0.445373 7.25771 1.15838 6.06937C1.37596 5.70674 1.73641 5.45272 2.1511 5.36978L3.84413 5.03117C3.94499 5.011 4.03591 4.95691 4.10176 4.87788L6.17085 2.39498C7.3534 0.975916 7.94468 0.266384 8.47234 0.457422C9 0.648462 9 1.57207 9 3.41928L9 12.5807C9 14.4279 9 15.3515 8.47234 15.5426C7.94468 15.7336 7.3534 15.0241 6.17085 13.605L4.10176 11.1221C4.03591 11.0431 3.94499 10.989 3.84413 10.9688L2.1511 10.6302C1.73641 10.5473 1.37596 10.2933 1.15838 9.93063Z" fill="white"></path>
+            <path d="M11.5355 4.46447C12.4684 5.39732 12.9948 6.66105 13 7.9803C13.0052 9.29955 12.4888 10.5674 11.5633 11.5076" stroke="white" stroke-width="2" stroke-linecap="round"></path>
+            <path d="M15.6569 2.34314C17.1494 3.83572 17.9916 5.85769 17.9999 7.96848C18.0083 10.0793 17.182 12.1078 15.7012 13.6121" stroke="white" stroke-width="2" stroke-linecap="round"></path>
+        </symbol>
+    </svg>
+</div>
+
+				
+				
+
+					    <noscript><div><img src="https://mc.yandex.ru/watch/1641813" style="display: none; position:absolute; left:-9999px;" alt=""/></div></noscript><noscript><div><img src="https://mc.yandex.ru/watch/1641813" style="position:absolute; left:-9999px;" alt=""/></div></noscript><div style="position: fixed; left: -9999px;"><a href="https://www.liveinternet.ru/click;RTNEWS" target="_blank"><img id="licntD91E" width="31" height="31" style="border:0" title="LiveInternet" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7" alt=""></a></div>		
+				
+					
+		
+		
+				
+
+
+						
+		
+		
+		
+
+				
+        
+
+
+		
+				
+		
+			
+			
+		
+		
+
+						
+
+			
+
+</body></html>

--- a/src/extractors/custom/actualidad.rt.com/index.js
+++ b/src/extractors/custom/actualidad.rt.com/index.js
@@ -1,0 +1,31 @@
+export const ActualidadRtComExtractor = {
+  domain: 'actualidad.rt.com',
+
+  title: {
+    selectors: [['meta[name="og:title"]', 'value']],
+  },
+
+  author: {
+    selectors: [['meta[name="article:author"]', 'value']],
+  },
+
+  date_published: {
+    selectors: [['meta[name="mediator_published_time"]', 'value']],
+  },
+
+  dek: {
+    selectors: [['meta[name="og:description"]', 'value']],
+  },
+
+  lead_image_url: {
+    selectors: [['meta[name="og:image"]', 'value']],
+  },
+
+  content: {
+    selectors: ['.ArticleView-text'],
+
+    transforms: {},
+
+    clean: ['.ReadMore-root'],
+  },
+};

--- a/src/extractors/custom/actualidad.rt.com/index.js
+++ b/src/extractors/custom/actualidad.rt.com/index.js
@@ -26,6 +26,9 @@ export const ActualidadRtComExtractor = {
 
     transforms: {},
 
-    clean: ['.ReadMore-root'],
+    // RT wraps each <img> in a <picture> whose <source> elements carry a
+    // base64 placeholder srcset; browsers honor that over the real <img src>,
+    // so drop the sources and let the <img> (real URL) render.
+    clean: ['.ReadMore-root', 'source'],
   },
 };

--- a/src/extractors/custom/actualidad.rt.com/index.test.js
+++ b/src/extractors/custom/actualidad.rt.com/index.test.js
@@ -77,4 +77,56 @@ describe('ActualidadRtComExtractor', () => {
       );
     });
   });
+
+  describe('image-heavy article', () => {
+    let result;
+    let url;
+    beforeAll(() => {
+      url =
+        'https://actualidad.rt.com/a-fondo/610168-almuerzo-salvo-mundo-desastre-nuclear';
+      const html = fs.readFileSync(
+        './fixtures/actualidad.rt.com/1781469971715.html'
+      );
+      result = Parser.parse(url, { html, fallback: false });
+    });
+
+    it('returns the title', async () => {
+      const { title } = await result;
+
+      assert.strictEqual(
+        title,
+        `El almuerzo que salvó al mundo de un desastre nuclear en 1962`
+      );
+    });
+
+    it('returns the content', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      const first13 = excerptContent($('*').first().text(), 13);
+
+      assert.strictEqual(
+        first13,
+        'La Crisis de los Misiles de Cuba en 1962 estuvo a punto de'
+      );
+    });
+
+    it('resolves inline images to real URLs', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+      const images = $('img').toArray();
+
+      assert.ok(images.length > 0, 'expected inline images in the content');
+
+      images.forEach(img => {
+        const src = $(img).attr('src') || '';
+        assert.ok(
+          /^https?:\/\//.test(src),
+          `expected a real image URL, got: ${src}`
+        );
+      });
+    });
+  });
 });

--- a/src/extractors/custom/actualidad.rt.com/index.test.js
+++ b/src/extractors/custom/actualidad.rt.com/index.test.js
@@ -1,0 +1,80 @@
+import assert from 'assert';
+import * as cheerio from 'cheerio';
+
+import Parser from 'mercury';
+import getExtractor from 'extractors/get-extractor';
+import { excerptContent } from 'utils/text';
+
+const fs = require('fs');
+
+describe('ActualidadRtComExtractor', () => {
+  describe('initial test case', () => {
+    let result;
+    let url;
+    beforeAll(() => {
+      url =
+        'https://actualidad.rt.com/actualidad/603743-iran-afirma-onu-garantizara-navegacion';
+      const html = fs.readFileSync(
+        './fixtures/actualidad.rt.com/1781468121405.html'
+      );
+      result = Parser.parse(url, { html, fallback: false });
+    });
+
+    it('is selected properly', () => {
+      const extractor = getExtractor(url);
+      assert.strictEqual(extractor.domain, new URL(url).hostname);
+    });
+
+    it('returns the title', async () => {
+      const { title } = await result;
+
+      assert.strictEqual(
+        title,
+        `Irán afirma ante la ONU que garantizará la navegación en Ormuz con esta condición`
+      );
+    });
+
+    it('returns the author', async () => {
+      const { author } = await result;
+
+      assert.strictEqual(author, `RT en Español`);
+    });
+
+    it('returns the date_published', async () => {
+      const { date_published } = await result;
+
+      assert.strictEqual(date_published, `2026-05-07T22:03:26.000Z`);
+    });
+
+    it('returns the dek', async () => {
+      const { dek } = await result;
+
+      assert.strictEqual(
+        dek,
+        'Amir Saeid Iravani denunció que "las acciones de EE.UU. contradicen flagrantemente sus objetivos declarados y solo han servido para intensificar las tensiones".'
+      );
+    });
+
+    it('returns the lead_image_url', async () => {
+      const { lead_image_url } = await result;
+
+      assert.strictEqual(
+        lead_image_url,
+        `https://mf.b37mrtl.ru/actualidad/public_images/2026.05/article/69fcfeb1e9ff710ff61e5ff9.jpg`
+      );
+    });
+
+    it('returns the content', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      const first13 = excerptContent($('*').first().text(), 13);
+
+      assert.strictEqual(
+        first13,
+        'El representante permanente de Irán ante la ONU, Amir Saeid Iravani, ha afirmado'
+      );
+    });
+  });
+});

--- a/src/extractors/custom/actualidad.rt.com/index.test.js
+++ b/src/extractors/custom/actualidad.rt.com/index.test.js
@@ -128,5 +128,17 @@ describe('ActualidadRtComExtractor', () => {
         );
       });
     });
+
+    it('drops placeholder <source> tags that mask the images', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      assert.strictEqual($('source').length, 0);
+      assert.ok(
+        !(content || '').includes('data:image'),
+        'expected no base64 placeholder images to remain'
+      );
+    });
   });
 });

--- a/src/extractors/custom/index.js
+++ b/src/extractors/custom/index.js
@@ -196,3 +196,4 @@ export * from './www.blick.de';
 export * from './www.euronews.com';
 export * from './gr.euronews.com';
 export * from './www.ilfattoquotidiano.it';
+export * from './actualidad.rt.com';


### PR DESCRIPTION
Adds a custom parser for RT en Español (actualidad.rt.com), requested in jocmp/capyreader#2101 ("Images Bug").

**Root cause of the image bug:** generic extraction pulled in RT's related-article "ReadMore" cards, whose thumbnails are lazy-loaded (real URL in `data-src`/`data-srcset`, a base64 placeholder in `src`/`srcset`) — so they render blank. This parser selects only the real article body and drops those widgets.

- Title/dek/lead image from `og:*` meta tags
- Author from `article:author`
- Date from `publish-date`
- Content from `.ArticleView-text`, cleaning `.ReadMore-root` related-article widgets

7/7 parser tests pass.

⚠️ Note for review: the reported article body is text-only (no inline images), so the lazy-load handling for *inline* body images is untested here. If RT articles with inline images surface, we may need a transform to swap `data-src`→`src` plus a fixture that includes them.