### PR TITLE
feat: Add animenewsnetwork.com custom parser

### DIFF
--- a/fixtures/www.animenewsnetwork.com/1781536993736.html
+++ b/fixtures/www.animenewsnetwork.com/1781536993736.html
@@ -1,0 +1,1859 @@
+<!DOCTYPE html><html render_time="89.25404892333984" lang="en" class="skin-mode-1 mobile-mode-0 gutter-mode-2 sidebar-mode-1 menu-mode-0 grid-mode-3 grid-mode-not-1 js-off desktop-device touch-mode-0"><head><meta http-equiv="Content-Type" value="text/html; charset=UTF-8">
+  <meta name="HandheldFriendly" value="true">
+  <meta name="viewport" value="width=device-width,initial-scale=1">
+  <meta name="referrer" value="origin-when-cross-origin">
+  
+  
+  <meta http-equiv="Content-Type" value="text/html; charset=UTF-8">
+  <link rel="shorturl" href="https://4nn.cx/.238512">
+<link rel="canonical" href="https://www.animenewsnetwork.com/news/2026-06-15/school-of-horns-mito-aoi-launches-new-manga/.238512">
+    <link rel="shortcut icon" href="https://www.animenewsnetwork.com/meta/favicon.ico" type="image/x-icon">
+  <link rel="search" type="application/opensearchdescription+xml" title="Anime News Network" href="https://www.animenewsnetwork.com/meta/search.general.xml">
+  <link rel="search" type="application/opensearchdescription+xml" title="ANN Encyclopedia" href="https://www.animenewsnetwork.com/meta/search.encyclopedia.xml">
+  <meta name="copyright" value="Copyright (C) 2006 Anime News Network">
+  <title>School of Horns' Mito Aoi Launches New Manga - News - Anime News Network</title>
+  
+
+  
+  <meta name="title" value="School of Horns' Mito Aoi Launches New Manga">
+  <meta name="description" value="Aoi, Meza Tōno launch Koko ni Fukuen Flag ga Tatteimasu manga">
+  <link rel="feed_image" href="https://www.animenewsnetwork.com/thumbnails/crop400x200gIB/cms/news.9/238512/fukuenflag.jpg">
+  <link rel="image_src" href="https://www.animenewsnetwork.com/thumbnails/crop1200x630gIB/cms/news.9/238512/fukuenflag.jpg">
+  <meta name="robots" value="max-image-preview:large">
+  
+  <meta value="School of Horns' Mito Aoi Launches New Manga" name="og:title">
+  
+  <meta value="article" name="og:type">
+  <meta value="https://www.animenewsnetwork.com/thumbnails/crop600x315gIB/cms/news.9/238512/fukuenflag.jpg" name="og:image">
+  <meta value="600" name="og:image:width">
+  <meta value="315" name="og:image:height">
+  <meta value="https://www.animenewsnetwork.com/news/2026-06-15/school-of-horns-mito-aoi-launches-new-manga/.238512" name="og:url">
+  <meta value="Anime News Network" name="og:site_name">
+  
+  <meta name="twitter:card" value="summary_large_image">
+  <meta name="twitter:site" value="@anime">
+  <meta name="twitter:image" value="https://www.animenewsnetwork.com/thumbnails/crop600x315gIB/cms/news.9/238512/fukuenflag.jpg">
+  <meta name="twitter:title" value="School of Horns' Mito Aoi Launches New Manga">
+
+  
+  
+  <link rel="stylesheet" type="text/css" href="https://www.animenewsnetwork.com/assets/2ea628feb221b14974f3e0a357eec3fe11ec1476.css" cdn="no">
+  <link rel="stylesheet" type="text/css" href="https://www.animenewsnetwork.com/assets/db5f2e7440ab8199fb475f0f926d7913db7d2c0c.css" asset="no" media="screen, projection, tv">
+  
+  <noscript><style>.requires-javascript { display:none !important }</style></noscript>
+  
+    <link rel="stylesheet" type="text/css" href="https://cdn.animenewsnetwork.com/assets/63efff8e8b91484aa76ccbec54e319cfb3fa136d.css" media="screen, projection, tv">
+  <link rel="stylesheet" type="text/css" href="https://cdn.animenewsnetwork.com/assets/6953595b3ffd6f198fad1eea3754f8de7184ec3c.css">
+  <noscript><style>.js-content{ display:none !important }</style></noscript>
+
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+
+    
+      
+
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+
+
+
+</head>
+ <body>
+  
+  
+  <div id="page">
+   <div class="left side gutter">
+    <span class="top-area"></span>
+    <a href="https://www.animenewsnetwork.com/sponsor/click.php/19269/8055/1781536993/612999/3" target="_blank" untracked-href="https://jjkpp.onelink.me/C5Wu/gat5o8dk" rel="sponsored nofollow"></a>
+   </div>
+   <div id="canvas">
+<div id="header" class="top-area">
+  
+  <div class="left half">
+    <div class="actionable hamburger">
+      <div class="header-button" title="Open Menu">
+        <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#menu"></use></svg>
+      </div>
+    </div>
+    <div class="actionable logo">
+      <a href="https://www.animenewsnetwork.com/" title="Return to Homepage"><img src="https://cdn.animenewsnetwork.com/stylesheets/img/logo.name.no-dot.png" width="313" height="37" alt=""></a>
+    </div>
+    <div class="actionable edition">
+      <div class="dropdown button" title="Choose Your Edition">
+        <span>USA &amp;<br>Canada</span>
+        <ul>
+          <li onclick="ANN.set_edition('en-W')">World</li>
+          <li onclick="ANN.set_edition('en-US')">USA &amp; Canada</li>
+          <li onclick="ANN.set_edition('en-AU')">Australia &amp; New-Zealand</li>
+          <li onclick="ANN.set_edition('en-IN')">India</li>
+          <li onclick="ANN.set_edition('en-SEA')">Southeast Asia</li>
+          <li onclick="ANN.set_edition('fr-FR')">Français</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  
+  <div class="right half">
+    <div class="actionable hamburger">
+      <div class="header-button" title="Open Menu">
+        <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#menu"></use></svg>
+      </div>
+    </div>
+    
+    <div class="actionable short-logo">
+      <img src="https://cdn.animenewsnetwork.com/stylesheets/img/logo.short.png" width="88" height="24" alt="">
+    </div>
+    
+    <div class="actionable socials">
+      <div class="header-button twitter" title="Twitter">
+        <a href="https://twitter.com/anime" target="_blank">
+          <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#twitter"></use></svg></a>
+      </div>
+      <div class="header-button youtube" title="Youtube">
+        <a href="https://www.youtube.com/c/animenewsnetworkANN" target="_blank">
+          <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#youtube"></use></svg></a>
+      </div>
+      <div class="header-button facebook" title="Facebook">
+        <a href="https://www.facebook.com/animenewsnetwork" target="_blank">
+          <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#facebook"></use></svg></a>
+      </div>
+      <div class="header-button instagram" title="Instagram">
+        <a href="https://www.instagram.com/animenewsnetwork/" target="_blank">
+          <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#instagram"></use></svg></a>
+      </div>
+      <div class="header-button tiktok" title="TikTok">
+        <a href="https://www.tiktok.com/@animenewsnetwork" target="_blank">
+          <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#tiktok"></use></svg></a>
+      </div>
+      <div class="header-button bluesky" title="Bluesky">
+        <a href="https://bsky.app/profile/animenewsnetwork.com" target="_blank">
+          <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#bluesky"></use></svg></a>
+      </div>
+    </div>
+    
+    <div class="actionable buttons">
+      <div class="header-button report" title="Report a Problem">
+        <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#bubble_exclamation"></use></svg>
+      </div>
+      <div class="header-button user" title="Login or Register">
+        <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#enter"></use></svg>
+
+<div class="user_menu login_register">
+  <div class="content">
+    
+    
+    
+    
+    
+  </div>
+</div>
+
+      </div>
+      <div class="header-button search" title="Search">
+        <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#search"></use></svg>
+      </div>
+    </div>
+    
+    <div class="actionable" id="searchbox">
+      
+      
+    </div>
+    
+  </div>
+  
+</div>
+    <div class="top gutter">
+     <a href="https://www.animenewsnetwork.com/sponsor/click.php/19269/8055/1781536993/612999/0" target="_blank" untracked-href="https://jjkpp.onelink.me/C5Wu/gat5o8dk" rel="sponsored nofollow"></a>
+    </div>
+    <div class="middle-area">
+     <div class="iab top">
+            <div>
+              <noscript>
+                <iframe src="/show.aframe?t=B&amp;js=no" scrolling="no"></iframe>
+              </noscript>
+            </div>
+          </div>
+     <div id="menu">
+<nav id="mega">
+  
+  <div class="news menu">
+    <span>News</span>
+    <div><nav>
+      <ul class="colspan1of2">
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/news/">News</a>
+          <a href="https://www.animenewsnetwork.com/news/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T11:15:00-04:00">11:15</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/school-of-horns-mito-aoi-launches-new-manga/.238512"><cite>School of Horns'</cite> Mito Aoi Launches New Manga</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T11:02:56-04:00">11:02</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/rascal-does-not-dream-of-a-dear-friend-film-trailer-previews-song-by-toko-kirishima/.238541"><cite>Rascal Does Not Dream of a Dear Friend</cite> Film's Trailer Previews Song by Tōko Kirishima</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T10:15:00-04:00">10:15</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/ameku-m.d.s-mikito-chinen-launches-new-manga/.238504"><cite>Ameku M.D.'s</cite> Mikito Chinen Launches New Manga</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T09:15:00-04:00">09:15</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/jun-nishikawa-maken-no-deshi-wa-muno-de-saikyo-manga-adaptation-ends/.238507">Jun Nishikawa's <cite>Maken no Deshi wa Munō de Saikyō!</cite> Manga Adaptation Ends</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T08:15:00-04:00">08:15</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/sublime-licenses-2-new-manga-for-physical-digital-release/.238505">SuBLime Licenses 2 New Manga for Physical, Digital Release</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T07:15:00-04:00">07:15</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/splatoon-raiders-game-gets-manga-on-july-15/.238510"><cite>Splatoon Raiders</cite> Game Gets Manga on July 15</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T06:12:52-04:00">06:12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/sasaki-and-peeps-2nd-season-anime-reveals-october-debut-more-returning-staff-in-new-promo-video/.238535"><cite>Sasaki and Peeps</cite> 2nd Season Anime Reveals October Debut, More Returning Staff in New Promo Video</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T04:19:08-04:00">04:19</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-15/the-apothecary-diaries-palace-chronicles-browser-game-launches/.238530"><cite>The Apothecary Diaries Palace Chronicles</cite> Browser Game Launches</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-14T23:58:39-04:00">Jun 14</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-14/black-clover-anime-season-2-unveils-director-october-tv-debut/.238515"><cite>Black Clover</cite> Anime Season 2 Unveils Director, October TV Debut</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-14T23:35:58-04:00">Jun 14</time></span>
+  <span><a href="https://www.animenewsnetwork.com/news/2026-06-14/within-the-villainess-anime-casts-ayane-sakura-as-star-maiden/.238513"><cite>Within the Villainess</cite> Anime Casts Ayane Sakura as Star Maiden</a></span>
+</li>
+
+
+
+        
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/convention/">Convention reports</a>
+          <a href="https://www.animenewsnetwork.com/convention/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-04-27T12:58:21-04:00">Apr 27</time></span>
+  <span><a href="https://www.animenewsnetwork.com/convention/2026/final-fantasy-xiv-director-naoki-yoshida-discusses-the-next-decade/.236834">Final Fantasy XIV Director Naoki Yoshida Discusses the Next Decade</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-03-29T11:41:46-04:00">Mar 29</time></span>
+  <span><a href="https://www.animenewsnetwork.com/convention/2026/animejapan/.235923">AnimeJapan 2026</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2025-10-16T17:30:00-04:00">Oct 16</time></span>
+  <span><a href="https://www.animenewsnetwork.com/convention/2025/ronin-and-sith-reunite-in-star-wars-visions-the-duel-payback/.229769">Ronin and Sith Reunite in <cite>Star Wars Visions The Duel: Payback</cite></a></span>
+</li>
+
+
+
+
+        <li><h4><a href="https://www.animenewsnetwork.com/newsfeed/">Newsfeed</a></h4></li>
+      </ul>
+      <ul class="colspan1of2">
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/interest/">Interest</a>
+          <a href="https://www.animenewsnetwork.com/interest/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-14T23:59:00-04:00">Jun 14</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-14/one-piece-luffy-joins-nba-champions-new-york-knicks/.238500"><i>One Piece's</i> Luffy Joins NBA Champions, New York Knicks</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-13T23:59:00-04:00">Jun 13</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-13/star-detective-precure-anime-asks-fans-to-figure-out-cure-eclair-secret-identity/.238453"><i>Star Detective Precure!</i> Anime Asks Fans to Figure Out Cure Eclair's Secret Identity</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T23:59:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-12/the-girl-who-leapt-through-time-screenings-offer-leap-counter-as-arm-tattoos/.238410"><i>The Girl Who Leapt Through Time</i> Screenings Offer Leap Counter as (Temporary) Arm Tattoos</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T21:00:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-12/naoki-urasawa-animates-new-rodrigo-y-gabriela-music-video-monster/.238420">Naoki Urasawa 'Animates' New Rodrigo y Gabriela Music Video 'Monster'</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-10T23:30:00-04:00">Jun 10</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-10/star-detective-precure-anime-announces-detective-conan-collaboration-merchandise/.238278"><cite>Star Detective Precure!</cite> Anime Announces <cite>Detective</cite> Conan Collaboration Merchandise</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-09T22:45:00-04:00">Jun  9</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-09/happy-rock-day-from-around-the-anime-world/.238331">Happy Rock Day (&amp; Lock Day) From Around the Anime World</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-09T12:00:00-04:00">Jun  9</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interest/2026-06-09/gundam-crosses-over-with-sgt-frog-in-latest-film-and-new-art/.238312"><i>Gundam</i> Crosses Over With <i>Sgt. Frog</i> in Latest Film &amp; New Art</a></span>
+</li>
+
+
+
+        
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/press-release/">Press Releases</a>
+          <a href="https://www.animenewsnetwork.com/press-release/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T08:02:22-04:00">08:02</time></span>
+  <span><a href="https://www.animenewsnetwork.com/press-release/2026-06-15/3-2-1-let-it-rip-beyblade-x-returns-to-anime-expo-bringing-high-energy-battles-and-interactive-fan-/.238539">3, 2, 1… Let It Rip! <cite>Beyblade X</cite> Returns to Anime Expo, Bringing High-Energy Battles and Interactive Fan Events</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T01:13:33-04:00">01:13</time></span>
+  <span><a href="https://www.animenewsnetwork.com/press-release/2026-06-15/toho-entertainment-asia-buffs-up-its-title-lineup-with-palace-drama-anime-though-i-am-an-inept-/.238518">Toho Entertainment Asia Buffs Up Its Title Lineup With Palace Drama Anime <cite>Though I Am an Inept Villainess</cite></a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-14T22:00:00-04:00">Jun 14</time></span>
+  <span><a href="https://www.animenewsnetwork.com/press-release/2026-06-14/the-apothecary-diaries-palace-chronicles-is-finally-here/.238461"><cite>'The Apothecary Diaries Palace Chronicles'</cite> is Finally Here</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-14T11:20:55-04:00">Jun 14</time></span>
+  <span><a href="https://www.animenewsnetwork.com/press-release/2026-06-14/tokyo-revengers-war-of-the-three-titans-arc-3rd-trailer-revealed/.238503"><cite>Tokyo Revengers</cite> “<cite>War of the Three Titans Arc</cite>” 3rd Trailer Revealed</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-13T17:38:41-04:00">Jun 13</time></span>
+  <span><a href="https://www.animenewsnetwork.com/press-release/2026-06-13/ikumi-hasegawa-joins-kill-blue-cast-as-mermaid-queen-mai-otohime/.238487">Ikumi Hasegawa Joins <cite>Kill Blue</cite>'s Cast As Mermaid Queen Mai Otohime</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T17:02:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/press-release/2026-06-12/ize-press-licenses-bl-webcomic-love-so-pure-for-print-publication/.238460">Ize Press Licenses BL Webcomic <cite>Love So Pure</cite> for Print Publication</a></span>
+</li>
+
+
+
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="views menu">
+    <span>Views</span>
+    <div><nav>
+      <ul class="colspan1of2">
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/feature/">Features</a>
+          <a href="https://www.animenewsnetwork.com/feature/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T23:30:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/weekly-ranking/2026/spring/.238465">Your Anime Rankings - Best of Spring 2026, June 3-9</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T09:00:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interview/2026-06-12/creating-visual-spectacle-in-nippon-sangoku-with-director-kazuaki-terasawa/.238390">Creating Visual Spectacle in <cite>Nippon Sangoku</cite> with Director Kazuaki Terasawa</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-11T10:00:00-04:00">Jun 11</time></span>
+  <span><a href="https://www.animenewsnetwork.com/feature/2026-06-11/hands-on-preview-you-cant-play-stranger-than-heaven-like-a-yakuza-game/.238392">Hands-On Preview: You Can't Play <cite>Stranger Than Heaven</cite> Like a <cite>Yakuza</cite> Game</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-10T11:00:00-04:00">Jun 10</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interview/2026-06-10/what-new-and-different-in-resident-evil-veronica/.238353">Interview: What's New and Different in <cite>Resident Evil Veronica</cite></a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-09T09:00:00-04:00">Jun  9</time></span>
+  <span><a href="https://www.animenewsnetwork.com/feature/2026-06-09/tokyo-revengers-returns-to-pony-canyon-stage-at-animejapan-2026-for-50-minutes-of-fun-and-games/.236384">Tokyo Revengers Returns to Pony Canyon Stage at AnimeJapan 2026 for 50 Minutes of Fun and Games</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-08T09:00:00-04:00">Jun  8</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interview/2026-06-08/the-astronaut-who-loves-anime/.238185">The Astronaut Who Loves Anime</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-06T12:10:00-04:00">Jun  6</time></span>
+  <span><a href="https://www.animenewsnetwork.com/weekly-ranking/2026/spring/.238223">Your Anime Rankings - Best of Spring 2026, May 27-June 2</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-05T09:00:00-04:00">Jun  5</time></span>
+  <span><a href="https://www.animenewsnetwork.com/feature/2026-06-05/finding-my-own-stand-at-shibuya-the-jojo-world-store/.236856">Finding My Own Stand at Shibuya's THE★JOJO WORLD Store</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-03T09:00:00-04:00">Jun  3</time></span>
+  <span><a href="https://www.animenewsnetwork.com/interview/2026-06-03/hololive-nerissa-ravencroft-talks-about-frieren-naruto-and-her-family-streams/.237749">Hololive's Nerissa Ravencroft Talks about <cite>Frieren, Naruto</cite>, and Her Family Streams</a></span>
+</li>
+
+
+
+        
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/review/">Reviews</a>
+          <a href="https://www.animenewsnetwork.com/review/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-14T12:00:00-04:00">Jun 14</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/red-river/omnibus-2-5/.238282"><cite>Red River</cite> Omnibus 2-5 Manga Review</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-13T12:00:00-04:00">Jun 13</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/dara-san-of-reiwa-volume-1-3/manga/.238157"><cite>Dara-san of Reiwa</cite> Volume 1-3 Manga Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T12:00:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/reform-with-no-wasted-draws-the-legend-of-koizumi-volume-1-manga/.238125"><cite>Reform with No Wasted Draws - The Legend of Koizumi</cite> Volume 1 Manga Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-11T12:00:00-04:00">Jun 11</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/dandelion-anime-series/.237900"><cite>Dandelion</cite> Anime Series Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-10T12:00:00-04:00">Jun 10</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/a-gentle-noble-vacation-recommendation/anime-series/.237980"><cite>A Gentle Noble's Vacation Recommendation</cite> Anime Series Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-09T12:00:00-04:00">Jun  9</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/game/nintendo-switch/yoshi-and-the-mysterious-book/.238000"><cite>Yoshi and the Mysterious Book</cite> Game Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-08T12:00:00-04:00">Jun  8</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/a-returner-magic-should-be-special/volumes-4-6/.238094"><cite>A Returner's Magic Should Be Special</cite> Volumes 4-6 K-Comic Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-07T12:00:00-04:00">Jun  7</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/alien-nine-blu-ray/.237979"><cite>Alien Nine</cite> Blu-ray Review</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-06T12:00:00-04:00">Jun  6</time></span>
+  <span><a href="https://www.animenewsnetwork.com/review/smoking-behind-the-supermarket-with-you/mini-episode-cut-anime/.238191"><cite>Smoking Behind the Supermarket with You</cite> Mini-Episode Cut Anime Review</a></span>
+</li>
+
+
+
+      </ul>
+      <ul class="colspan1of2">
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/column/">Columns</a>
+          <a href="https://www.animenewsnetwork.com/column/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T10:00:00-04:00">10:00</time></span>
+  <span><a href="https://www.animenewsnetwork.com/answerman/2026-06-15/.238511">Answerman - What's Actually Happening at Kadokawa?</a></span>
+</li>
+
+<li>
+  <span class="time-posted"><time datetime="2026-06-15T09:00:00-04:00">09:00</time></span>
+  <span><a href="https://www.animenewsnetwork.com/this-week-in-mobile-games/2026-06-15/.238088">This Week in Mobile Games - Seeking Summer Smartphone Succor</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-12T10:00:00-04:00">Jun 12</time></span>
+  <span><a href="https://www.animenewsnetwork.com/this-week-in-games/2026-06-12/summer-showcase-slamfest-save-room-for-aincrad/.238267">This Week in Games - Summer Showcase Slamfest - Save Room For Aincrad</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2026-06-11T10:00:00-04:00">Jun 11</time></span>
+  <span><a href="https://www.animenewsnetwork.com/this-week-in-anime/2026-06-11/.238376">This Week in Anime - Movie Night Madness</a></span>
+</li>
+
+
+
+        
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/newtype/" class="t-newtype">Newtype</a>...
+          <a href="https://www.animenewsnetwork.com/newtype/archive" class="archives">view full archive</a>
+        </h4></li>
+        
+
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2025-04-29T09:00:00-04:00">Apr 29</time></span>
+  <span><a href="https://www.animenewsnetwork.com/newtype/2025-04-29/exclusive-interview-with-sakamoto-days-cast-tomokazu-sugita-as-taro-sakamoto-and-nobunaga-shimazaki-/.223555">Newtype Exclusive Interview with <cite>SAKAMOTO DAYS</cite> Cast, Tomokazu Sugita as Taro Sakamoto and Nobunaga Shimazaki as Shin Asakura!</a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2025-03-13T09:00:00-04:00">Mar 13</time></span>
+  <span><a href="https://www.animenewsnetwork.com/newtype/2025-03-13/exclusive-interview-with-composer-kaoru-wada-crafting-the-soundscape-of-ranma/.221672">Newtype Exclusive Interview with Composer Kaoru Wada: Crafting the Soundscape of <cite>Ranma ½</cite></a></span>
+</li>
+
+<li class="not_recent">
+  <span class="time-posted"><time datetime="2025-02-11T09:00:00-05:00">Feb 11</time></span>
+  <span><a href="https://www.animenewsnetwork.com/newtype/2025-02-11/exclusive-interview-with-creators-behind-one-piece-fan-letter-part-2/.220541">Newtype Exclusive Interview with Creators Behind <cite>ONE PIECE FAN LETTER</cite> - Part 2</a></span>
+</li>
+
+
+
+        
+        <li><h4>
+          <a href="https://www.animenewsnetwork.com/views/">Everything</a>
+          <a href="https://www.animenewsnetwork.com/views/archive" class="archives">view full archive</a>
+        </h4></li>
+        <li class="subtypes">
+          <a href="https://www.animenewsnetwork.com/feature/">Features</a>
+          (incl.
+          <a href="https://www.animenewsnetwork.com/interviews/">Interviews</a> and
+          <a href="https://www.animenewsnetwork.com/newtype/">Newtype</a>,
+          and also as
+          <a href="https://www.animenewsnetwork.com/seasonal/">Seasonal</a> features like
+          <a href="https://www.animenewsnetwork.com/anime-spotlight/">Anime Spotlight</a>,
+          <a href="https://www.animenewsnetwork.com/preview-guide/">Preview Guide</a>,
+          <a href="https://www.animenewsnetwork.com/weekly-ranking/">Weekly Rankings</a>)
+        </li>
+        <li class="subtypes">
+          <a href="https://www.animenewsnetwork.com/review/">Reviews</a>
+          (incl. <a href="https://www.animenewsnetwork.com/game-review/">Game Reviews</a>)
+        </li>
+        <li class="subtypes">
+          <a href="https://www.animenewsnetwork.com/column/">Current Columns</a>
+          (incl. <a href="https://www.animenewsnetwork.com/answerman/">Answerman</a>, <a href="https://www.animenewsnetwork.com/azure/">Intern Annika</a>, <a href="https://www.animenewsnetwork.com/aftershow/">The ANN Aftershow</a>, <a href="https://www.animenewsnetwork.com/anime-backlog/">The Anime Backlog</a>, <a href="https://www.animenewsnetwork.com/this-week-in-anime/">This Week in Anime</a>, <a href="https://www.animenewsnetwork.com/this-week-in-games/">This Week in Games</a>, <a href="https://www.animenewsnetwork.com/this-week-in-mobile-games/">This Week in Mobile Games</a>)
+        </li>
+        <li class="subtypes">
+          <a href="https://www.animenewsnetwork.com/old-column/">Archived Columns</a>
+          (incl. <a href="https://www.animenewsnetwork.com/anncast/">ANNCast</a>, <a href="https://www.animenewsnetwork.com/ann-tv/">ANNtv</a>, <a href="https://www.animenewsnetwork.com/anime-news-nina/">Anime News Nina!</a>, <a href="https://www.animenewsnetwork.com/astro-toy/">Astro Toy</a>, <a href="https://www.animenewsnetwork.com/brain-diving/">Brain Diving</a>, <a href="https://www.animenewsnetwork.com/buried-treasure/">Buried Treasure</a>, <a href="https://www.animenewsnetwork.com/chicks-on-anime/">Chicks On Anime</a>, <a href="https://www.animenewsnetwork.com/crashing-japan/">Crashing Japan</a>, <a href="https://www.animenewsnetwork.com/epic-threads/">Epic Threads</a>, <a href="https://www.animenewsnetwork.com/from-the-gallery/">From The Gallery</a>, <a href="https://www.animenewsnetwork.com/hai-fidelity/">Hai Fidelity</a>, <a href="https://www.animenewsnetwork.com/house-of-1000-manga/">House of 1000 Manga</a>, <a href="https://www.animenewsnetwork.com/ima-kore-ga-hoshiin-da/">Ima Kore Ga Hoshiin Da</a>, <a href="https://www.animenewsnetwork.com/old-school/">Old School</a>, <a href="https://www.animenewsnetwork.com/pile-of-shame/">Pile of Shame</a>, <a href="https://www.animenewsnetwork.com/right-turn-only/">RIGHT TURN ONLY!!</a>, <a href="https://www.animenewsnetwork.com/shelf-life/">Shelf Life</a>, <a href="https://www.animenewsnetwork.com/sound-decision/">Sound Decision</a>, <a href="https://www.animenewsnetwork.com/sub-culture/">Sub Culture</a>, <a href="https://www.animenewsnetwork.com/super-plastic/">Super Plastic</a>, <a href="https://www.animenewsnetwork.com/tales-of-the-industry/">Tales Of The Industry</a>, <a href="https://www.animenewsnetwork.com/tankobon-tower/">Tankobon Tower</a>, <a href="https://www.animenewsnetwork.com/the-click/">The Click</a>, <a href="https://www.animenewsnetwork.com/dub-track/">The Dub Track</a>, <a href="https://www.animenewsnetwork.com/edit-list/">The Edit List</a>, <a href="https://www.animenewsnetwork.com/the-gallery/">The Gallery</a>, <a href="https://www.animenewsnetwork.com/the-list/">The List</a>, <a href="https://www.animenewsnetwork.com/the-mike-toole-show/">The Mike Toole Show</a>, <a href="https://www.animenewsnetwork.com/the-set-list/">The Set List</a>, <a href="https://www.animenewsnetwork.com/the-stream/">The Stream</a>, <a href="https://www.animenewsnetwork.com/the-x-button/">The X Button</a>, <a href="https://www.animenewsnetwork.com/vice-and-luna/">Vice &amp; Luna</a>)
+        </li>
+        <li class="subtypes">
+          <a href="https://www.animenewsnetwork.com/editorial/">Editorials</a>
+          (incl. <a href="https://www.animenewsnetwork.com/industry-comments/">Industry Comments</a>)
+        </li>
+        <li class="subtypes">
+          <a href="https://www.animenewsnetwork.com/advertorial/">Advertorials</a>
+        </li>
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="newanime menu">
+    <span>New Anime</span>
+    <div><nav>
+      <ul>
+          <li><h4><a href="https://www.animenewsnetwork.com/season/2026/summer/">Summer 2026 next season</a></h4></li>
+        <li><h4><a href="https://www.animenewsnetwork.com/season/2026/spring/">Spring 2026 current season</a></h4></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime/episodes/latest"><b>Your Score:</b> Rate the Latest Simulcasts</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime/upcoming/tv">Upcoming Anime List</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/releases.php?format=video" rel="nofollow">Upcoming DVD &amp; Blu-ray</a></li>
+        <li><a href="https://www.animenewsnetwork.com/weekly-ranking/">Your Anime Rankings: The Best of the Season So Far According to Readers</a></li>
+        <li><h4>Anime Spotlight</h4></li>
+        <li><a href="https://www.animenewsnetwork.com/anime-spotlight/">» previous seasons</a></li>
+      </ul>
+      <ul>
+        
+
+<li><h4><a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/.234640">Spring 2026 Preview Guide</a></h4></li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/a-hundred-scenes-of-awajima/.234736">A Hundred Scenes of AWAJIMA</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/agents-of-the-four-seasons-dance-of/.234688">Agents of the Four Seasons: Dance of Spring</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/akane-banashi/.234701">Akane-banashi</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/always-a-catch/.234722">Always a Catch!</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/an-observation-log-of-my-fiancee-who-calls-herself-a-villainess/.234705">An Observation Log of My Fiancée Who Calls Herself a Villainess</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-angel-next-door-spoils-me-rotten-season-2/.234695">The Angel Next Door Spoils Me Rotten Season 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/ascendance-of-a-bookworm-part-3-adopted-daughter-of-an-archduke/.234702">Ascendance of a Bookworm Part 3: Adopted Daughter of an Archduke</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/beastars-final-season-part-2/.235897">BEASTARS Final Season Part 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-beginning-after-the-end-season-2/.234733">The Beginning After The End Season 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/botan-kamiina-fully-blossoms-when-drunk/.234714">Botan Kamiina Fully Blossoms When Drunk</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-classroom-of-a-black-cat-and-a-witch/.234735">The Classroom of a Black Cat and a Witch</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/classroom-of-the-elite-4th-season-second-year-first-semester/.234691">Classroom of the Elite 4th Season: Second Year, First Semester</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/daemons-of-the-shadow-realm/.234698">Daemons of the Shadow Realm</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/dandelion/.234749">Dandelion</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/dorohedoro-season-2/.234748">Dorohedoro Season 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/dr-stone-science-future-season-4/.234694">Dr. STONE SCIENCE FUTURE Season 4</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-drops-of-god/.234730">The Drops of God</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/eren-the-southpaw/.234707">Eren the Southpaw</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/even-a-replica-can-fall-in-love/.234708">Even a Replica Can Fall in Love</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/farming-life-in-another-world-2/.234743">Farming Life in Another World 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-food-diary-of-miss-maid/.234746">The Food Diary of Miss Maid</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/gals-cant-be-kind-to-otaku/.234712">Gals Can't Be Kind to Otaku!?</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/ghost-concert-missing-songs/.234703">Ghost Concert: missing Songs</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/go-for-it-nakamura-kun/.234689">Go For It, Nakamura-kun!!</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/haibara-teenage-new-game/.234738">Haibara's Teenage New Game+</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/hokuto-no-ken-fist-of-the-north-star/.235229">Hokuto no Ken -Fist of the North Star-</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/i-made-friends-with-the-second-prettiest-girl-in-my-class/.234728">I Made Friends with the Second Prettiest Girl in My Class</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/i-want-to-end-this-love-game/.234734">I Want to End This Love Game</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/ichijyoma-mankitsu-gurashi/.234719">Ichijyoma Mankitsu Gurashi!</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/kill-blue/.234724">Kill Blue</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/killed-again-mr-detective/.234729">Killed Again, Mr. Detective?</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/kirio-fan-club/.234692">Kirio Fan Club</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-klutzy-class-monitor-and-the-girl-with-the-short-skirt/.234744">The Klutzy Class Monitor and the Girl with the Short Skirt</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/kujima-why-sing-when-you-can-warble/.234737">Kujima: Why Sing, When You Can Warble?</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/kusunoki-garden-of-gods/.234700">Kusunoki's Garden of Gods</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/liar-game/.234740">Liar Game</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/mao/.234732">MAO</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/marriagetoxin/.234711">MARRIAGETOXIN</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/mission-yozakura-family-season-2/.234727">Mission: Yozakura Family Season 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/mistress-kanan-is-devilishly-easy/.234699">Mistress Kanan is Devilishly Easy</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-most-heretical-last-boss-queen-from-villainess-to-savior-season-2/.234710"> The Most Heretical Last Boss Queen: From Villainess to Savior Season 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/my-ribdiculous-reincarnation/.234745">My Ribdiculous Reincarnation</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/needy-girl-overdose/.234726">Needy Girl Overdose</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/one-piece-elbaph-arc/.234750">ONE PIECE Elbaph Arc</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/pardon-the-intrusion-im-home/.234709">Pardon the Intrusion, I'm Home!</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/petals-of-reincarnation/.234716">Petals of Reincarnation</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-ramparts-of-ice/.234693">The Ramparts of Ice</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/re-zero-starting-life-in-another-world-season-4/.234717">Re:ZERO -Starting Life in Another World- Season 4</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/reborn-as-a-vending-machine-i-now-wander-the-dungeon-season-3/.234739">Reborn as a Vending Machine, I Now Wander the Dungeon Season 3</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/rent-a-girlfriend-season-5/.234741">Rent-A-Girlfriend Season 5</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/rooster-fighter/.234686">Rooster Fighter</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/snowball-earth/.234697">Snowball Earth</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/nippon-sangoku-the-three-nations-of-the-crimson-sun/.234704">The Spring 2026 Anime Preview Guide:  Nippon Sangoku The Three Nations of the Crimson Sun</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-strongest-job-is-apparently-not-a-hero-or-a-sage-but-an-appraiser/.234718">The Strongest Job is Apparently Not a Hero or a Sage, But an Appraiser (Provisional)</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/that-time-i-got-reincarnated-as-a-slime-season-4/.234696">That Time I Got Reincarnated as a Slime Season 4</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/the-warrior-princess-and-the-barbaric-king/.234713">The Warrior Princess and the Barbaric King</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/welcome-to-demon-school-iruma-kun-season-4/.234747">Welcome to Demon School! Iruma-kun Season 4</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/wistoria-wand-and-sword-season-2/.234725">Wistoria: Wand and Sword Season 2</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/witch-hat-atelier/.234706">Witch Hat Atelier</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/yowayowa-sensei/.234723">Yowayowa Sensei</a>
+</li>
+
+
+
+        <li><a href="https://www.animenewsnetwork.com/preview-guide/">» previous seasons</a></li>
+      </ul>
+      <ul id="episode-review-for-aside">
+        <li>
+          <h4><a href="https://www.animenewsnetwork.com/episode-review/">Daily Streaming Reviews</a></h4>
+        </li>
+        
+
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/agents-of-the-four-seasons-dance-of-spring/.236452">Agents of the Four Seasons: Dance of Spring</a>
+  <a href="https://www.animenewsnetwork.com/review/agents-of-the-four-seasons-dance-of-spring/episodes-10-12/.238501">#10-12</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/akane-banashi/.236458">Akane-banashi</a>
+  <a href="https://www.animenewsnetwork.com/review/akane-banashi/episode-10/.238256">#10</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/always-a-catch/.236428">Always a Catch!</a>
+  <a href="https://www.animenewsnetwork.com/review/always-a-catch/episode-11/.238388">#11</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/ascendance-of-a-bookworm-part-3-adopted-daughter-of-an-archduke/.236456">Ascendance of a Bookworm Part 3: Adopted Daughter of an Archduke</a>
+  <a href="https://www.animenewsnetwork.com/review/ascendance-of-a-bookworm-part-3-adopted-daughter-of-an-archduke/episode-9/.238266">#9</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/daemons-of-the-shadow-realm/.236439">Daemons of the Shadow Realm</a>
+  <a href="https://www.animenewsnetwork.com/review/daemons-of-the-shadow-realm/episode-10/.238265">#10</a>
+</li>
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/dr-stone-science-future/.219955">Dr. STONE SCIENCE FUTURE</a>
+  <a href="https://www.animenewsnetwork.com/review/dr-stone-science-future/episode-35/.238473">#35</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/go-for-it-nakamura-kun/.236427">Go For It, Nakamura-kun!!</a>
+  <a href="https://www.animenewsnetwork.com/review/go-for-it-nakamura-kun/episode-12/.238464">#12</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/hundred-scenes-of-awajima/.236457">Hundred Scenes of AWAJIMA</a>
+  <a href="https://www.animenewsnetwork.com/review/hundred-scenes-of-awajima/episodes-8-and-9/.238249">#9</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/isekai-office-worker-the-other-world-books-depend-on-the-bean-counter/.233102">Isekai Office Worker: The Other World's Books Depend on the Bean Counter</a>
+  <a href="https://www.animenewsnetwork.com/review/isekai-office-worker-the-other-world-books-depend-on-the-bean-counter/episode-13/.238145">#13</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/mao/.236442">MAO</a>
+  <a href="https://www.animenewsnetwork.com/review/mao/episode-9/.238062">#9</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/marriagetoxin/.236426">MARRIAGETOXIN</a>
+  <a href="https://www.animenewsnetwork.com/review/marriagetoxin/episode-10/.238387">#10</a>
+</li>
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/needy-girl-overdose/.236438">Needy Girl Overdose</a>
+  <a href="https://www.animenewsnetwork.com/review/needy-girl-overdose/episode-11/.238497">#11</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/one-piece/.236459">One Piece (2026-)</a>
+  <a href="https://www.animenewsnetwork.com/review/one-piece/episode-1165/.238304">#1165</a>
+</li>
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/ramparts-of-ice/.236435">Ramparts of Ice</a>
+  <a href="https://www.animenewsnetwork.com/review/ramparts-of-ice/episode-11/.238466">#11</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/re-zero-starting-life-in-another-world-season-4/.236425">Re:ZERO -Starting Life in Another World- Season 4</a>
+  <a href="https://www.animenewsnetwork.com/review/re-zero-starting-life-in-another-world-season-4/episode-10/.238434">#10</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/rooster-fighter/.234500">Rooster Fighter</a>
+  <a href="https://www.animenewsnetwork.com/review/rooster-fighter/episode-12/.238015">#12</a>
+</li>
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/snowball-earth/.236437">Snowball Earth</a>
+  <a href="https://www.animenewsnetwork.com/review/snowball-earth/episode-11/.238472">#11</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/the-warrior-princess-and-the-barbaric-king/.236440">The Warrior Princess and the Barbaric King</a>
+  <a href="https://www.animenewsnetwork.com/review/the-warrior-princess-and-the-barbaric-king/episodes-9-10/.238421">#9-10</a>
+</li>
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/welcome-to-demon-school-iruma-kun-season-4/.236441">Welcome to Demon School, Iruma-kun Season 4</a>
+  <a href="https://www.animenewsnetwork.com/review/welcome-to-demon-school-iruma-kun-season-4/episode-11/.238475">#11</a>
+</li>
+
+<li>
+  <a href="https://www.animenewsnetwork.com/review/wistoria-wand-and-sword-season-2/.236455">Wistoria: Wand and Sword Season 2</a>
+  <a href="https://www.animenewsnetwork.com/review/wistoria-wand-and-sword-season-2/episodes-8-10/.238502">#8-10</a>
+</li>
+
+<li class="not_recent">
+  <a href="https://www.animenewsnetwork.com/review/witch-hat-atelier/.236416">Witch Hat Atelier</a>
+  <a href="https://www.animenewsnetwork.com/review/witch-hat-atelier/episode-11/.238318">#11</a>
+</li>
+
+
+
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="encyc menu">
+    <span>Encyclopedia</span>
+    <div><nav>
+      <ul>
+        <li><h4><a href="https://www.animenewsnetwork.com/encyclopedia/anime.php">Anime</a></h4></li>
+        <li>
+          
+          
+        </li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/ratings-anime.php">Top 10</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime/episodes/latest">Latest Simulcasts</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime-list.php?licensed=1&amp;sort=title&amp;showT=1&amp;showM=1&amp;showO=1&amp;showN=1&amp;showS=1" rel="nofollow">Licensed</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime-list.php?showdate=1&amp;limit_to=100&amp;sort=date&amp;invertsort=1&amp;showT=1&amp;showM=1&amp;showO=1&amp;showN=1&amp;showS=1" rel="nofollow">Latest in Japan</a></li>
+        <li>
+          <a href="https://www.animenewsnetwork.com/encyclopedia/anime/upcoming/tv">Upcoming TV series</a>,
+          <a href="https://www.animenewsnetwork.com/encyclopedia/anime/upcoming/movie">movies</a>,
+          <a href="https://www.animenewsnetwork.com/encyclopedia/anime/upcoming/oav">OAVs</a>
+        </li>
+        
+        <li><h4><a href="https://www.animenewsnetwork.com/encyclopedia/manga.php">Manga</a></h4></li>
+        <li>
+          
+          
+        </li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/ratings-manga.php">Top 10</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime-list.php?licensed=1&amp;sort=title&amp;showG=1" rel="nofollow">Licensed</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime-list.php?showdate=1&amp;limit_to=100&amp;sort=date&amp;invertsort=1&amp;showG=1" rel="nofollow">Latest in Japan</a></li>
+      </ul>
+      <ul>
+        <li><h4><a href="https://www.animenewsnetwork.com/encyclopedia/people.php">People</a></h4></li>
+        <li>
+          
+          
+        </li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/people.php?most_prolific=cast">Most prolific cast</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/people.php?most_prolific=staff">Most prolific staff</a></li>
+        
+        <li><h4><a href="https://www.animenewsnetwork.com/encyclopedia/releases.php">Releases</a></h4></li>
+        <li>
+          
+          
+        </li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/releases.php?yearmonth=2026-06" rel="nofollow">This month</a></li>
+      </ul>
+      <ul>
+        <li><h4><a href="https://www.animenewsnetwork.com/encyclopedia/company.php">Companies</a></h4></li>
+        <li>
+          
+          
+        </li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/company.php?list=licensing">Licensors</a></li>
+        
+        <li><h4><a href="https://www.animenewsnetwork.com/encyclopedia/lexicon.php">Lexicon</a></h4></li>
+        <li>
+          
+          
+        </li>
+        
+        <li><h4>Tools</h4></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/search/genre" rel="nofollow">Search by genre, theme, year</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/compare.php" rel="nofollow">Comparison tool</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/preferences.php">Personal settings</a></li>
+        <li><a href="https://www.animenewsnetwork.com/encyclopedia/">more »</a></li>
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="forum menu">
+    <span>Forum</span>
+    <div><nav>
+      <ul>
+        <li><h4><a href="https://www.animenewsnetwork.com/bbs/phpBB2/">Forum Categories</a></h4></li>
+        
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/?c=5">Site-Related</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/?c=2">General</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/?c=6">Industry</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/?c=8">For Subscribers</a></li>
+      </ul>
+      <ul>
+        <li><h4><a href="https://www.animenewsnetwork.com/bbs/phpBB2/">Forums</a></h4></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=15">Talkback</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=1">Anime</a> &gt;
+            <a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=65">Series Discussion</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=14">Manga</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=8">Encyclopedia</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=50">Feedback</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=22">Retail</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=42">Community</a></li>
+      </ul>
+      <ul>
+        <li><h4>Forum Information</h4></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/search.php" rel="nofollow">Search</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/faq.php">FAQ</a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/groupcp.php">Usergroups</a></li>
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="my menu">
+    <span>My ANN</span>
+    <div><nav>
+      <ul>
+        <li><h4>Public</h4></li>
+        <li><a href="https://www.animenewsnetwork.com/MyAnime/public.php">Public Anime Lists</a></li>
+        <li><a href="https://www.animenewsnetwork.com/survey/">Surveys</a></li>
+        <li><a href="https://www.animenewsnetwork.com/contest/">Contests</a> &amp; <a href="https://www.animenewsnetwork.com/giveaway/">Giveaways</a></li>
+        <li><a href="https://www.animenewsnetwork.com/newsletter">Newsletter</a></li>
+        <li><a href="https://www.animenewsnetwork.com/connect/">ANN:Connect</a></li>
+      </ul>
+      <ul>
+        <li><h4>Subscribers</h4></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=42">Subscriber Forum</a></li>
+          <li><a href="https://www.animenewsnetwork.com/subscription/">Subscribe »</a></li>
+      </ul>
+      <ul>
+        <li><h4><a href="https://www.animenewsnetwork.com/my/">Personal</a></h4></li>
+        <li><a href="https://www.animenewsnetwork.com/MyAnime/">My Anime</a></li>
+        <li><a href="https://www.animenewsnetwork.com/MyManga/">My Manga</a></li>
+        <li><a href="https://www.animenewsnetwork.com/skin/">Change skin</a></li>
+        <li><a href="https://www.animenewsnetwork.com/myann">My Anime 2 (beta)</a></li>
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="about menu">
+    <span>About</span>
+    <div><nav>
+      <ul>
+        <li><a href="https://www.animenewsnetwork.com/staff">Our Team</a></li>
+        <li><a href="https://www.animenewsnetwork.com/contact">Contact us</a></li>
+        <li><a href="https://www.animenewsnetwork.com/site-news/">Site news</a></li>
+        <li><a href="https://www.animenewsnetwork.com/staff-openings">Staff openings</a></li>
+      </ul>
+      <ul>
+        <li><a href="https://www.animenewsnetwork.com/privacy-policy">Privacy policy</a></li>
+        <li><a href="https://www.animenewsnetwork.com/copyright-policy">Copyright policy</a></li>
+        <li><a href="https://www.animenewsnetwork.com/policy">Other policies</a></li>
+        <li><a href="https://www.animenewsnetwork.com/advertising">Advertise with ANN</a></li>
+      </ul>
+      <ul>
+        <li><h4>Help</h4></li>
+        <li><a href="https://www.animenewsnetwork.com/faq">FAQ</a></li>
+        <li><a href="https://www.animenewsnetwork.com/news/2026-06-14/school-of-horns-mito-aoi-launches-new-manga/.238512#" data-report-button="">Report a Problem <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#bubble_exclamation"></use></svg></a></li>
+        <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=6">Bugs &amp; Technical Questions Forum</a></li>
+      </ul>
+    </nav></div>
+  </div>
+  
+  
+  
+  <div class="login menu">
+    <span>
+      <span class="icon"><svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#enter"></use></svg></span>
+      <span class="text">Login or Register</span>
+    </span>
+    <div><nav class="login_register">
+      <ul class="login">
+        <li>
+          
+          
+        </li>
+      </ul>
+      <ul>
+        <li>
+          <a class="social_login facebook" href="https://www.animenewsnetwork.com/auth/facebook/login">
+            <div class="sicon"><svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#facebook"></use></svg></div>
+            <div class="stext">Login with Facebook</div></a>
+          <a class="social_login twitter" href="https://www.animenewsnetwork.com/auth/twitter/login">
+            <div class="sicon"><svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#twitter"></use></svg></div>
+            <div class="stext">Login with Twitter</div></a>
+        </li>
+      </ul>
+      <ul>
+        <li>No account yet?
+          <a href="https://www.animenewsnetwork.com/account/register" rel="nofollow">Registering</a> is <b>free</b>, <b>easy</b>, and <b>private</b>.
+          Discuss in the forum, contribute to the Encyclopedia, build your own MyAnime lists, and more.
+          
+        </li>
+        <li>
+          
+          
+        </li>
+      </ul>
+    </nav></div>
+  </div>
+  
+  <div class="clear"></div>
+</nav>
+
+     </div>
+     
+
+
+
+
+
+
+
+
+
+
+
+     <div id="content">
+     
+      <div id="main">
+       <div>
+        <div id="notifications" class="same-width-as-main">
+         
+         
+
+         <div class="ror-css"></div>
+         
+         
+        </div>
+          <div id="content-preferences">
+            <div class="open-preferences" title="open preferences" data-user-preferences-action-open="miscellaneous">
+              <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#gear"></use></svg>
+            </div>
+          </div>
+        <div class="en-US ror-css">
+  <div id="maincontent" class="maincontent news article">
+    
+    
+    
+    
+<div id="page-title">
+<h1 id="page_header" class="same-width-as-main">
+  <div class="sub-title">News</div>
+School of Horns' Mito Aoi Launches New Manga
+
+</h1>
+<small>posted on <time datetime="2026-06-15T11:15:00-04:00"><strong>2026-06-15</strong> 11:15 EDT</time></small> by Rafael Antonio Pineda
+
+
+</div>
+
+    
+    
+    
+<div id="content-zone">
+<div class="news">
+  
+  
+        
+      
+
+<div class="text-zone easyread-width">
+<div class="KonaBody">
+
+
+
+  <div class="intro">Aoi, <cite class="e person"><a href="https://www.animenewsnetwork.com/encyclopedia/people.php?id=278385">Meza Tōno</a></cite> launch <cite>Koko ni Fukuen Flag ga Tatteimasu</cite> manga</div>
+  <hr>
+
+
+
+  
+  <instaread-player publication="animenewsnetwork" style="max-width:766px;margin:0 auto;display:block;overflow:hidden"></instaread-player>
+  <hr>
+
+
+
+  <div class="meat"><figure class="fright"><img src="https://www.animenewsnetwork.com/img/spacer.gif" width="300" height="169" alt="fukuenflag" border="1" data-src="/thumbnails/max300x600/cms/news.9/238512/fukuenflag.jpg" class="lazyload"><figcaption class="credit">Image via <a href="https://x.com/comicdays_team/status/2063093771927965895" target="_blank">Comic Days X/Twitter account</a></figcaption><figcaption class="credit copyright"><div class="text">© Mito Aoi, Kodansha</div></figcaption></figure><p>Manga creators <cite class="e person"><a href="https://www.animenewsnetwork.com/encyclopedia/people.php?id=164253">Mito Aoi</a></cite> and <cite class="e person"><a href="https://www.animenewsnetwork.com/encyclopedia/people.php?id=278385">Meza Tōno</a></cite> launched a new manga titled <cite>Koko ni Fukuen Flag ga Tatteimasu</cite> (<cite>Here is the flag of reconciliation.</cite>) in <cite class="e company"><a href="https://www.animenewsnetwork.com/encyclopedia/company.php?id=88">Kodansha</a></cite>'s <cite class="e anime"><a href="https://www.animenewsnetwork.com/encyclopedia/manga.php?id=22882">Comic Days</a></cite> app on June 6. Tōno is writing the story, and Aoi is drawing the art.</p><p>The manga centers on Marina and Haruto, who married each other at 22 but divorced soon after, largely due to a lack of sexual intimacy after marriage. A decade later, they re-encounter each other, and Haruto proposes they restart their relationship, including the sex.</p><p>Aoi serialized the <cite><cite class="e anime"><a href="https://www.animenewsnetwork.com/encyclopedia/manga.php?id=20296">School of Horns</a></cite></cite>&nbsp;(<cite><cite class="e anime">Tsuno no Gakuen</cite></cite>) manga in <cite class="e company"><a href="https://www.animenewsnetwork.com/encyclopedia/company.php?id=15420">Kadokawa</a></cite>'s <cite class="e anime"><a href="https://www.animenewsnetwork.com/encyclopedia/manga.php?id=19913">Young Ace Up</a></cite> website from August 2016 to January 2018. <cite class="e company">Kadokawa</cite> published two compiled book volumes for the manga. <cite class="e company"><a href="https://www.animenewsnetwork.com/encyclopedia/company.php?id=6612">Yen Press</a></cite>&nbsp;<a href="https://www.animenewsnetwork.com/news/2017-11-18/yen-press-adds-new-sword-art-online-worldend-little-witch-academia-fruits-basket-star-wars-titles/.124212">released</a>&nbsp;both volumes in English.</p><p><cite class="e company"><a href="https://www.animenewsnetwork.com/encyclopedia/company.php?id=15577">Kodansha USA Publishing</a></cite> also&nbsp;<a href="https://www.animenewsnetwork.com/news/2022-03-01/kodansha-comics-publishes-having-an-idol-loving-boyfriend-is-the-best-9-more-new-manga-in-march/.183133">released</a>&nbsp;all six volumes of Aoi's&nbsp;<cite><cite class="e anime">Having an Idol-Loving Boyfriend is the Best!</cite></cite> (<cite><cite class="e anime"><a href="https://www.animenewsnetwork.com/encyclopedia/manga.php?id=25879">Otatomo ga Kareshi ni Nattara, Saikō, Kamo Shirenai</a></cite></cite>) manga in English.</p><p><em>Sources:&nbsp;<a href="https://comic-days.com/episode/12207421983540381570" target="_blank" rel="noopener noreferrer">Comic Days</a>, <cite class="e person">Mito Aoi</cite>'s X/Twitter&nbsp;<a href="https://x.com/a0mit0/status/2063106350138392779" target="_blank" rel="noopener noreferrer">account</a></em></p><br><hr><em>Disclosure: Kadokawa World Entertainment (KWE), a wholly owned subsidiary of Kadokawa Corporation, is the majority owner of Anime News Network, LLC. One or more of the companies mentioned in this article are part of the Kadokawa Group of Companies.</em></div>
+  <hr>
+
+
+
+</div>
+</div>
+
+
+
+
+
+<div><a href="https://www.animenewsnetwork.com/cms/discuss/238512" rel="nofollow">discuss this in the forum</a> |
+
+<div id="social-bookmarks">
+  
+  bookmark/share with:
+  <span onclick="social_share_238512('twitter')" class="-clickable" style="color:#2ebbe9" title="Twitter">
+    <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#twitter"></use></svg>
+  </span>
+  <span onclick="social_share_238512('facebook')" class="-clickable" style="color:#486cb9" title="Facebook">
+    <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#facebook"></use></svg>
+  </span>
+  
+  
+  <a onclick="$('article-238512-shorturl').toggle();this.blur();" class="-clickable">
+    <img src="https://www.animenewsnetwork.com/img/spacer.gif" width="18" height="18" alt="short url" data-src="/images/system/bookmark-shorturl.png" class="lazyload">
+  </a>
+  <input type="text" id="article-238512-shorturl" style="margin:-4px;display:none;width:140px" value="http://4NN.cx/.238512" readonly="">
+</div>
+
+
+
+
+
+
+
+
+
+</div>
+
+<p>
+
+<a href="https://www.animenewsnetwork.com/news/">News homepage</a> / <a href="https://www.animenewsnetwork.com/news/archive" rel="archives">archives</a>
+</p>
+
+
+
+  
+</div>
+
+</div>
+
+  </div>
+</div>
+<div id="pop_survey_clone"></div>
+
+
+  
+  
+  <div id="infinite-scroll-outlet" style="height: 0;"></div>
+  
+  
+
+       </div>
+      </div>
+<div id="sidebar" class="grid-view thumb-view">
+  <div>
+    <div class="options-menu requires-javascript">
+      <div class="minimize-off icon" title="maximize sidebar" onclick="ANN.sidebar.minimize(false);">⬈</div>
+      <div class="minimize-on icon" title="minimize sidebar" onclick="ANN.sidebar.minimize(true);">⬋</div>
+      <div class="images-off icon" title="hide images" onclick="ANN.sidebar.images(false)">-</div>
+      <div class="images-on icon" title="show images" onclick="ANN.sidebar.images(true)">+</div>
+      <div class="open-preferences icon" title="open preferences" data-user-preferences-action-open="sidebar">
+        <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#gear"></use></svg>
+      </div>
+    </div>
+    
+    <div class="herald-boxes">
+      
+      
+      
+      
+      
+      
+   <div class="box iab side">
+          <div>
+            <noscript>
+              <iframe src="/show.aframe?t=R&amp;js=no" scrolling="no"></iframe>
+            </noscript>
+          </div>
+        </div>
+  <div class="herald box aside column t-answerman" data-topics="article238511 column anime">
+    <div class="category-line column t-answerman"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200g60/herald/stock/answerman/annbanner-answerman.png.jpg">
+      <div class="overlay">
+        <div class="category column t-answerman">
+          column
+        </div>
+        
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/answerman/2026-06-15/.238511" data-track="id=198620&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/answerman/2026-06-15/.238511" data-track="id=198620&amp;from=SB">Answerman - What's Actually Happening at Kadokawa?</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-15T10:00:00-04:00">Jun 15, 10:00</time>
+          
+          <span class="topics">
+            <a topic="anime" href="https://www.animenewsnetwork.com/all/?topic=anime" target="intro-by-topic">
+              anime</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">With everything from an oversaturation of isekai stories in the market to activist investors trying to decide the future of FromSoftware, a lot is happening over at one of Japan's biggest multimedia companies.</span>
+          <span class="full">―  DeliciousDungeonMaster25 asks: Dear Answerman, I keep seeing headlines saying Kadokawa is in trouble because of isekai. Now I am reading that an activist shareholder is getting involved and ...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+   
+  <div class="herald box aside column t-this-week-in-mobile-games" data-topics="article238088 column games">
+    <div class="category-line column t-this-week-in-mobile-games"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gH0/youtube/OEPjLFS8hpI.jpg">
+      <div class="overlay">
+        <div class="category column t-this-week-in-mobile-games">
+          column
+        </div>
+        
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/this-week-in-mobile-games/2026-06-15/.238088" data-track="id=198619&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/this-week-in-mobile-games/2026-06-15/.238088" data-track="id=198619&amp;from=SB">This Week in Mobile Games - Seeking Summer Smartphone Succor</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-15T09:00:00-04:00">Jun 15, 09:00</time>
+          
+          <span class="topics">
+            <a topic="games" href="https://www.animenewsnetwork.com/all/?topic=games" target="intro-by-topic">
+              games</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">This week, we take a look at the mobile game news coming out of the Summer Game Fest and other similar showcases.</span>
+          <span class="full">― Hello, and welcome once again to another installment of the column! Despite the rainy season soon approaching over here, the summer is still as hot as ever. All the more reason to hide indoors and watch the game industry make it rain new game announcements and previews, thanks to the ye...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside news t-news" data-topics="article238508 news manga">
+    <div class="category-line news t-news"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200g78/cms/news.8/219844/holic-rei-jpeg.jpg">
+      <div class="overlay">
+        <div class="category news t-news">
+          news
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238508">5 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/news/2026-06-14/clamp-xxxholic-rei-manga-teases-plan-for-final-battle/.238508" data-track="id=198618&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/news/2026-06-14/clamp-xxxholic-rei-manga-teases-plan-for-final-battle/.238508" data-track="id=198618&amp;from=SB">CLAMP's <cite>xxxHOLiC: Rei</cite> Manga Teases Plan for 'Final Battle'</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-14T20:25:03-04:00">Jun 14, 20:25</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238508">5 comments</a></div>
+          <span class="topics">
+            <a topic="manga" href="https://www.animenewsnetwork.com/all/?topic=manga" target="intro-by-topic">
+              manga</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">CLAMP launched <i>xxxHOLiC</i> sequel manga in 2013</span>
+          <span class="full">― This year's 29th issue of Kodansha's Young Magazine teased on Monday that Watanuki, the protagonist of CLAMP's <cite data-pasted="true">xxxHOLiC: Rei</cite> manga, is planning a strategy for the "final battle."<cite data-pasted="true">xxxHOLiC: Rei</cite> is the latest manga in CLAMP's <cite>xxxHOLiC</cite> series, and it launched in Kodansha's <cite>Weekly Young Magazine</cite> in 2013 after an initial delay. The series went on hiatus in Jul...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside reviews t-review" data-topics="article238282 reviews manga">
+    <div class="category-line reviews t-review"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gFA/cms/review.2/238282/red-river.jpg">
+      <div class="overlay">
+        <div class="category reviews t-review">
+          review
+        </div>
+        
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/review/red-river/omnibus-2-5/.238282" data-track="id=198463&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/review/red-river/omnibus-2-5/.238282" data-track="id=198463&amp;from=SB"><cite>Red River</cite> Omnibus 2-5 Manga Review</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-14T12:00:00-04:00">Jun 14, 12:00</time>
+          
+          <span class="topics">
+            <a topic="manga" href="https://www.animenewsnetwork.com/all/?topic=manga" target="intro-by-topic">
+              manga</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook"><i>Red River</i> is a work of epic fiction, shoujo manga style, and it's still worth reading thirty years after its original publication.</span>
+          <span class="full">― Historical fiction doesn't always owe history fidelity, but Chie Shinohara absolutely gives it more than its due in <i>Red River</i>. Although she fudges history a bit – the inspiration for Yuri was likely the wife of one of Kail's successors, a woman named Puduhepa – and chan...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside reviews t-review" data-topics="article238157 reviews manga">
+    <div class="category-line reviews t-review"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200g00/cms/review.2/238157/darasan.jpg">
+      <div class="overlay">
+        <div class="category reviews t-review">
+          review
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238157">2 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/review/dara-san-of-reiwa-volume-1-3/manga/.238157" data-track="id=198462&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/review/dara-san-of-reiwa-volume-1-3/manga/.238157" data-track="id=198462&amp;from=SB"><cite>Dara-san of Reiwa</cite> Volume 1-3 Manga Review</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-13T12:00:00-04:00">Jun 13, 12:00</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238157">2 comments</a></div>
+          <span class="topics">
+            <a topic="manga" href="https://www.animenewsnetwork.com/all/?topic=manga" target="intro-by-topic">
+              manga</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook"><cite>Dara-san of Reiwa</cite> feels like two manga stitched together, not unlike its monstrous central character.</span>
+          <span class="full">― How should readers approach <cite>Dara-san of Reiwa</cite>, a story that feels like two manga stitched together, not unlike its monstrous central character? Creator Haruomi Tomotsuka shared at the end of volume one that the story originated as a web manga and was, at least at first, an outlet for his own fetish...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside survey t-weekly-ranking" data-topics="article238465 survey anime">
+    <div class="category-line survey t-weekly-ranking"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gWU/cms/weekly-ranking/238465/spring2026-montage-w10.jpeg">
+      <div class="overlay">
+        <div class="category survey t-weekly-ranking">
+          your score
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238465">5 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/weekly-ranking/2026/spring/.238465" data-track="id=198576&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/weekly-ranking/2026/spring/.238465" data-track="id=198576&amp;from=SB">Your Anime Rankings - Best of Spring 2026, June 3-9</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-12T23:30:00-04:00">Jun 12, 23:30</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238465">5 comments</a></div>
+          <span class="topics">
+            <a topic="anime" href="https://www.animenewsnetwork.com/all/?topic=anime" target="intro-by-topic">
+              anime</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook"><cite>Akane-banashi</cite> finally has its turn in the weekly limelight, and <cite>Needy Girl Overdose</cite> catches up in the cumulative chart thanks to steady high marks since week 3. Check out our weekly user rankings!</span>
+          <span class="full">―  Let's have a look at what ANN readers consider the best (and worst) of the season,
+based on the polls you can find in our Daily Streaming Reviews
+and on the Your Score page with the latest simulcasts. Ke...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+   
+  <div class="herald box aside reviews t-review" data-topics="article238125 reviews manga">
+    <div class="category-line reviews t-review"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gK4/cms/review.2/238125/mahjong-pros-reform-with-no-wasted-draws-volume-1-cover-galley.png.jpg">
+      <div class="overlay">
+        <div class="category reviews t-review">
+          review
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238125">3 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/review/reform-with-no-wasted-draws-the-legend-of-koizumi-volume-1-manga/.238125" data-track="id=198460&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/review/reform-with-no-wasted-draws-the-legend-of-koizumi-volume-1-manga/.238125" data-track="id=198460&amp;from=SB"><cite>Reform with No Wasted Draws - The Legend of Koizumi</cite> Volume 1 Manga Review</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-12T12:00:00-04:00">Jun 12, 12:00</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238125">3 comments</a></div>
+          <span class="topics">
+            <a topic="manga" href="https://www.animenewsnetwork.com/all/?topic=manga" target="intro-by-topic">
+              manga</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">When a manga has a two-page disclaimer, you <i>know</i> you're in for a good time.</span>
+          <span class="full">― When a manga has a two-page disclaimer, you <i>know</i> you're in for a good time. And let me tell you, <i>Reform with No Wasted Draws - The Legend of Koizumi</i>'s first volume is a hell of a ride. My initial thought was, “Why bother with using real people?” but after reading this volume, I've come to understand why it was a much more e...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside column t-this-week-in-games" data-topics="article238267 column games">
+    <div class="category-line column t-this-week-in-games"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200g55/youtube/2Kzqdbuy13Y.jpg">
+      <div class="overlay">
+        <div class="category column t-this-week-in-games">
+          column
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238267">41 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/this-week-in-games/2026-06-12/summer-showcase-slamfest-save-room-for-aincrad/.238267" data-track="id=198541&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/this-week-in-games/2026-06-12/summer-showcase-slamfest-save-room-for-aincrad/.238267" data-track="id=198541&amp;from=SB">This Week in Games - Summer Showcase Slamfest - Save Room For Aincrad</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-12T10:00:00-04:00">Jun 12, 10:00</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238267">41 comments</a></div>
+          <span class="topics">
+            <a topic="games" href="https://www.animenewsnetwork.com/all/?topic=games" target="intro-by-topic">
+              games</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">It's a smorgasbord of new announcements from a variety of showcases! Jean-Karlo's got the details from the Japanese side of gaming.</span>
+          <span class="full">― Welcome back, folks! I took up the challenge of playing <cite>Kirby: Return to Dream Land Deluxe</cite> over the weekend. It is as charming as you'd expect. Also deeper than I expected. I'm used to the Copy abilities in a <cite>Kirby</cite> game having varied move lists; they've done that since...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside views t-interview" data-topics="article238390 views anime">
+    <div class="category-line views t-interview"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gI6/cms/interview/238390/main.png.jpg">
+      <div class="overlay">
+        <div class="category views t-interview">
+          interview
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238390">1 comment</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/interview/2026-06-12/creating-visual-spectacle-in-nippon-sangoku-with-director-kazuaki-terasawa/.238390" data-track="id=198546&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/interview/2026-06-12/creating-visual-spectacle-in-nippon-sangoku-with-director-kazuaki-terasawa/.238390" data-track="id=198546&amp;from=SB">Creating Visual Spectacle in <cite>Nippon Sangoku</cite> with Director Kazuaki Terasawa</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-12T09:00:00-04:00">Jun 12, 09:00</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238390">1 comment</a></div>
+          <span class="topics">
+            <a topic="anime" href="https://www.animenewsnetwork.com/all/?topic=anime" target="intro-by-topic">
+              anime</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">It's easy to miss a true seasonal anime highlight, but you'll regret leaving the beautiful <cite>Nippon Sangoku</cite> on your "watch later" list.</span>
+          <span class="full">― With more anime than ever to choose from and high-profile series split among several streaming services, it's easy to miss a true seasonal highlight. <cite>Nippon Sangoku The Three Nations of the Crimson Sun</cite> first caught my attention while preparing for the Spring 2026 Ani...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside news t-news" data-topics="article238438 news anime">
+    <div class="category-line news t-news"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gHD/youtube/-RxE_7uSDVg.jpg">
+      <div class="overlay">
+        <div class="category news t-news">
+          news
+        </div>
+        
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/news/2026-06-11/akiwashi-living-in-a-world-without-magic-music-video-has-animated-film-project-in-the-works/.238438" data-track="id=198557&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/news/2026-06-11/akiwashi-living-in-a-world-without-magic-music-video-has-animated-film-project-in-the-works/.238438" data-track="id=198557&amp;from=SB">Akiwashi's 'Living in a World Without Magic' Music Video Has Animated Film Project in the Works</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-11T23:35:18-04:00">Jun 11, 23:35</time>
+          
+          <span class="topics">
+            <a topic="anime" href="https://www.animenewsnetwork.com/all/?topic=anime" target="intro-by-topic">
+              anime</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">Kasagi Labo has overseas plans for film of indie music video</span>
+          <span class="full">― Illustrator Akiwashi and Euluca Lab's self-produced music video "Living in a World Without Magic" ("Mahō no Nai Sekai de Ikiru to Iu Koto" or Mahoseka for short) has an animated feature-length film project in the works. The original music video is below: Akiwashi served as the director, scriptwriter, character designer, animator, backgrou...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside news t-news" data-topics="article238436 news manga">
+    <div class="category-line news t-news"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200g9I/herald/198552/xfs2giwq-400x400b.png.jpg">
+      <div class="overlay">
+        <div class="category news t-news">
+          news
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238436">9 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/news/2026-06-11/monster-naoki-urasawa-to-launch-new-manga-series-on-august-12/.238436" data-track="id=198559&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/news/2026-06-11/monster-naoki-urasawa-to-launch-new-manga-series-on-august-12/.238436" data-track="id=198559&amp;from=SB"><i>Monster's</i> Naoki Urasawa to Launch New Manga Series on August 12</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-11T22:28:01-04:00">Jun 11, 22:28</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/238436">9 comments</a></div>
+          <span class="topics">
+            <a topic="manga" href="https://www.animenewsnetwork.com/all/?topic=manga" target="intro-by-topic">
+              manga</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">Creator of <cite>Yawara, Master Keaton, 20th Century Boys, Pluto, Billy Bat</cite> starts <i>Saigo no Manga Kyōshitsu</i></span>
+          <span class="full">― The July issue of Shogakukan's <i>Big Comic Original Special (Big Comic Original Zōkan)</i> magazine announced on Friday that Naoki Urasawa will launch the new manga series <i>Saigo no Manga Kyōshitsu</i> (The Final Manga Classroom) in the September issue on August 12. The announcement teased, "What's Urasawa tr...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="herald box aside reviews t-review" data-topics="article237900 reviews anime">
+    <div class="category-line reviews t-review"></div>
+    <div class="thumbnail lazyload" data-src="/thumbnails/crop348x200gUG/cms/review.2/237900/dandelion-tv.jpg">
+      <div class="overlay">
+        <div class="category reviews t-review">
+          review
+        </div>
+        <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/237900">3 comments</a></div>
+      </div>
+      
+      <a href="https://www.animenewsnetwork.com/review/dandelion-anime-series/.237900" data-track="id=198182&amp;from=SB"></a>
+    </div>
+    <div class="wrap">
+      <div>
+        <h3>
+          <a href="https://www.animenewsnetwork.com/review/dandelion-anime-series/.237900" data-track="id=198182&amp;from=SB"><cite>Dandelion</cite> Anime Series Review</a>
+        </h3>
+        <div class="byline">
+          <time datetime="2026-06-11T12:00:00-04:00">Jun 11, 12:00</time>
+          <div class="comments"><a href="https://www.animenewsnetwork.com/cms/discuss/237900">3 comments</a></div>
+          <span class="topics">
+            <a topic="anime" href="https://www.animenewsnetwork.com/all/?topic=anime" target="intro-by-topic">
+              anime</a>
+          </span>
+        </div>
+        <div class="snippet">
+          <span class="hook">Traces of <i>Gintama</i>'s heart and hilarity are definitely here, but each episode goes on five minutes too long in service of a tacked-on climax.</span>
+          <span class="full">― <i>Gintama</i> is one of the most celebrated comedy manga of all time. Hideaki Sorachi smashing aliens into the tail-end of the Sengoku era was every bit as bold as when Akira Toriyama dropped dinosaurs and mechs (and eventually aliens) into <i>Journey to the West</i>. What...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+   
+
+      
+      
+    </div>
+  </div>
+</div>
+      
+     </div>
+     <div id="footer">
+       All material <a href="https://www.animenewsnetwork.com/copyright-policy">Copyright</a> © Anime News Network LLC. All rights reserved.<br>
+       <small>served by epsilon-chan</small>
+       <div id="Adbanner"></div>
+     </div>
+    </div>
+    <div class="bottom gutter">
+     <a href="https://www.animenewsnetwork.com/sponsor/click.php/19269/8055/1781536993/612999/2" target="_blank" untracked-href="https://jjkpp.onelink.me/C5Wu/gat5o8dk" rel="sponsored nofollow"></a>
+    </div>
+   </div>
+   <div class="right side gutter">
+    <span class="top-area"></span>
+    <a href="https://www.animenewsnetwork.com/sponsor/click.php/19269/8055/1781536993/612999/1" target="_blank" untracked-href="https://jjkpp.onelink.me/C5Wu/gat5o8dk" rel="sponsored nofollow"></a>
+   </div>
+  </div>
+  
+  <button class="report_button" type="button" data-report-button="">
+    <svg role="img" class="icon"><use xlink:href="https://www.animenewsnetwork.com/stylesheets/icons/all.svg?1747874973#bubble_exclamation"></use></svg>
+    <span>Report a Problem</span>
+  </button>
+<div id="mobile-menu-overlay"></div>
+<div id="mobile-menu">
+  <button class="close" type="button">×</button>
+  
+  <ul class="sections">
+  
+    <li class="news front">
+      <a href="https://www.animenewsnetwork.com/news/">News</a>
+      <div class="subsections-wrapper">
+        <ul class="subsections">
+          <li><a href="https://www.animenewsnetwork.com/convention/">Convention reports</a></li>
+          <li><a href="https://www.animenewsnetwork.com/newsfeed/">Newsfeed</a></li>
+          <li><a href="https://www.animenewsnetwork.com/interest/">Interest</a></li>
+          <li><a href="https://www.animenewsnetwork.com/press-release/">Press Releases</a></li>
+        </ul>
+      </div>
+    </li>
+    
+    <li class="views">
+      <a href="https://www.animenewsnetwork.com/views/">Views</a>
+      <div class="subsections-wrapper">
+        <ul class="subsections">
+          <li><a href="https://www.animenewsnetwork.com/feature/">Features</a></li>
+          <li><a href="https://www.animenewsnetwork.com/review/">Reviews</a></li>
+          <li><a href="https://www.animenewsnetwork.com/column/">Columns</a></li>
+        </ul>
+      </div>
+    </li>
+    
+    <li class="newanime">
+      <div class="heading">New Anime</div>
+      <div class="subsections-wrapper">
+        <ul class="subsections">
+            <li><a href="https://www.animenewsnetwork.com/season/2026/summer/">Summer 2026 next season</a></li>
+          <li><a href="https://www.animenewsnetwork.com/season/2026/spring/">Spring 2026 current season</a></li>
+          <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime/episodes/latest"><b>Your Score</b> for Recent Simulcasts</a></li>
+          <li><a href="https://www.animenewsnetwork.com/encyclopedia/anime/upcoming/tv">Upcoming Anime List</a></li>
+          <li><a href="https://www.animenewsnetwork.com/encyclopedia/releases.php?format=video" rel="nofollow">Upcoming DVD &amp; Blu-ray</a></li>
+          <li><a href="https://www.animenewsnetwork.com/weekly-ranking/">Weekly Rankings</a></li>
+          
+          
+  
+    <li><a href="https://www.animenewsnetwork.com/preview-guide/2026/spring/.234640">Spring 2026 Preview Guide</a></li>
+  
+
+          <li><a href="https://www.animenewsnetwork.com/episode-review/">Daily Streaming Reviews</a></li>
+        </ul>
+      </div>
+    </li>
+    
+    <li class="encyc">
+      <a href="https://www.animenewsnetwork.com/encyclopedia/">Encyclopedia</a>
+    </li>
+    
+    <li class="forum">
+      <a href="https://www.animenewsnetwork.com/bbs/phpBB2/">Forum</a>
+    </li>
+    
+    <li class="interactive">
+      <a href="https://www.animenewsnetwork.com/my/">My ANN</a>
+      <div class="subsections-wrapper">
+        <ul class="subsections">
+            <li><a href="https://www.animenewsnetwork.com/subscription/">Subscribe »</a></li>
+          <li><a href="https://www.animenewsnetwork.com/MyAnime/">My Anime</a></li>
+          <li><a href="https://www.animenewsnetwork.com/MyManga/">My Manga</a></li>
+          <li><a href="https://www.animenewsnetwork.com/newsletter">Newsletter</a></li>
+          <li><a href="https://www.animenewsnetwork.com/connect/">ANN:Connect</a></li>
+        </ul>
+      </div>
+    </li>
+    
+    <li class="about">
+      <div class="heading">About</div>
+      <div class="subsections-wrapper">
+        <ul class="subsections">
+          <li><a href="https://www.animenewsnetwork.com/staff">Our Team</a></li>
+          <li><a href="https://www.animenewsnetwork.com/contact">Contact us</a></li>
+          <li><a href="https://www.animenewsnetwork.com/staff-openings">Staff openings</a></li>
+          <li><a href="https://www.animenewsnetwork.com/privacy-policy">Privacy policy</a></li>
+          <li><a href="https://www.animenewsnetwork.com/copyright-policy">Copyright policy</a></li>
+          <li><a href="https://www.animenewsnetwork.com/advertising">Advertise with ANN</a></li>
+          <li><a href="https://www.animenewsnetwork.com/faq">FAQ</a></li>
+          <li><a href="https://www.animenewsnetwork.com/news/2026-06-14/school-of-horns-mito-aoi-launches-new-manga/.238512#" data-report-button="">Report a Problem</a></li>
+          <li><a href="https://www.animenewsnetwork.com/bbs/phpBB2/viewforum.php?f=6">Bugs &amp; Technical Questions Forum</a></li>
+        </ul>
+      </div>
+    </li>
+    
+  </ul>
+</div>
+  
+
+
+
+
+
+  <span id="DOM_end"></span>
+
+
+
+
+
+
+  
+  
+
+  
+  
+
+
+  
+  
+  
+
+
+  
+  
+ 
+
+
+</body></html>

--- a/src/extractors/custom/index.js
+++ b/src/extractors/custom/index.js
@@ -203,3 +203,4 @@ export * from './www.motorsport.com';
 export * from './www.nexojornal.com.br';
 export * from './substack.com';
 export * from './www.dw.com';
+export * from './www.animenewsnetwork.com';

--- a/src/extractors/custom/www.animenewsnetwork.com/index.js
+++ b/src/extractors/custom/www.animenewsnetwork.com/index.js
@@ -1,0 +1,43 @@
+export const WwwAnimenewsnetworkComExtractor = {
+  domain: 'www.animenewsnetwork.com',
+
+  title: {
+    selectors: [['meta[name="og:title"]', 'value']],
+  },
+
+  author: null,
+
+  date_published: {
+    selectors: [['small time', 'datetime']],
+  },
+
+  dek: {
+    selectors: [['meta[name="description"]', 'value']],
+  },
+
+  lead_image_url: {
+    selectors: [['meta[name="og:image"]', 'value']],
+  },
+
+  content: {
+    selectors: ['.KonaBody'],
+
+    transforms: {
+      // Images are lazy-loaded: real URL in data-src, a spacer.gif in src.
+      // Promote data-src so the images survive cleaning and render.
+      img: node => {
+        const dataSrc = node.attr('data-src');
+        if (dataSrc) {
+          const src = dataSrc.startsWith('/')
+            ? `https://www.animenewsnetwork.com${dataSrc}`
+            : dataSrc;
+          node.attr('src', src);
+          node.removeAttr('data-src');
+        }
+      },
+    },
+
+    // .intro duplicates the dek; instaread-player is an audio widget.
+    clean: ['.intro', 'instaread-player'],
+  },
+};

--- a/src/extractors/custom/www.animenewsnetwork.com/index.test.js
+++ b/src/extractors/custom/www.animenewsnetwork.com/index.test.js
@@ -1,0 +1,92 @@
+import assert from 'assert';
+import * as cheerio from 'cheerio';
+
+import Parser from 'mercury';
+import getExtractor from 'extractors/get-extractor';
+import { excerptContent } from 'utils/text';
+
+const fs = require('fs');
+
+describe('WwwAnimenewsnetworkComExtractor', () => {
+  describe('initial test case', () => {
+    let result;
+    let url;
+    beforeAll(() => {
+      url =
+        'https://www.animenewsnetwork.com/news/2026-06-14/school-of-horns-mito-aoi-launches-new-manga/.238512';
+      const html = fs.readFileSync(
+        './fixtures/www.animenewsnetwork.com/1781536993736.html'
+      );
+      result = Parser.parse(url, { html, fallback: false });
+    });
+
+    it('is selected properly', () => {
+      const extractor = getExtractor(url);
+      assert.strictEqual(extractor.domain, new URL(url).hostname);
+    });
+
+    it('returns the title', async () => {
+      const { title } = await result;
+
+      assert.strictEqual(title, `School of Horns' Mito Aoi Launches New Manga`);
+    });
+
+    it('returns the date_published', async () => {
+      const { date_published } = await result;
+
+      assert.strictEqual(date_published, `2026-06-15T15:15:00.000Z`);
+    });
+
+    it('returns the dek', async () => {
+      const { dek } = await result;
+
+      assert.strictEqual(
+        dek,
+        'Aoi, Meza Tōno launch Koko ni Fukuen Flag ga Tatteimasu manga'
+      );
+    });
+
+    it('returns the lead_image_url', async () => {
+      const { lead_image_url } = await result;
+
+      assert.strictEqual(
+        lead_image_url,
+        `https://www.animenewsnetwork.com/thumbnails/crop600x315gIB/cms/news.9/238512/fukuenflag.jpg`
+      );
+    });
+
+    it('returns the content', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      const first13 = excerptContent($('*').first().text(), 13);
+
+      assert.strictEqual(
+        first13,
+        'Image via Comic Days X/Twitter accountManga creators Mito Aoi and Meza Tōno launched'
+      );
+    });
+
+    it('resolves lazy-loaded images to real URLs', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+      const images = $('img').toArray();
+
+      assert.ok(images.length > 0, 'expected inline images in the content');
+      assert.ok(
+        !(content || '').includes('spacer.gif'),
+        'expected no spacer.gif placeholders to remain'
+      );
+
+      images.forEach(img => {
+        const src = $(img).attr('src') || '';
+        assert.ok(
+          /^https?:\/\//.test(src),
+          `expected an absolute image URL, got: ${src}`
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds a custom parser for Anime News Network, requested in jocmp/capyreader#2129 ("images went missing in full content").

**Image bug:** ANN lazy-loads images — `src` is a `spacer.gif` placeholder with the real URL in `data-src` + `class="lazyload"`. Mercury stripped the spacers, leaving no images. Added an `img` transform that promotes `data-src` to an absolute `src` before cleaning.

- Title/dek/lead image from meta tags
- Date from `small time[datetime]` (carries an explicit offset → TZ-stable)
- Content from `.KonaBody`, cleaning the `.intro` (dek dup) and `instaread-player` audio widget

7/7 parser tests pass, including an assertion that no `spacer.gif` placeholders remain.