### PR TITLE
feat: Add www.rosa.gr custom parser

### DIFF
--- a/fixtures/www.rosa.gr/1781600000000.html
+++ b/fixtures/www.rosa.gr/1781600000000.html
@@ -1,0 +1,1407 @@
+<!DOCTYPE html>
+<html lang="el" style="--vh: 9.870000000000001px; --fh: 689px; --hh: 60px; --lh: 80px; --flh: NaNpx;"><head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+
+	<meta name="robots" content="max-image-preview:large">
+
+	 
+
+	
+	
+        
+        
+	<!-- OCM -->
+	
+
+	
+	<!-- Google Tag Manager -->
+	
+	<!-- End Google Tag Manager -->
+
+	<!-- 
+	 -->
+
+			
+		<iframe src="javascript:false" style="display: none;"></iframe>
+
+	
+	<!-- Cursor tracker -->
+	
+
+	<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+
+	<!-- This site is optimized with the Yoast SEO Premium plugin v27.8 (Yoast SEO v27.8) - https://yoast.com/product/yoast-seo-premium-wordpress/ -->
+	<title>Η επόμενη μέρα στον Λίβανο: Το κύμα επιστροφής των εκτοπισμένων και η βαριά σκιά της καταστροφής - Rosa.gr</title>
+	<meta name="description" content="Η αρχική συμφωνία κατάπαυσης του πυρός ανάμεσα σε ΗΠΑ και Ιράν ανοίγει τον δρόμο της επιστροφής για χιλιάδες κατοίκους του Νότου">
+	<link rel="canonical" href="https://www.rosa.gr/kosmos/i-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis/">
+	<meta property="og:locale" content="el_GR">
+	<meta property="og:type" content="article">
+	<meta property="og:title" content="Η επόμενη μέρα στον Λίβανο: Το κύμα επιστροφής των εκτοπισμένων και η βαριά σκιά της καταστροφής">
+	<meta property="og:description" content="Η αρχική συμφωνία κατάπαυσης του πυρός ανάμεσα σε ΗΠΑ και Ιράν ανοίγει τον δρόμο της επιστροφής για χιλιάδες κατοίκους του Νότου">
+	<meta property="og:url" content="https://www.rosa.gr/kosmos/i-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis/">
+	<meta property="og:site_name" content="Σκέψου προοδευτικά | Κοινότητα ενημέρωσης ROSA.GR">
+	<meta property="article:publisher" content="https://www.facebook.com/RosaProgressive/">
+	<meta property="article:published_time" content="2026-06-16T20:17:00+00:00">
+	<meta property="og:image" content="https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail.jpg">
+	<meta property="og:image:width" content="1274">
+	<meta property="og:image:height" content="623">
+	<meta property="og:image:type" content="image/jpeg">
+	<meta name="author" content="Χρήστος Τζίφας">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:creator" content="@rosa_progress">
+	<meta name="twitter:site" content="@rosa_progress">
+	<meta name="twitter:label1" content="Συντάχθηκε από">
+	<meta name="twitter:data1" content="Χρήστος Τζίφας">
+	<meta name="twitter:label2" content="Εκτιμώμενος χρόνος ανάγνωσης">
+	<meta name="twitter:data2" content="2 λεπτά">
+	
+	<!-- / Yoast SEO Premium plugin. -->
+
+
+<link rel="dns-prefetch" href="//www.rosa.gr">
+<link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
+<link rel="alternate" type="application/rss+xml" title="Ροή RSS » Σκέψου προοδευτικά | Κοινότητα ενημέρωσης ROSA.GR" href="https://www.rosa.gr/feed/">
+<meta property="og:image:alt" content="Μπαράζ βομβαρδισμών και επιθέσεων πραγματοποιεί από το πρωί το Ισραήλ στον Λίβανο">
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.rosa.gr/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.rosa.gr%2Fkosmos%2Fi-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis%2F">
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.rosa.gr/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.rosa.gr%2Fkosmos%2Fi-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis%2F&amp;format=xml">
+<link rel="alternate" type="application/rss+xml" title="Σκέψου προοδευτικά | Κοινότητα ενημέρωσης ROSA.GR » Stories Feed" href="https://www.rosa.gr/rosa-stories/feed/"><style id="wp-img-auto-sizes-contain-inline-css">
+img:is([sizes=auto i],[sizes^="auto," i]){contain-intrinsic-size:3000px 1500px}
+/*# sourceURL=wp-img-auto-sizes-contain-inline-css */
+</style>
+<link rel="stylesheet" id="nnrobots_author_stats_selectize_css-css" href="https://www.rosa.gr/wp-content/plugins/99robots-author-stats/admin/css/selectize.css?ver=2.2.7" media="all">
+<link rel="stylesheet" id="nnrobots_author_stats_font_awesome-css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css?ver=4.7.0" media="all">
+<link rel="stylesheet" id="robots-author-stats-frontend-css" href="https://www.rosa.gr/wp-content/plugins/99robots-author-stats/core/css/author-stats-pro.css?ver=2.2.7" media="all">
+<link rel="stylesheet" id="nnrobots_author_stats_fontawesome_css-css" href="https://www.rosa.gr/wp-content/plugins/99robots-author-stats/admin/include/fontawesome/css/font-awesome.min.css?ver=2.2.7" media="all">
+<style id="classic-theme-styles-inline-css">
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+/*# sourceURL=/wp-includes/css/classic-themes.min.css */
+</style>
+<style id="global-styles-inline-css">
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgb(252,185,0) 0%,rgb(255,105,0) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgb(255,105,0) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0);--wp--preset--shadow--crisp: 6px 6px 0px rgb(0, 0, 0);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+/*# sourceURL=global-styles-inline-css */
+</style>
+
+<link rel="stylesheet" id="contact-form-7-css" href="https://www.rosa.gr/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=6.1.6" media="all">
+<link rel="stylesheet" id="wpcf7-redirect-script-frontend-css" href="https://www.rosa.gr/wp-content/plugins/wpcf7-redirect/build/assets/frontend-script.css?ver=2c532d7e2be36f6af233" media="all">
+<link rel="stylesheet" id="slick-css-css" href="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/css/slick.css?ver=1.2.64" media="all">
+<link rel="stylesheet" id="slick-theme-css-css" href="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/css/slick-theme.css?ver=1.2.64" media="all">
+<link rel="stylesheet" id="lightbox2-css-css" href="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/css/lightbox.min.css?ver=1.2.64" media="all">
+<link rel="stylesheet" id="rosa-style-css" href="https://www.rosa.gr/wp-content/themes/rosa-theme/style.css?ver=1.2.64" media="all">
+<link rel="stylesheet" id="rosa-google-preferred-source-css" href="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/css/google-preferred-source.css?ver=1.2.64" media="all">
+<link rel="stylesheet" id="template-style-article-normal-css" href="https://www.rosa.gr/wp-content/themes/rosa-theme/html/assets/scss/pages/article-normal.css?ver=1.2.64" media="all">
+<link rel="stylesheet" id="owl-carousel-css" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css?ver=2.3.4" media="all">
+<link rel="stylesheet" id="owl-carousel-theme-css" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css?ver=2.3.4" media="all">
+<link rel="stylesheet" id="tributes-style-css" href="https://www.rosa.gr/wp-content/plugins/tributes/assets/css/tributes.css?ver=6.9.4" media="all">
+
+
+
+
+
+<link rel="https://api.w.org/" href="https://www.rosa.gr/wp-json/"><link rel="alternate" title="JSON" type="application/json" href="https://www.rosa.gr/wp-json/wp/v2/posts/313401"><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.rosa.gr/xmlrpc.php?rsd">
+<meta name="generator" content="WordPress 6.9.4">
+<link rel="shortlink" href="https://www.rosa.gr/?p=313401">
+<meta name="onesignal-plugin" content="wordpress-3.9.0">
+  
+  
+<meta name="generator" content="performance-lab 4.1.0; plugins: image-prioritizer, webp-uploads">
+<!-- Weather data --><!-- End Weather data --><!-- Next scheduled cron run: 2026-06-16 20:18:26 --><!-- Expected next run time based on admin setting: 2026-06-16 20:18:26 --><!-- Current time: 2026-06-16 20:17:24 --><meta name="generator" content="webp-uploads 2.6.1">
+<meta data-od-replaced-content="optimization-detective 1.0.0-beta5" name="generator" content="optimization-detective 1.0.0-beta5; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
+<meta name="generator" content="image-prioritizer 1.0.0-beta3">
+<link rel="icon" href="https://www.rosa.gr/wp-content/uploads/2024/09/fav-icon-150x150.png" sizes="32x32">
+<link rel="icon" href="https://www.rosa.gr/wp-content/uploads/2024/09/fav-icon-300x300.png" sizes="192x192">
+<link rel="apple-touch-icon" href="https://www.rosa.gr/wp-content/uploads/2024/09/fav-icon-300x300.png">
+<meta name="msapplication-TileImage" content="https://www.rosa.gr/wp-content/uploads/2024/09/fav-icon-300x300.png">
+		<style id="wp-custom-css">
+			button.totalpoll-button.totalpoll-buttons-results {
+    display: none;
+}		</style>
+		<style id="wp-block-heading-inline-css">
+h1:where(.wp-block-heading).has-background,h2:where(.wp-block-heading).has-background,h3:where(.wp-block-heading).has-background,h4:where(.wp-block-heading).has-background,h5:where(.wp-block-heading).has-background,h6:where(.wp-block-heading).has-background{padding:1.25em 2.375em}h1.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h1.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h2.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h2.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h3.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h3.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h4.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h4.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h5.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h5.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h6.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h6.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]){rotate:180deg}
+/*# sourceURL=https://www.rosa.gr/wp-includes/blocks/heading/style.min.css */
+</style>
+<style id="wp-block-paragraph-inline-css">
+.is-small-text{font-size:.875em}.is-regular-text{font-size:1em}.is-large-text{font-size:2.25em}.is-larger-text{font-size:3em}.has-drop-cap:not(:focus):first-letter{float:left;font-size:8.4em;font-style:normal;font-weight:100;line-height:.68;margin:.05em .1em 0 0;text-transform:uppercase}body.rtl .has-drop-cap:not(:focus):first-letter{float:none;margin-left:.1em}p.has-drop-cap.has-background{overflow:hidden}:root :where(p.has-background){padding:1.25em 2.375em}:where(p.has-text-color:not(.has-link-color)) a{color:inherit}p.has-text-align-left[style*="writing-mode:vertical-lr"],p.has-text-align-right[style*="writing-mode:vertical-rl"]{rotate:180deg}
+/*# sourceURL=https://www.rosa.gr/wp-includes/blocks/paragraph/style.min.css */
+</style>
+
+<meta http-equiv="origin-trial" content="AlK2UR5SkAlj8jjdEc9p3F3xuFYlF6LYjAML3EOqw1g26eCwWPjdmecULvBH5MVPoqKYrOfPhYVL71xAXI1IBQoAAAB8eyJvcmlnaW4iOiJodHRwczovL2RvdWJsZWNsaWNrLm5ldDo0NDMiLCJmZWF0dXJlIjoiV2ViVmlld1hSZXF1ZXN0ZWRXaXRoRGVwcmVjYXRpb24iLCJleHBpcnkiOjE3NTgwNjcxOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="><meta http-equiv="origin-trial" content="Amm8/NmvvQfhwCib6I7ZsmUxiSCfOxWxHayJwyU1r3gRIItzr7bNQid6O8ZYaE1GSQTa69WwhPC9flq/oYkRBwsAAACCeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXN5bmRpY2F0aW9uLmNvbTo0NDMiLCJmZWF0dXJlIjoiV2ViVmlld1hSZXF1ZXN0ZWRXaXRoRGVwcmVjYXRpb24iLCJleHBpcnkiOjE3NTgwNjcxOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="><meta http-equiv="origin-trial" content="A9nrunKdU5m96PSN1XsSGr3qOP0lvPFUB2AiAylCDlN5DTl17uDFkpQuHj1AFtgWLxpLaiBZuhrtb2WOu7ofHwEAAACKeyJvcmlnaW4iOiJodHRwczovL2RvdWJsZWNsaWNrLm5ldDo0NDMiLCJmZWF0dXJlIjoiQUlQcm9tcHRBUElNdWx0aW1vZGFsSW5wdXQiLCJleHBpcnkiOjE3NzQzMTA0MDAsImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><meta http-equiv="origin-trial" content="A93bovR+QVXNx2/38qDbmeYYf1wdte9EO37K9eMq3r+541qo0byhYU899BhPB7Cv9QqD7wIbR1B6OAc9kEfYCA4AAACQeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXN5bmRpY2F0aW9uLmNvbTo0NDMiLCJmZWF0dXJlIjoiQUlQcm9tcHRBUElNdWx0aW1vZGFsSW5wdXQiLCJleHBpcnkiOjE3NzQzMTA0MDAsImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><meta http-equiv="origin-trial" content="A1S5fojrAunSDrFbD8OfGmFHdRFZymSM/1ss3G+NEttCLfHkXvlcF6LGLH8Mo5PakLO1sCASXU1/gQf6XGuTBgwAAACQeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXRhZ3NlcnZpY2VzLmNvbTo0NDMiLCJmZWF0dXJlIjoiQUlQcm9tcHRBUElNdWx0aW1vZGFsSW5wdXQiLCJleHBpcnkiOjE3NzQzMTA0MDAsImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><link href="https://securepubads.g.doubleclick.net/pagead/managed/dict/m202606160101/gpt" rel="compression-dictionary"><link rel="stylesheet" type="text/css" id="ttEmbedLibCSS" href="https://lf16-tiktok-web.tiktokcdn-us.com/obj/tiktok-web-tx/tiktok/falcon/embed/embed_lib_v1.0.13.css"><style>div[data-id="ocm-st"] { margin: 0 !important; } .ad-placement .ad-wraper .ob-widget-header { text-align: left !important; }</style><style>
+          .OUTBRAIN { 
+            width: 100% !important;
+            max-width: 100% !important;
+          }
+
+          @media (min-width: 1920px) {
+            .OUTBRAIN {
+              width: 1920px !important;
+              max-width: 1920px !important;
+            }
+          }
+          </style><link rel="stylesheet" href="https://onesignal.com/sdks/web/v16/OneSignalSDK.page.styles.css?v=160607"></head>
+
+<body class="wp-singular post-template-default single single-post postid-313401 single-format-standard wp-custom-logo wp-theme-rosa-theme article-normal">
+
+	<!-- Google Tag Manager (noscript) -->
+	<div id="prestitial_415qq" style="" data-oau-code="/22767323261/rosa.gr/prestitial" data-lazyloaded-by-ocm="" data-google-query-id="CPHL2L7rjJUDFVWFpgQdPoY3rQ"><div id="google_ads_iframe_/22767323261/rosa.gr/prestitial_0__container__" style="border: 0pt; margin: auto; text-align: center;"></div></div>
+	<!-- End Google Tag Manager (noscript) -->
+
+	
+	
+	<header class="slide-back header-scrolled slide">
+		<div class="horizontal-header">
+			<div class="horizontal-header-container">
+				<div class="logo horizontal">
+					<a href="https://www.rosa.gr/" rel="home" class="logo"><img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/HEADER/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="142" height="162" src="https://www.rosa.gr/wp-content/uploads/2024/09/logo-vertical.png" class="vertical" alt="" decoding="async"><img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/HEADER/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::A]/*[2][self::IMG]" src="https://www.rosa.gr/wp-content/uploads/2024/08/logo-horizontal.svg" class="horizontal hidden" alt="" decoding="async"></a>				</div>
+
+				<div class="weather">
+					<select style="display: none;"><option data-html="&lt;img src='//cdn.weatherapi.com/weather/64x64/night/113.png'&gt; Athens,&nbsp;&lt;span class='degrees'&gt;22  °C&lt;/span&gt;">Athens</option><option data-html="&lt;img src='//cdn.weatherapi.com/weather/64x64/night/176.png'&gt; Thessaloniki,&nbsp;&lt;span class='degrees'&gt;22  °C&lt;/span&gt;">Thessaloniki</option><option data-html="&lt;img src='//cdn.weatherapi.com/weather/64x64/night/113.png'&gt; Patra,&nbsp;&lt;span class='degrees'&gt;23  °C&lt;/span&gt;">Patra</option></select><div class="custom-select" style="width: 202px;"><div class="custom-select__selected" style="width: 202px;"><div><img src="//cdn.weatherapi.com/weather/64x64/night/113.png"> Athens,&nbsp;<span class="degrees">22  °C</span></div></div><ul class="custom-select__options" style="width: 202px;"><li class="selected"><div><img src="//cdn.weatherapi.com/weather/64x64/night/113.png"> Athens,&nbsp;<span class="degrees">22  °C</span></div></li><li><div><img src="//cdn.weatherapi.com/weather/64x64/night/176.png"> Thessaloniki,&nbsp;<span class="degrees">22  °C</span></div></li><li><div><img src="//cdn.weatherapi.com/weather/64x64/night/113.png"> Patra,&nbsp;<span class="degrees">23  °C</span></div></li></ul></div>
+				</div>
+				<nav>
+					<div class="horizontal-menu-container">
+						<ul class="horizontal-menu"><li id="menu-item-238188" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-331 current_page_item current_page_parent menu-item-238188"><a href="https://www.rosa.gr/latest/" aria-current="page">Latest</a></li>
+<li id="menu-item-115279" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-115279"><a href="https://www.rosa.gr/politiki/">ΠΟΛΙΤΙΚΗ</a></li>
+<li id="menu-item-97695" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-97695"><a href="https://www.rosa.gr/koinonia/">ΚΟΙΝΩΝΙΑ</a></li>
+<li id="menu-item-115277" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-115277"><a href="https://www.rosa.gr/kosmos/">ΚΟΣΜΟΣ</a></li>
+<li id="menu-item-238234" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-238234"><a href="https://www.rosa.gr/koultoura/">Rosa Culture</a></li>
+<li id="menu-item-238191" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-238191"><a href="https://www.rosa.gr/opinions/">OPINIONS</a></li>
+<li id="menu-item-240771" class="menu-item menu-item-type-post_type_archive menu-item-object-video menu-item-240771"><a href="https://www.rosa.gr/videos/">Videos</a></li>
+</ul>					</div>
+				</nav>
+				<div class="search-form">
+	<form role="search" method="get" action="https://www.rosa.gr/">
+		<input type="search" name="s" placeholder="ΑΝΑΖΗΤΗΣΗ" value="">
+		<button type="button" title="search-icon">
+			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/HEADER/*[1][self::DIV]/*[1][self::DIV]/*[4][self::DIV]/*[1][self::FORM]/*[2][self::BUTTON]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/html/assets/images/icons/search-icon.svg" alt="search-icon">
+			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/HEADER/*[1][self::DIV]/*[1][self::DIV]/*[4][self::DIV]/*[1][self::FORM]/*[2][self::BUTTON]/*[2][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/html/assets/images/icons/search-open.svg" alt="search-open">
+		</button>
+		<button type="submit" title="submit"></button>
+	</form>
+</div>
+				<div class="full-sreen-menu-toggle">
+					<button>
+						<svg xmlns="http://www.w3.org/2000/svg" width="38" height="25.333" viewBox="0 0 38 25.333">
+							<path id="Icon_material-menu" data-name="Icon material-menu" d="M4.5,34.333h38V30.111H4.5Zm0-10.556h38V19.556H4.5ZM4.5,9v4.222h38V9Z" transform="translate(-4.5 -9)" fill="#fff"></path>
+						</svg>
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="full-screen-header">
+			<div class="full-screen-header-container-left">
+				<ul class="full-screen-menu"><li id="menu-item-27" class="menu-item menu-item-type-post_type menu-item-object-page full-screen-menu-item menu-item-27"><a href="https://www.rosa.gr/homepage/">HOME</a></li>
+<li id="menu-item-98792" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent full-screen-menu-item menu-item-98792"><a href="https://www.rosa.gr/latest/">Latest</a></li>
+<li id="menu-item-119928" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-119928"><a href="https://www.rosa.gr/ellada/">ΕΛΛΑΔΑ</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-119905" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119905"><a href="https://www.rosa.gr/politiki/">ΠΟΛΙΤΙΚΗ</a></li>
+	<li id="menu-item-119904" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119904"><a href="https://www.rosa.gr/oikonomia/">ΟΙΚΟΝΟΜΙΑ</a></li>
+</ul>
+</li>
+<li id="menu-item-97699" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-97699"><a href="https://www.rosa.gr/koinonia/">ΚΟΙΝΩΝΙΑ</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-119906" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119906"><a href="https://www.rosa.gr/dikaiosyni/">ΔΙΚΑΙΟΣΥΝΗ</a></li>
+	<li id="menu-item-119908" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119908"><a href="https://www.rosa.gr/ergasia/">ΕΡΓΑΣΙΑ</a></li>
+	<li id="menu-item-148696" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-148696"><a href="https://www.rosa.gr/ekpaideusi/">ΕΚΠΑΙΔΕΥΣΗ</a></li>
+	<li id="menu-item-210614" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-210614"><a href="https://www.rosa.gr/koinonia/ygeia/">ΥΓΕΙΑ</a></li>
+	<li id="menu-item-257199" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-257199"><a href="https://www.rosa.gr/technologia/">ΤΕΧΝΟΛΟΓΙΑ</a></li>
+</ul>
+</li>
+<li id="menu-item-97700" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-97700"><a href="https://www.rosa.gr/kosmos/">ΚΟΣΜΟΣ</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-119910" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119910"><a href="https://www.rosa.gr/evropi/">ΕΥΡΩΠΗ</a></li>
+</ul>
+</li>
+<li id="menu-item-97701" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-97701"><a href="https://www.rosa.gr/koultoura/">ΚΟΥΛΤΟΥΡΑ</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-119911" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119911"><a href="https://www.rosa.gr/koultoura/theatro/">ΘΕΑΤΡΟ</a></li>
+	<li id="menu-item-119912" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119912"><a href="https://www.rosa.gr/koultoura/kinimatografos/">ΚΙΝΗΜΑΤΟΓΡΑΦΟΣ</a></li>
+	<li id="menu-item-119913" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119913"><a href="https://www.rosa.gr/koultoura/mousiki/">ΜΟΥΣΙΚΗ</a></li>
+	<li id="menu-item-122228" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-122228"><a href="https://www.rosa.gr/koultoura/seires/">ΣΕΙΡΕΣ</a></li>
+	<li id="menu-item-121258" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-121258"><a href="https://www.rosa.gr/koultoura/anthropoi-stin-poli/">ΑΝΘΡΩΠΟΙ ΣΤΗΝ ΠΟΛΗ</a></li>
+	<li id="menu-item-137865" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-137865"><a href="https://www.rosa.gr/koultoura/vivlio/">ΒΙΒΛΙΟ</a></li>
+</ul>
+</li>
+<li id="menu-item-119918" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-119918"><a href="https://www.rosa.gr/symperilipsi/">ΣΥΜΠΕΡΙΛΗΨΗ</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-115273" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent full-screen-menu-sub-item menu-item-115273"><a href="https://www.rosa.gr/feminismos/">ΦΕΜΙΝΙΣΜΟΣ</a></li>
+	<li id="menu-item-98796" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-98796"><a href="https://www.rosa.gr/loatki/">ΛΟΑΤΚΙ</a></li>
+	<li id="menu-item-115275" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-115275"><a href="https://www.rosa.gr/prosfygiko/">ΠΡΟΣΦΥΓΙΚΟ</a></li>
+	<li id="menu-item-119917" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119917"><a href="https://www.rosa.gr/perivallon/">ΠΕΡΙΒΑΛΛΟΝ</a></li>
+	<li id="menu-item-119919" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119919"><a href="https://www.rosa.gr/filozoia/">ΦΙΛΟΖΩΙΑ</a></li>
+	<li id="menu-item-176279" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-176279"><a href="https://www.rosa.gr/istories-choris-foni/">Ιστοριες χωρις φωνη</a></li>
+</ul>
+</li>
+<li id="menu-item-119921" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-119921"><a href="https://www.rosa.gr/carpe-diem/">CARPE DIEM</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-119925" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119925"><a href="https://www.rosa.gr/taxidia/">ΤΑΞΙΔΙΑ</a></li>
+	<li id="menu-item-119926" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119926"><a href="https://www.rosa.gr/out-and-about/">OUT &amp; ABOUT</a></li>
+	<li id="menu-item-119923" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119923"><a href="https://www.rosa.gr/ekdiloseis/">ΕΚΔΗΛΩΣΕΙΣ</a></li>
+</ul>
+</li>
+<li id="menu-item-279779" class="menu-item menu-item-type-post_type_archive menu-item-object-podcast menu-item-has-children full-screen-menu-item menu-item-279779"><a href="https://www.rosa.gr/podcast/">PODCASTS</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-279782" class="menu-item menu-item-type-custom menu-item-object-custom full-screen-menu-sub-item menu-item-279782"><a href="https://www.rosa.gr/show/rosa-talks/">Rosa Talks</a></li>
+	<li id="menu-item-279781" class="menu-item menu-item-type-custom menu-item-object-custom full-screen-menu-sub-item menu-item-279781"><a href="https://www.rosa.gr/show/mila-mou-gi-afto/">Mιλα μου γι’ αυτο</a></li>
+	<li id="menu-item-279783" class="menu-item menu-item-type-custom menu-item-object-custom full-screen-menu-sub-item menu-item-279783"><a href="https://www.rosa.gr/show/anthropoi-stin-poli/">Ανθρωποι στην Πολη</a></li>
+	<li id="menu-item-279784" class="menu-item menu-item-type-custom menu-item-object-custom full-screen-menu-sub-item menu-item-279784"><a href="https://www.rosa.gr/show/i-lathos-ekpobi/">Η Λαθος Εκπομπη</a></li>
+</ul>
+</li>
+<li id="menu-item-119929" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-119929"><a href="https://www.rosa.gr/rosa-view/">ROSA VIEW</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-98798" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-98798"><a href="https://www.rosa.gr/editorial/">EDITORIAL</a></li>
+	<li id="menu-item-98797" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-98797"><a href="https://www.rosa.gr/erevna/">ΕΡΕΥΝΑ</a></li>
+	<li id="menu-item-98799" class="menu-item menu-item-type-custom menu-item-object-custom full-screen-menu-sub-item menu-item-98799"><a href="https://www.rosa.gr/video/">VIDEOS</a></li>
+	<li id="menu-item-122229" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-122229"><a href="https://www.rosa.gr/opinions/">OPINIONS</a></li>
+	<li id="menu-item-180259" class="menu-item menu-item-type-post_type menu-item-object-page full-screen-menu-sub-item menu-item-180259"><a href="https://www.rosa.gr/rosa-stories/">ROSA STORIES</a></li>
+</ul>
+</li>
+<li id="menu-item-97702" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children full-screen-menu-item menu-item-97702"><a href="https://www.rosa.gr/athlitismos/">ΑΘΛΗΤΙΣΜΟΣ</a>
+<ul class="full-screen-menu-sub">
+	<li id="menu-item-119931" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119931"><a href="https://www.rosa.gr/mpasket/">ΜΠΑΣΚΕΤ</a></li>
+	<li id="menu-item-120389" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-120389"><a href="https://www.rosa.gr/podosfairo/">ΠΟΔΟΣΦΑΙΡΟ</a></li>
+	<li id="menu-item-119933" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-sub-item menu-item-119933"><a href="https://www.rosa.gr/stivos/">ΣΤΙΒΟΣ</a></li>
+</ul>
+</li>
+<li id="menu-item-121265" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-item menu-item-121265"><a href="https://www.rosa.gr/koinonia-politon/">ΚΟΙΝΩΝΙΑ ΠΟΛΙΤΩΝ</a></li>
+<li id="menu-item-177091" class="menu-item menu-item-type-taxonomy menu-item-object-category full-screen-menu-item menu-item-177091"><a href="https://www.rosa.gr/mikromesaies-epicheiriseis/">Μικρομεσαιες Επιχειρησεις</a></li>
+</ul>			</div>
+
+			<div class="full-screen-header-container-right" style="height: 927px;">
+				<div class="socials-container">
+    <ul class="socials">
+        <li>
+            <a href="https://www.facebook.com/RosaProgressive/">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16.068" height="30" viewBox="0 0 16.068 30">
+                    <path id="Icon_awesome-facebook-f" data-name="Icon awesome-facebook-f" d="M16.624,16.875l.833-5.429h-5.21V7.922a2.715,2.715,0,0,1,3.061-2.933h2.368V.367A28.882,28.882,0,0,0,13.473,0C9.183,0,6.378,2.6,6.378,7.308v4.138H1.609v5.429H6.378V30h5.869V16.875Z" transform="translate(-1.609)" fill="#0A001F"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://www.instagram.com/rosa_progressive/">
+                <svg xmlns="http://www.w3.org/2000/svg" width="30" height="29.993" viewBox="0 0 30 29.993">
+                    <path id="Icon_awesome-instagram" data-name="Icon awesome-instagram" d="M15,9.544a7.69,7.69,0,1,0,7.69,7.69A7.678,7.678,0,0,0,15,9.544Zm0,12.689a5,5,0,1,1,5-5,5.009,5.009,0,0,1-5,5Zm9.8-13A1.794,1.794,0,1,1,23,7.436,1.789,1.789,0,0,1,24.8,9.23Zm5.093,1.82a8.876,8.876,0,0,0-2.423-6.284,8.935,8.935,0,0,0-6.284-2.423c-2.476-.141-9.9-.141-12.375,0A8.922,8.922,0,0,0,2.523,4.759,8.9,8.9,0,0,0,.1,11.044c-.141,2.476-.141,9.9,0,12.375A8.876,8.876,0,0,0,2.523,29.7a8.946,8.946,0,0,0,6.284,2.423c2.476.141,9.9.141,12.375,0A8.876,8.876,0,0,0,27.467,29.7a8.935,8.935,0,0,0,2.423-6.284c.141-2.476.141-9.892,0-12.368Zm-3.2,15.025a5.062,5.062,0,0,1-2.851,2.851c-1.974.783-6.659.6-8.841.6s-6.873.174-8.841-.6a5.062,5.062,0,0,1-2.851-2.851c-.783-1.974-.6-6.659-.6-8.841s-.174-6.873.6-8.841A5.062,5.062,0,0,1,6.157,5.542c1.974-.783,6.659-.6,8.841-.6s6.873-.174,8.841.6A5.062,5.062,0,0,1,26.69,8.393c.783,1.974.6,6.659.6,8.841S27.473,24.108,26.69,26.075Z" transform="translate(0.005 -2.238)" fill="#0A001F"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://twitter.com/rosa_progress">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32.052" height="30" viewBox="0 0 32.052 30">
+                    <path id="path1009" d="M6.368,21.9,18.743,38.45,6.29,51.9h2.8L20,40.122,28.807,51.9h9.535L25.271,34.423,36.862,21.9h-2.8L24.019,32.745,15.905,21.9Zm4.122,2.065h4.382l19.347,25.87h-4.38Z" transform="translate(-6.29 -21.9)" fill="#0A001F"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://www.tiktok.com/@rosa_progressive">
+                <svg xmlns="http://www.w3.org/2000/svg" width="26.063" height="30" viewBox="0 0 26.063 30">
+                    <path id="Icon_simple-tiktok" data-name="Icon simple-tiktok" d="M16.057.025C17.695,0,19.32.012,20.945,0a7.786,7.786,0,0,0,2.187,5.212,8.815,8.815,0,0,0,5.3,2.237v5.037a13.379,13.379,0,0,1-5.25-1.212,15.444,15.444,0,0,1-2.025-1.162c-.012,3.65.013,7.3-.025,10.937a9.547,9.547,0,0,1-1.687,4.925,9.313,9.313,0,0,1-7.387,4.012,9.114,9.114,0,0,1-5.1-1.287,9.426,9.426,0,0,1-4.562-7.137c-.025-.625-.037-1.25-.013-1.862a9.41,9.41,0,0,1,10.912-8.35c.025,1.85-.05,3.7-.05,5.55A4.289,4.289,0,0,0,7.77,19.55a4.959,4.959,0,0,0-.175,2.012A4.254,4.254,0,0,0,11.97,25.15a4.2,4.2,0,0,0,3.462-2.012,2.884,2.884,0,0,0,.512-1.325c.125-2.237.075-4.462.087-6.7.012-5.037-.013-10.062.025-15.087Z" transform="translate(-2.369)" fill="#0A001F"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://www.youtube.com/@ROSAProgressive" target="_blank">
+                <svg fill="#0A001F" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30px" height="30px" viewBox="0 0 512 512" xml:space="preserve" stroke="#0A001F">
+
+                    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+
+                    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+
+                    <g id="SVGRepo_iconCarrier">
+                        <g id="7935ec95c421cee6d86eb22ecd1368a9">
+                            <path style="display: inline;" d="M34.354,0.5h45.959l29.604,91.096h2.863L141.013,0.5h46.353l-53.107,133.338v94.589H88.641V138.08 L34.354,0.5z M192.193,98.657c0-13.374,5.495-24.003,16.493-31.938c10.984-7.934,25.749-11.901,44.3-11.901 c16.893,0,30.728,4.192,41.506,12.55c10.805,8.358,16.193,19.112,16.193,32.287v89.2c0,14.771-5.301,26.373-15.868,34.782 c-10.579,8.408-25.151,12.625-43.684,12.625c-17.859,0-32.143-4.342-42.866-13.024c-10.709-8.683-16.074-20.36-16.074-35.057 V98.657z M234.205,191.424c0,4.766,1.44,8.409,4.354,11.029c2.907,2.595,7.055,3.867,12.451,3.867c5.532,0,9.93-1.297,13.18-3.942 c3.256-2.669,4.891-6.313,4.891-10.954V97.359c0-3.768-1.672-6.812-4.99-9.132c-3.318-2.321-7.679-3.494-13.081-3.494 c-4.972,0-9.027,1.173-12.133,3.494c-3.119,2.32-4.672,5.364-4.672,9.132V191.424z M459.992,57.588v172.711h-40.883v-19.063 c-7.547,7.037-15.381,12.375-23.541,16.069c-8.146,3.643-16.068,5.489-23.729,5.489c-9.455,0-16.592-2.57-21.383-7.71 c-4.791-5.141-7.186-12.85-7.186-23.13V57.588h40.895v132.39c0,4.117,0.861,7.061,2.57,8.907c1.723,1.822,4.492,2.745,8.322,2.745 c3.018,0,6.824-1.223,11.4-3.643c4.604-2.42,8.82-5.514,12.65-9.282V57.588H459.992z M421.68,363.262 c-2.008-2.221-5.203-3.368-9.594-3.368c-4.59,0-7.883,1.147-9.879,3.368c-1.996,2.245-2.994,5.963-2.994,11.153v10.754h25.473 v-10.754C424.686,369.225,423.688,365.507,421.68,363.262z M300.855,444.228c2.195,0.898,4.516,1.322,6.961,1.322 c3.543,0,6.113-0.849,7.785-2.595c1.67-1.722,2.494-4.591,2.494-8.533v-62.178c0-4.191-1.023-7.36-3.068-9.531 c-2.059-2.171-5.064-3.244-8.957-3.244c-2.059,0-4.092,0.399-6.102,1.198c-2.008,0.823-3.991,2.096-5.95,3.792v75.402 C296.364,441.907,298.646,443.354,300.855,444.228z M490.496,312.587c0-29.941-30.754-54.219-68.654-54.219 c-54.068-1.822-109.396-2.62-165.842-2.521c-56.427-0.1-111.756,0.698-165.843,2.521c-37.881,0-68.633,24.277-68.633,54.219 c-2.277,23.678-3.263,47.381-3.175,71.085c-0.087,23.703,0.898,47.406,3.175,71.11c0,29.916,30.752,54.192,68.633,54.192 c54.087,1.797,109.416,2.596,165.843,2.521c56.446,0.075,111.774-0.724,165.842-2.521c37.9,0,68.654-24.276,68.654-54.192 c2.27-23.704,3.254-47.407,3.154-71.11C493.75,359.968,492.766,336.265,490.496,312.587z M121.251,463.465v1.797H88.778v-1.797 V321.644H55.182v-1.771v-22.605v-1.771h99.672v1.771v22.605v1.771h-33.603V463.465z M236.768,341.33v122.135v1.797h-28.831v-1.797 v-11.901c-5.327,5.064-10.848,8.882-16.592,11.527c-5.757,2.619-11.334,3.942-16.748,3.942c-6.662,0-11.684-1.847-15.065-5.515 c-3.387-3.692-5.078-9.231-5.078-16.617v-1.797V341.33v-1.772h28.844v1.772v93.216c0,2.92,0.599,5.065,1.802,6.363 c1.217,1.322,3.175,1.971,5.876,1.971c2.127,0,4.803-0.873,8.047-2.595c3.231-1.747,6.2-3.967,8.914-6.662V341.33v-1.772h28.831 V341.33z M347.775,370.847v66.943v1.797c0,8.808-2.258,15.544-6.773,20.235c-4.518,4.641-11.055,6.986-19.588,6.986 c-5.639,0-10.652-0.898-15.07-2.695c-4.428-1.821-8.532-4.616-12.325-8.384v7.735v1.797h-29.105v-1.797V297.267v-1.771h29.105 v1.771v52.297c3.893-3.793,8.009-6.662,12.376-8.608c4.379-1.971,8.809-2.969,13.273-2.969c9.107,0,16.094,2.645,20.896,7.935 c4.803,5.289,7.211,12.999,7.211,23.13V370.847z M454.365,374.64v29.767v1.797h-55.152v21.581c0,6.513,0.947,11.029,2.844,13.549 c1.908,2.521,5.152,3.793,9.742,3.793c4.779,0,8.135-1.073,10.043-3.219c1.896-2.121,2.844-6.837,2.844-14.123v-6.811v-1.796h29.68 v1.796v7.51v1.796c0,12.7-3.605,22.257-10.84,28.694c-7.225,6.438-18.016,9.631-32.375,9.631c-12.912,0-23.066-3.418-30.49-10.229 c-7.41-6.812-11.127-16.193-11.127-28.096v-1.796V374.64v-1.771c0-10.754,4.078-19.512,12.213-26.299 c8.146-6.762,18.689-10.155,31.588-10.155c13.199,0,23.328,3.144,30.416,9.406c7.061,6.264,10.615,15.296,10.615,27.048V374.64z">
+                            </path>
+                        </g>
+                    </g>
+                </svg>
+            </a>
+        </li>
+    </ul>
+</div>
+				
+<div class="menu-social-container">
+    <ul class="menu-social"><li id="menu-item-98813" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-98813"><a href="https://www.rosa.gr/manifesto/">Manifesto</a></li>
+<li id="menu-item-161730" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-161730"><a href="https://www.rosa.gr/newsletter/">Newsletter</a></li>
+<li id="menu-item-43" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-43"><a href="https://www.rosa.gr/epikoinonia/">Επικοινωνία</a></li>
+<li id="menu-item-42" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-42"><a href="https://www.rosa.gr/taftotita/">Ταυτότητα</a></li>
+<li id="menu-item-98886" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-98886"><a href="https://www.rosa.gr/diafimisteite-sto-rosa-gr/">Διαφημιστείτε</a></li>
+<li id="menu-item-165530" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-165530"><a href="https://smb.rosa.gr/">Στηρίζουμε τις ΜμΕ</a></li>
+<li id="menu-item-283151" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-283151"><a href="https://creators.rosa.gr/">Γίνε Creator στη Rosa</a></li>
+</ul></div>
+			</div>
+		</div>
+	</header>
+
+	<main>
+
+<section id="breaking-news">
+	
+</section>
+
+<style>
+	/*the container must be positioned relative:*/
+	.custom-select {
+		position: relative;
+		font-family: Arial;
+	}
+
+	.custom-select select {
+		display: none;
+		/*hide original SELECT element:*/
+	}
+
+	.select-selected {
+		background-color: DodgerBlue;
+	}
+
+	/*style the arrow inside the select element:*/
+	.select-selected:after {
+		position: absolute;
+		content: "";
+		top: 14px;
+		right: 10px;
+		width: 0;
+		height: 0;
+		border: 6px solid transparent;
+		border-color: #fff transparent transparent transparent;
+	}
+
+	/*point the arrow upwards when the select box is open (active):*/
+	.select-selected.select-arrow-active:after {
+		border-color: transparent transparent #fff transparent;
+		top: 7px;
+	}
+
+	/*style the items (options), including the selected item:*/
+	.select-items div,
+	.select-selected {
+		color: #ffffff;
+		padding: 8px 16px;
+		border: 1px solid transparent;
+		border-color: transparent transparent rgba(0, 0, 0, 0.1) transparent;
+		cursor: pointer;
+		user-select: none;
+	}
+
+	/*style items (options):*/
+	.select-items {
+		position: absolute;
+		background-color: DodgerBlue;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: 99;
+	}
+
+	/*hide the items when the select box is closed:*/
+	.select-hide {
+		display: none;
+	}
+
+	.select-items div:hover,
+	.same-as-selected {
+		background-color: rgba(0, 0, 0, 0.1);
+	}
+</style>
+<section id="hero">
+	<div class="container">
+		
+
+	<div class="top-row">
+			
+					<div class="spotlight-title  show-desktop violet">
+				<a href="https://www.rosa.gr/kosmos/">
+					ΚΟΣΜΟΣ					
+					
+				</a>
+			</div>
+				
+		<div class="title">
+			<h1>
+									Η επόμενη μέρα στον Λίβανο: Το κύμα επιστροφής των εκτοπισμένων και η βαριά σκιά της καταστροφής									</h1>
+							<h2 class="subtitle">
+					Η αρχική συμφωνία κατάπαυσης του πυρός ανάμεσα σε ΗΠΑ και Ιράν ανοίγει τον δρόμο της επιστροφής για χιλιάδες κατοίκους του Νότου
+				</h2>
+									<div class="author show-mobile">
+				<a href="https://www.rosa.gr/author/rosa-team/">
+											<div class="author-avatar">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[2][self::DIV]/*[3][self::DIV]/*[1][self::A]/*[1][self::DIV]/*[1][self::IMG]" width="150" height="150" src="https://www.rosa.gr/wp-content/uploads/2025/11/rosalogo2-150x150.png" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/rosalogo2-150x150.png 150w, https://www.rosa.gr/wp-content/uploads/2025/11/rosalogo2-96x96.png 96w" sizes="(max-width: 150px) 100vw, 150px">						</div>
+										<div class="author-name">
+
+												Newsroom					</div>
+				</a>
+			</div>
+						</div>
+
+		<span class="title-mobile" aria-hidden="true">Η επόμενη μέρα στον Λίβανο: Το κύμα επιστροφής των εκτοπισμένων και η βαριά σκιά της καταστροφής</span>
+
+			<div class="post-image">
+						<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[4][self::DIV]/*[1][self::IMG]" width="1274" height="623" src="https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail.jpg" class="attachment-full size-full" alt="Μπαράζ βομβαρδισμών και επιθέσεων πραγματοποιεί από το πρωί το Ισραήλ στον Λίβανο" decoding="async" fetchpriority="high" srcset="https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail.jpg 1274w, https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail-300x147.jpg 300w, https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail-1024x501.jpg 1024w, https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail-768x376.jpg 768w, https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail-150x73.jpg 150w" sizes="(max-width: 1274px) 100vw, 1274px">						<span class="image-credits">ΑΠΕ-ΜΠΕ/EPA</span>		</div>
+		<div class="bottom-row">
+					<div class="author show-desktop">
+				<a href="https://www.rosa.gr/author/rosa-team/">
+											<div class="author-image">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[1][self::DIV]/*[1][self::A]/*[1][self::DIV]/*[1][self::IMG]" width="150" height="150" src="https://www.rosa.gr/wp-content/uploads/2025/11/rosalogo2-150x150.png" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/rosalogo2-150x150.png 150w, https://www.rosa.gr/wp-content/uploads/2025/11/rosalogo2-96x96.png 96w" sizes="(max-width: 150px) 100vw, 150px">						</div>
+										<div class="author-name">
+
+												Newsroom					</div>
+				</a>
+			</div>
+				
+<div class="post-share">
+	<div class="container">
+		<div class="spotlight-title violet">
+			<h2>Share</h2>
+		</div>
+
+		<ul class="share-buttons">
+			<li class="share-button">
+				<a href="https://www.facebook.com/sharer/sharer.php?u=https://www.rosa.gr/kosmos/i-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis/" class="facebook">
+					<svg xmlns="http://www.w3.org/2000/svg" width="10.712" height="20" viewBox="0 0 10.712 20">
+						<path id="Icon_awesome-facebook-f" data-name="Icon awesome-facebook-f" d="M11.619,11.25l.555-3.62H8.7V5.282a1.81,1.81,0,0,1,2.041-1.955h1.579V.245A19.254,19.254,0,0,0,9.518,0c-2.86,0-4.73,1.734-4.73,4.872V7.63H1.609v3.62H4.789V20H8.7V11.25Z" transform="translate(-1.609)"></path>
+					</svg>
+				</a>
+			</li>
+			<li class="share-button">
+				<a href="https://twitter.com/intent/post?text=Η επόμενη μέρα στον Λίβανο: Το κύμα επιστροφής των εκτοπισμένων και η βαριά σκιά της καταστροφής&amp;url=https://www.rosa.gr/kosmos/i-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis/" class="x">
+					<svg xmlns="http://www.w3.org/2000/svg" width="20.3" height="19" viewBox="0 0 20.3 19">
+						<path id="path1009" d="M6.34,21.9l7.837,10.481L6.29,40.9H8.065l6.905-7.459L20.551,40.9H26.59L18.311,29.831,25.652,21.9H23.877l-6.359,6.869L12.38,21.9Zm2.61,1.308h2.775L23.978,39.592H21.2Z" transform="translate(-6.29 -21.9)" fill="#1d1d1b"></path>
+					</svg>
+				</a>
+			</li>
+			<li class="share-button">
+				<a href="fb-messenger://share/?link=https://www.rosa.gr/kosmos/i-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis/" class="messenger">
+					<svg xmlns="http://www.w3.org/2000/svg" width="19.001" height="19" viewBox="0 0 19.001 19">
+						<path id="Icon_awesome-facebook-messenger" data-name="Icon awesome-facebook-messenger" d="M10.084.563A9.18,9.18,0,0,0,.563,9.778a9.007,9.007,0,0,0,2.991,6.817c.32.288.254.454.308,2.231A.763.763,0,0,0,4.93,19.5c2.027-.893,2.053-.963,2.4-.87,5.872,1.616,12.237-2.142,12.237-8.851A9.144,9.144,0,0,0,10.084.563ZM15.8,7.655,13,12.082a1.432,1.432,0,0,1-2.065.38L8.715,10.8a.575.575,0,0,0-.69,0l-3,2.277a.452.452,0,0,1-.655-.6l2.8-4.427a1.431,1.431,0,0,1,2.065-.38l2.224,1.665a.575.575,0,0,0,.69,0l3-2.275a.45.45,0,0,1,.655.6Z" transform="translate(-0.563 -0.563)"></path>
+					</svg>
+				</a>
+			</li>
+			<li class="share-button">
+				<a href="https://api.whatsapp.com/send?text=%CE%97%20%CE%B5%CF%80%CF%8C%CE%BC%CE%B5%CE%BD%CE%B7%20%CE%BC%CE%AD%CF%81%CE%B1%20%CF%83%CF%84%CE%BF%CE%BD%20%CE%9B%CE%AF%CE%B2%CE%B1%CE%BD%CE%BF%3A%20%CE%A4%CE%BF%20%CE%BA%CF%8D%CE%BC%CE%B1%20%CE%B5%CF%80%CE%B9%CF%83%CF%84%CF%81%CE%BF%CF%86%CE%AE%CF%82%20%CF%84%CF%89%CE%BD%20%CE%B5%CE%BA%CF%84%CE%BF%CF%80%CE%B9%CF%83%CE%BC%CE%AD%CE%BD%CF%89%CE%BD%20%CE%BA%CE%B1%CE%B9%20%CE%B7%20%CE%B2%CE%B1%CF%81%CE%B9%CE%AC%20%CF%83%CE%BA%CE%B9%CE%AC%20%CF%84%CE%B7%CF%82%20%CE%BA%CE%B1%CF%84%CE%B1%CF%83%CF%84%CF%81%CE%BF%CF%86%CE%AE%CF%82%20https%3A%2F%2Fwww.rosa.gr%2Fkosmos%2Fi-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis%2F" class="whatsapp" target="_blank" rel="noopener">
+					<svg fill="#000000" width="800px" height="800px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+						<title>whatsapp</title>
+						<path d="M26.576 5.363c-2.69-2.69-6.406-4.354-10.511-4.354-8.209 0-14.865 6.655-14.865 14.865 0 2.732 0.737 5.291 2.022 7.491l-0.038-0.070-2.109 7.702 7.879-2.067c2.051 1.139 4.498 1.809 7.102 1.809h0.006c8.209-0.003 14.862-6.659 14.862-14.868 0-4.103-1.662-7.817-4.349-10.507l0 0zM16.062 28.228h-0.005c-0 0-0.001 0-0.001 0-2.319 0-4.489-0.64-6.342-1.753l0.056 0.031-0.451-0.267-4.675 1.227 1.247-4.559-0.294-0.467c-1.185-1.862-1.889-4.131-1.889-6.565 0-6.822 5.531-12.353 12.353-12.353s12.353 5.531 12.353 12.353c0 6.822-5.53 12.353-12.353 12.353h-0zM22.838 18.977c-0.371-0.186-2.197-1.083-2.537-1.208-0.341-0.124-0.589-0.185-0.837 0.187-0.246 0.371-0.958 1.207-1.175 1.455-0.216 0.249-0.434 0.279-0.805 0.094-1.15-0.466-2.138-1.087-2.997-1.852l0.010 0.009c-0.799-0.74-1.484-1.587-2.037-2.521l-0.028-0.052c-0.216-0.371-0.023-0.572 0.162-0.757 0.167-0.166 0.372-0.434 0.557-0.65 0.146-0.179 0.271-0.384 0.366-0.604l0.006-0.017c0.043-0.087 0.068-0.188 0.068-0.296 0-0.131-0.037-0.253-0.101-0.357l0.002 0.003c-0.094-0.186-0.836-2.014-1.145-2.758-0.302-0.724-0.609-0.625-0.836-0.637-0.216-0.010-0.464-0.012-0.712-0.012-0.395 0.010-0.746 0.188-0.988 0.463l-0.001 0.002c-0.802 0.761-1.3 1.834-1.3 3.023 0 0.026 0 0.053 0.001 0.079l-0-0.004c0.131 1.467 0.681 2.784 1.527 3.857l-0.012-0.015c1.604 2.379 3.742 4.282 6.251 5.564l0.094 0.043c0.548 0.248 1.25 0.513 1.968 0.74l0.149 0.041c0.442 0.14 0.951 0.221 1.479 0.221 0.303 0 0.601-0.027 0.889-0.078l-0.031 0.004c1.069-0.223 1.956-0.868 2.497-1.749l0.009-0.017c0.165-0.366 0.261-0.793 0.261-1.242 0-0.185-0.016-0.366-0.047-0.542l0.003 0.019c-0.092-0.155-0.34-0.247-0.712-0.434z"></path>
+					</svg>
+				</a>
+			</li>
+			<li class="share-button">
+				<p onclick="navigator.clipboard.writeText(window.location.href);" class="copy-link" style="cursor: pointer;">
+					<svg xmlns="http://www.w3.org/2000/svg" width="19.006" height="19" viewBox="0 0 19.006 19">
+						<g id="copy-link" transform="translate(0 0)">
+							<path id="Path_660" data-name="Path 660" d="M10.23,108.508l-2.908,2.908h0a3.084,3.084,0,0,1-4.362-4.362h0l2.908-2.908a1.028,1.028,0,0,0-1.454-1.454L1.506,105.6h0a5.141,5.141,0,0,0,7.271,7.269h0l2.908-2.908a1.028,1.028,0,0,0-1.454-1.454" transform="translate(0 -95.374)"></path>
+							<path id="Path_661" data-name="Path 661" d="M114.409,5.138A5.141,5.141,0,0,0,105.634,1.5h0l-2.908,2.908a1.028,1.028,0,1,0,1.454,1.454l2.908-2.908h0a3.084,3.084,0,0,1,4.362,4.362h0l-2.908,2.908A1.028,1.028,0,1,0,110,11.681L112.9,8.773h0a5.107,5.107,0,0,0,1.505-3.634" transform="translate(-95.404 0)"></path>
+							<path id="Path_662" data-name="Path 662" d="M81.515,88.748a1.028,1.028,0,0,0,1.454,0l5.816-5.816a1.028,1.028,0,0,0-1.454-1.454l-5.816,5.816a1.028,1.028,0,0,0,0,1.454" transform="translate(-75.647 -75.613)"></path>
+						</g>
+					</svg>
+				</p>
+			</li>
+		</ul>
+	</div>
+</div>
+		<div class="meta">
+							<div class="spotlight-title show-mobile violet">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026 | 19:18				</div>
+									<div class="reading-time">
+				Διαβάζεται σε 2'			</div>
+						
+		</div>
+		
+	</div>
+
+
+
+
+
+
+<div class="google-preferred-source google-preferred-source--top google-preferred-source--hero">
+	<a href="https://www.google.com/preferences/source?q=rosa.gr" class="google-preferred-source-button" target="_blank" rel="noopener noreferrer">
+		<span class="google-preferred-source-icon" aria-hidden="true">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"></path><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"></path><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"></path><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"></path></svg>		</span>
+		<span class="google-preferred-source-text">
+			Προσθέστε το Rosa.gr ως προτιμώμενη πηγή στην Google		</span>
+	</a>
+
+			<div class="google-preferred-source-mobile-banner">
+			<p class="google-preferred-source-mobile-banner__text">
+				Ανακαλύψτε περισσότερα άρθρα στα αποτελέσματα αναζήτησης.			</p>
+			<a href="https://www.google.com/preferences/source?q=rosa.gr" class="google-preferred-source-mobile-banner__cta" target="_blank" rel="noopener noreferrer">
+				<span class="google-preferred-source-icon" aria-hidden="true">
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"></path><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"></path><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"></path><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"></path></svg>				</span>
+				<span class="google-preferred-source-mobile-banner__cta-text">
+					Προσθήκη του Rosa.gr στην Google				</span>
+			</a>
+		</div>
+	</div>
+	</div>
+</div></section><div class="ai-summary" data-nosnippet=""><div class="ai-summary-title" aria-expanded="false" style="cursor: pointer;">
+            <img src="https://www.rosa.gr/wp-content/uploads/2026/01/ai-1.png" alt="AI Summary" class="ai-summary-logo">
+            <span class="ai-summary-text">Quick take by Rosa.gr</span>
+            <svg class="politisgroup-toggle-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="transform: rotate(-90deg); transition: transform 0.3s;">
+                <path d="M8 11L3 6h10z"></path>
+            </svg>
+        </div><div class="ai-summary-content collapsed"><ul><li>Ανακοινώθηκε αρχική συμφωνία για κατάπαυση του πυρός, με διαμεσολάβηση ΗΠΑ και Ιράν.  </li><li>Η εκεχειρία οδήγησε στον άμεσο τερματισμό των εχθροπραξιών στον Νότιο Λίβανο και σε μαζική επιστροφή εκτοπισμένων (από 15 Ιουνίου προς Ρμαϊλέ και άλλες κοινότητες).  </li><li>Ανταποκρίσεις καταγράφουν εκτεταμένες καταστροφές: οικισμοί ισοπεδωμένοι, δίκτυα ηλεκτροδότησης και υδροδότησης εκτός λειτουργίας.  </li><li>Επιστρέφοντες συναντούν σωρούς μπάζων και πολλοί νοικοκυριού διαθέτουν πλέον χωρίς κατοικία ή προσωπικά αντικείμενα.  </li><li>Το άρθρο αναφέρει ότι, παρά την αποφυγή ευρύτερης περιφερειακής ανάφλεξης, η ανθρωπιστική κρίση και η ανοικοδόμηση της περιοχής απαιτούν σημαντική διεθνή βοήθεια και χρόνο.</li></ul><div class="ai-summary-disclaimer">Αυτό το περιεχόμενο δημιουργείται με τεχνητή νοημοσύνη.</div></div></div>
+
+<section id="post" class="">
+
+	
+	
+<div class="post-wrap">
+	
+	<div class="post-content">
+		
+		<div class="post-text">
+						
+<p>Μια νέα, εξαιρετικά κρίσιμη σελίδα ανοίγει για τη <a href="https://www.rosa.gr/tag/mesi-anatoli/" type="post_tag" id="623">Μέση Ανατολή</a> μετά την επίσημη ανακοίνωση της αρχικής συμφωνίας για κατάπαυση του πυρός, η οποία επιτεύχθηκε με τη διαμεσολάβηση των <a href="https://www.rosa.gr/tag/ipa/" type="post_tag" id="65">Ηνωμένων Πολιτειών</a> και του <a href="https://www.rosa.gr/tag/iran/" type="post_tag" id="80">Ιράν</a>. Η διπλωματική αυτή εξέλιξη, αν και ακόμα σε αρχικό στάδιο, έδωσε το σύνθημα για τον άμεσο τερματισμό των εχθροπραξιών στον πολύπαθο Νότιο Λίβανο, πυροδοτώντας ένα μαζικό κύμα επιστροφής των αμάχων.</p>
+
+
+
+<div class="short-read-also">
+	<div class="backgrounded-title dark">
+		<h2>ΔΙΑΒΑΣΤΕ ΕΠΙΣΗΣ</h2>
+	</div>
+	<ul class="post-list">
+					<li class="post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/livanos-nees-israilines-aeroporikes-epidromes-12-nekroi/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::DIV]/*[2][self::DIV]/*[2][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" decoding="async" width="1103" height="735" src="https://www.rosa.gr/wp-content/uploads/2024/12/29578223-1.jpg" class="attachment-full size-full" alt="Ισραηλινοί βομβαρδισμοί στον Λίβανο" srcset="https://www.rosa.gr/wp-content/uploads/2024/12/29578223-1.jpg 1103w, https://www.rosa.gr/wp-content/uploads/2024/12/29578223-1-300x200.jpg 300w, https://www.rosa.gr/wp-content/uploads/2024/12/29578223-1-1024x682.jpg 1024w, https://www.rosa.gr/wp-content/uploads/2024/12/29578223-1-768x512.jpg 768w" sizes="(max-width: 1103px) 100vw, 1103px">			</a>				</div>
+	<div class="post-info">
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/livanos-nees-israilines-aeroporikes-epidromes-12-nekroi/">						Λίβανος: Νέες ισραηλινές αεροπορικές επιδρομές – 12 νεκροί						</a>		</h3>
+			</div>
+	</div>
+			</li>
+			</ul>
+</div>
+
+
+
+<p>Ήδη από τη Δευτέρα 15 Ιουνίου, οι δρόμοι που οδηγούν προς την περιοχή του Ρμαϊλέ και άλλες κοινότητες του Νότου γέμισαν ξανά με αυτοκίνητα. Χιλιάδες εκτοπισμένοι, που αναγκάστηκαν να εγκαταλείψουν άρον άρον τα σπίτια τους για να γλιτώσουν από τη δίνη του πολέμου, παίρνουν τώρα το ρίσκο της επιστροφής, διψώντας για ασφάλεια και επανασύνδεση με τις εστίες τους.</p>
+
+
+
+<div id="inline1_zhsuyl" style="margin-bottom: 25px;" data-oau-code="/22767323261/rosa.gr/inline1" data-lazyloaded-by-ocm="" data-google-query-id="CKbE4r7rjJUDFVizpgQd01sEnQ"><div id="google_ads_iframe_/22767323261/rosa.gr/inline1_0__container__" style="border: 0pt; margin: auto; text-align: center;"><iframe id="google_ads_iframe_/22767323261/rosa.gr/inline1_0" name="google_ads_iframe_/22767323261/rosa.gr/inline1_0" title="3rd party ad content" width="300" height="600" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="private-state-token-redemption;attribution-reporting" data-load-complete="true" data-google-container-id="3" style="border: 0px; vertical-align: bottom;"></iframe></div></div><h2 class="wp-block-heading" id="h-η-σκληρή-πραγματικότητα-της-εκεχειρίας">Η σκληρή πραγματικότητα της εκεχειρίας</h2>
+
+
+
+<p>Ωστόσο, η ανακούφιση από τη σιγή των όπλων μετατρέπεται γρήγορα σε βαρύ σοκ. Οι εικόνες που μεταδίδουν οι ανταποκριτές των διεθνών πρακτορείων αποτυπώνουν το μέγεθος της βιβλικής καταστροφής.</p>
+
+
+
+<p>Ολόκληροι οικισμοί έχουν ισοπεδωθεί από τις πολύμηνες συγκρούσεις και τις σφοδρές αεροπορικές επιδρομές. Επιστρέφοντας στα χωριά τους, οι κάτοικοι βρίσκονται αντιμέτωποι με ένα τοπίο απόλυτης ερήμωσης:</p><div class="widget-article" style="margin: 20px 0;">
+            <a href="https://986.gr/player/" target="_blank" rel="noopener noreferrer">
+                <picture>
+                    <source media="(max-width: 1280px)" srcset="https://www.rosa.gr/wp-content/uploads/2026/02/widget-mobile.png">
+                    <img src="https://www.rosa.gr/wp-content/uploads/2026/02/widget-article-web.png" alt="Widget Article">
+                </picture>
+            </a>
+        </div><div class="ad-placement">
+            <div class="ad-wraper">
+                <div id="ocm-inread" style=""></div><div class="teads-adCall"></div>
+            </div>
+        </div>
+
+
+
+<p>Δίκτυα ηλεκτροδότησης και υδροδότησης έχουν τεθεί πλήρως εκτός λειτουργίας. Πολίτες στέκονται πάνω από σωρούς από μπάζα, προσπαθώντας με γυμνά χέρια να εντοπίσουν προσωπικά αντικείμενα ή ό,τι απέμεινε από το βιος τους. Χιλιάδες οικογένειες συνειδητοποιούν ότι, παρά την εκεχειρία, δεν έχουν πλέον σπίτι για να μείνουν.</p>
+
+
+
+<p>«Η συμφωνία Ουάσινγκτον – Τεχεράνης σταματά το αίμα, αλλά η ανθρωπιστική κρίση στον Λίβανο μόλις περνά στην επόμενη φάση της. Η ανοικοδόμηση της περιοχής θα απαιτήσει χρόνια και τεράστια διεθνή βοήθεια.»</p>
+
+
+
+<div id="inline2_biorr" style="margin-bottom: 25px;" data-oau-code="/22767323261/rosa.gr/inline2" data-lazyloaded-by-ocm="" data-google-query-id="CMiugb_rjJUDFZGgpgQdj4gGrw"><div id="google_ads_iframe_/22767323261/rosa.gr/inline2_0__container__" style="border: 0pt; margin: auto; text-align: center; width: 300px; height: 600px;"><iframe frameborder="0" src="https://d49429867c3ea625503e07a2adf63e9f.safeframe.googlesyndication.com/safeframe/1-0-45/html/container.html" id="google_ads_iframe_/22767323261/rosa.gr/inline2_0" title="Περιεχόμενο διαφήμισης τρίτου μέρους" name="" scrolling="no" marginwidth="0" marginheight="0" width="300" height="600" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="private-state-token-redemption;attribution-reporting" aria-label="Διαφήμιση" tabindex="0" data-google-container-id="2" style="border: 0px; vertical-align: bottom;" data-load-complete="true"></iframe></div></div><p>Η επόμενη μέρα βρίσκει τον Λίβανο σε μια εύθραυστη ισορροπία. Ενώ η διπλωματία πανηγυρίζει για την αποφυγή μιας ευρύτερης περιφερειακής ανάφλεξης, οι απλοί άνθρωποι καλούνται να μαζέψουν τα κομμάτια τους και να χτίσουν τη ζωή τους από την αρχή, πάνω στα συντρίμμια ενός ακόμη πολέμου.</p>
+		</div>
+
+		
+<div class="post-tags">
+	<div class="backgrounded-title light">
+		<h2>TAGS</h2>
+	</div>
+	<ul class="post-tag-list">
+					<li class="tag">
+				<a href="https://www.rosa.gr/tag/livanos/">
+					Λιβανος				</a>
+			</li>
+					<li class="tag">
+				<a href="https://www.rosa.gr/tag/ekecheiria/">
+					εκεχειρια				</a>
+			</li>
+			</ul>
+</div>
+		<div class="ad-section ">
+			<div class="ad-placement">
+				<div class="ad-wraper">
+					<!-- /22767323261/rosa.gr/storyteller -->
+                            <div id="ocm-storyteller"></div>				</div>
+			</div>
+		</div>
+		<div class="google-preferred-source">
+	<a href="https://www.google.com/preferences/source?q=rosa.gr" class="google-preferred-source-button" target="_blank" rel="noopener noreferrer">
+		<span class="google-preferred-source-icon" aria-hidden="true">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"></path><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"></path><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"></path><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"></path></svg>		</span>
+		<span class="google-preferred-source-text">
+			Προσθέστε το Rosa.gr ως προτιμώμενη πηγή στην Google		</span>
+	</a>
+
+	</div>
+
+<div class="follow-google-news">
+	<a href="https://www.youtube.com/@ROSAProgressive" class="follow-link facebook" target="_blank">
+		<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[1][self::A]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/facebook.svg" alt="facebook">
+	</a>
+	<a href="https://www.youtube.com/@ROSAProgressive" class="follow-link instagram" target="_blank">
+		<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[2][self::A]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/instagram.svg" alt="instagram">
+	</a>
+	<a href="https://www.youtube.com/@ROSAProgressive" class="follow-link tiktok" target="_blank">
+		<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[3][self::A]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/tiktok.svg" alt="tiktok">
+	</a>
+	<a href="https://www.youtube.com/@ROSAProgressive" class="follow-link youtube" target="_blank">
+		<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[4][self::A]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/youtube.svg" alt="youtube">
+	</a>
+	<a href="https://www.messenger.com/channel/RosaProgressive" class="follow-link messenger" target="_blank">
+		<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[5][self::A]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/messenger.svg" alt="messenger">
+	</a>
+	<a href="https://whatsapp.com/channel/0029Vb4s1a90LKZLQquYAt15" class="follow-link whatsapp" target="_blank">
+		<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[1][self::DIV]/*[1][self::DIV]/*[5][self::DIV]/*[6][self::A]/*[1][self::IMG]" src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/whatsapp.png" alt="whatsapp">
+	</a>
+	<!-- <a href="https://news.google.com/publications/CAAqBwgKMIzomwsw0PKzAw?hl=el&gl=GR&ceid=GR%3Ael" class="follow-link google-news">
+		<img src="https://www.rosa.gr/wp-content/themes/rosa-theme/assets/images/google-news.png" alt="google news">
+	</a> -->
+	<p>
+		Ακολουθήστε το rosa.gr	</p>
+</div>	</div>
+
+</div>
+	
+<div class="post-sidebar">
+
+			<div class="ad-section ">
+			<div class="ad-placement">
+				<div class="ad-wraper">
+					<!-- /22767323261/rosa.gr/sidebar1 -->
+                            <div id="sidebar1" data-ocm-ad="" style="min-height:unset" data-oau-code="/22767323261/rosa.gr/sidebar1">
+                            </div>				</div>
+			</div>
+		</div>
+		
+	<div class="popular">
+	<div class="popular-container">
+		<div class="title-column">
+			<h2 class="section-title" data-text="ΔΗΜΟΦΙΛΗ">
+				Δημοφιλή			</h2>
+		</div>
+		<ol class="popolar-list">
+							<li class="popular-item">
+					<div class="post-image">
+						<a href="https://www.rosa.gr/opinions/irthe-xana-i-epochi-pou-to-na-foras-to-magio-sou-kai-na-pigaineis-gia-banio-ginetai-eidisi/">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[2][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::OL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="300" height="147" src="https://www.rosa.gr/wp-content/uploads/2026/06/somata-300x147.avif" class="attachment-medium size-medium wp-post-image" alt="σώματα-μαγιό-shaming" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/somata-300x147.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/somata-1024x501.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/somata-768x376.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/somata-150x73.avif 150w, https://www.rosa.gr/wp-content/uploads/2026/06/somata.avif 1274w" sizes="(max-width: 300px) 100vw, 300px">						</a>
+					</div>
+					<div class="post-meta">
+						<span class="category">
+							OPINIONS						</span>
+						<span class="date">
+							09.06.2026						</span>
+					</div>
+					<h3>
+						<a href="https://www.rosa.gr/opinions/irthe-xana-i-epochi-pou-to-na-foras-to-magio-sou-kai-na-pigaineis-gia-banio-ginetai-eidisi/">
+							Ξανάρθε η εποχή που το να φοράς το μαγιό σου γίνεται είδηση						</a>
+					</h3>
+				</li>
+							<li class="popular-item">
+					<div class="post-image">
+						<a href="https://www.rosa.gr/opinions/to-akrodexio-misos-diatazei-oi-kyverniseis-ekteloun/">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[2][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::OL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="300" height="200" src="https://www.rosa.gr/wp-content/uploads/2026/06/belfast26-300x200.avif" class="attachment-medium size-medium wp-post-image" alt="Μπέλφαστ" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/belfast26-300x200.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/belfast26-768x512.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/belfast26-150x100.avif 150w, https://www.rosa.gr/wp-content/uploads/2026/06/belfast26.avif 935w" sizes="(max-width: 300px) 100vw, 300px">						</a>
+					</div>
+					<div class="post-meta">
+						<span class="category">
+							OPINIONS						</span>
+						<span class="date">
+							11.06.2026						</span>
+					</div>
+					<h3>
+						<a href="https://www.rosa.gr/opinions/to-akrodexio-misos-diatazei-oi-kyverniseis-ekteloun/">
+							Το ακροδεξιό μίσος διατάζει, οι κυβερνήσεις εκτελούν						</a>
+					</h3>
+				</li>
+							<li class="popular-item">
+					<div class="post-image">
+						<a href="https://www.rosa.gr/politiki/tsipras-to-dilimma-ton-eklogon-den-einai-statherotita-i-chaos-alla-stasimotita-i-proodos-ta-5-metra-pou-proteinei/">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[2][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::OL]/*[3][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="300" height="200" src="https://www.rosa.gr/wp-content/uploads/2026/06/6997290-300x200.avif" class="attachment-medium size-medium wp-post-image" alt="Τσίπρας" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/6997290-300x200.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/6997290-1024x683.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/6997290-768x512.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/6997290-1536x1024.avif 1536w, https://www.rosa.gr/wp-content/uploads/2026/06/6997290-150x100.avif 150w, https://www.rosa.gr/wp-content/uploads/2026/06/6997290.avif 1920w" sizes="(max-width: 300px) 100vw, 300px">						</a>
+					</div>
+					<div class="post-meta">
+						<span class="category">
+							ΠΟΛΙΤΙΚΗ						</span>
+						<span class="date">
+							12.06.2026						</span>
+					</div>
+					<h3>
+						<a href="https://www.rosa.gr/politiki/tsipras-to-dilimma-ton-eklogon-den-einai-statherotita-i-chaos-alla-stasimotita-i-proodos-ta-5-metra-pou-proteinei/">
+							Τσίπρας: «Το δίλημμα των εκλογών  δεν είναι σταθερότητα ή χάος, αλλά στασιμότητα ή προοδος»- Τα 5 μέτρα που προτείνει						</a>
+					</h3>
+				</li>
+							<li class="popular-item">
+					<div class="post-image">
+						<a href="https://www.rosa.gr/editorial/apo-to-belfast-ston-voridi-enas-fasismos-dromos/">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[2][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::OL]/*[4][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="300" height="169" src="https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20-300x169.avif" class="attachment-medium size-medium wp-post-image" alt="Βορίδης Ρόμπινσον Μπέλφαστ" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20-300x169.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20-1024x576.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20-768x432.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20-1536x864.avif 1536w, https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20-150x84.avif 150w, https://www.rosa.gr/wp-content/uploads/2026/06/Untitled-design-20.avif 1920w" sizes="(max-width: 300px) 100vw, 300px">						</a>
+					</div>
+					<div class="post-meta">
+						<span class="category">
+							EDITORIAL						</span>
+						<span class="date">
+							10.06.2026						</span>
+					</div>
+					<h3>
+						<a href="https://www.rosa.gr/editorial/apo-to-belfast-ston-voridi-enas-fasismos-dromos/">
+							Από το Μπέλφαστ στον Βορίδη ένας φασισμός δρόμος						</a>
+					</h3>
+				</li>
+							<li class="popular-item">
+					<div class="post-image">
+						<a href="https://www.rosa.gr/koinonia/irakleio-kritis-xypolitoi-prosfyges-kai-metanastes-richnoun-nero-stin-asfalto-gia-na-antexoun-ta-egkavmata/">
+							<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[2][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::OL]/*[5][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="300" height="147" src="https://www.rosa.gr/wp-content/uploads/2026/06/metanastes-1-300x147.avif" class="attachment-medium size-medium wp-post-image" alt="μετανάστες" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/metanastes-1-300x147.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/metanastes-1-1024x502.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/metanastes-1-768x376.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/metanastes-1-150x73.avif 150w, https://www.rosa.gr/wp-content/uploads/2026/06/metanastes-1.avif 1274w" sizes="(max-width: 300px) 100vw, 300px">						</a>
+					</div>
+					<div class="post-meta">
+						<span class="category">
+							ΚΟΙΝΩΝΙΑ						</span>
+						<span class="date">
+							12.06.2026						</span>
+					</div>
+					<h3>
+						<a href="https://www.rosa.gr/koinonia/irakleio-kritis-xypolitoi-prosfyges-kai-metanastes-richnoun-nero-stin-asfalto-gia-na-antexoun-ta-egkavmata/">
+							Ηράκλειο Κρήτης: Ξυπόλητοι πρόσφυγες και μετανάστες ρίχνουν νερό στην άσφαλτο για να αντέξουν τα εγκαύματα						</a>
+					</h3>
+				</li>
+					</ol>
+	</div>
+</div>
+
+	
+	
+<div class="posts-container">
+	
+<article id="post-313272" class="post-item top-category post-313272 post type-post status-publish format-standard has-post-thumbnail hentry category-politiki category-editorial tag-alexis-tsipras tag-mitsotakis tag-el-a-s">
+
+	
+	<div class="post-content">
+
+					<div class="post-author-avatar">
+				<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[2][self::DIV]/*[3][self::DIV]/*[1][self::ARTICLE]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::IMG]" width="683" height="1024" src="https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης-683x1024.png" class="attachment-large size-large" alt="Σπύρος Ραπανάκης" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης-683x1024.png 683w, https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης-200x300.png 200w, https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης-768x1152.png 768w, https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης-1024x1536.png 1024w, https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης-150x225.png 150w, https://www.rosa.gr/wp-content/uploads/2025/11/Σπύρος_Ραπανάκης.png 1280w" sizes="(max-width: 683px) 100vw, 683px">			</div>
+		
+		<div class="post-meta">
+
+							<div class="post-category">
+					<a href="
+					https://www.rosa.gr/editorial/					">
+						EDITORIAL					</a>
+				</div>
+			
+							<span class="post-author-name"><a href="https://www.rosa.gr/author/srapanakis/">Σπυρος Ραπανακης</a></span>
+			
+							<div class="post-date">
+					<span class="published-date">16.06.2026</span>
+				</div>
+			
+			<h2 class="post-title">
+				<a href="https://www.rosa.gr/editorial/i-proti-kyriaki/">
+					Η πρώτη Κυριακή				</a>
+			</h2>
+		</div>
+	</div>
+
+</article>
+</div>
+
+			<div class="ad-section ">
+			<div class="ad-placement">
+				<div class="ad-wraper">
+					<!-- /22767323261/rosa.gr/sidebar3 -->
+                            <div id="sidebar3" data-ocm-ad="" style="min-height:unset" data-oau-code="/22767323261/rosa.gr/sidebar3">
+                            </div>				</div>
+			</div>
+		</div>
+		
+	</div>
+
+<div class="related">
+	<div class="title-row">
+		<h2 class="section-title">
+			Σχετικά Άρθρα		</h2>
+	</div>
+	
+	<ul class="related-posts-list">
+					<li class="related-post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/dyo-stous-pente-amerikanous-pistevoun-oti-oi-ipa-den-tha-antexoun-alla-250-chronia/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[3][self::DIV]/*[2][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1274" height="623" src="https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos.jpg" class="attachment-full size-full" alt="Λευκός Οίκος" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos.jpg 1274w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-300x147.jpg 300w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-1024x501.jpg 1024w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-768x376.jpg 768w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-150x73.jpg 150w" sizes="(max-width: 1274px) 100vw, 1274px">			</a>				</div>
+	<div class="post-info">
+			<div class="top-row">
+							<div class="spotlight-title  green">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026				</div>
+					</div>
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/dyo-stous-pente-amerikanous-pistevoun-oti-oi-ipa-den-tha-antexoun-alla-250-chronia/">						Δύο στους πέντε Αμερικανούς πιστεύουν ότι οι ΗΠΑ δεν θα αντέξουν άλλα 250 χρόνια						</a>		</h3>
+			</div>
+	</div>
+			</li>
+					<li class="related-post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/symfonia-ipa-iran-tin-paraskevi-sto-biourgkenstok-tis-elvetias-oi-ypografes/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[3][self::DIV]/*[2][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1920" height="1280" src="https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010.avif" class="attachment-full size-full" alt="Ιράν" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010.avif 1920w, https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010-300x200.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010-1024x683.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010-768x512.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010-1536x1024.avif 1536w, https://www.rosa.gr/wp-content/uploads/2026/06/AP26163613213010-150x100.avif 150w" sizes="(max-width: 1920px) 100vw, 1920px">			</a>				</div>
+	<div class="post-info">
+			<div class="top-row">
+							<div class="spotlight-title  green">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026				</div>
+					</div>
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/symfonia-ipa-iran-tin-paraskevi-sto-biourgkenstok-tis-elvetias-oi-ypografes/">						Συμφωνία ΗΠΑ-Ιράν: Την Παρασκευή στο Μπιούργκενστοκ της Ελβετίας οι υπογραφές &nbsp;						</a>		</h3>
+			</div>
+	</div>
+			</li>
+					<li class="related-post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/synagermos-sti-dytiki-evropi-erchetai-istorikos-kafsonas-me-45aria/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[3][self::DIV]/*[2][self::UL]/*[3][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1274" height="851" src="https://www.rosa.gr/wp-content/uploads/2026/06/kafsonas-1.avif" class="attachment-full size-full" alt="" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/kafsonas-1.avif 1274w, https://www.rosa.gr/wp-content/uploads/2026/06/kafsonas-1-300x200.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/kafsonas-1-1024x684.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/kafsonas-1-768x513.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/kafsonas-1-150x100.avif 150w" sizes="(max-width: 1274px) 100vw, 1274px">			</a>				</div>
+	<div class="post-info">
+			<div class="top-row">
+							<div class="spotlight-title  green">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026				</div>
+					</div>
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/synagermos-sti-dytiki-evropi-erchetai-istorikos-kafsonas-me-45aria/">						Συναγερμός στη Δυτική Ευρώπη: Έρχεται ιστορικός καύσωνας με 45άρια						</a>		</h3>
+			</div>
+	</div>
+			</li>
+					<li class="related-post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/iran-kai-oman-dilonoun-pos-tha-tirisoun-to-diethnes-dikaio-oson-afora-ta-stena-tou-ormouz/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[3][self::DIV]/*[2][self::UL]/*[4][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1064" height="623" src="https://www.rosa.gr/wp-content/uploads/2026/04/hormuz-1.jpg" class="attachment-full size-full" alt="Στενά του Ορμούζ" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/04/hormuz-1.jpg 1064w, https://www.rosa.gr/wp-content/uploads/2026/04/hormuz-1-300x176.jpg 300w, https://www.rosa.gr/wp-content/uploads/2026/04/hormuz-1-1024x600.jpg 1024w, https://www.rosa.gr/wp-content/uploads/2026/04/hormuz-1-768x450.jpg 768w, https://www.rosa.gr/wp-content/uploads/2026/04/hormuz-1-150x88.jpg 150w" sizes="(max-width: 1064px) 100vw, 1064px">			</a>				</div>
+	<div class="post-info">
+			<div class="top-row">
+							<div class="spotlight-title  green">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026				</div>
+					</div>
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/iran-kai-oman-dilonoun-pos-tha-tirisoun-to-diethnes-dikaio-oson-afora-ta-stena-tou-ormouz/">						Ιράν και Ομάν δηλώνουν πως θα τηρήσουν το διεθνές δίκαιο όσον αφορά τα Στενά του Ορμούζ						</a>		</h3>
+			</div>
+	</div>
+			</li>
+					<li class="related-post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/dysarestimenos-me-tis-epitheseis-netaniachou-ston-livano-o-trab-an-den-imoun-ego-den-tha-ypirche-israil/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[3][self::DIV]/*[2][self::UL]/*[5][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1274" height="623" src="https://www.rosa.gr/wp-content/uploads/2026/06/TRUMP-1.avif" class="attachment-full size-full" alt="" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/TRUMP-1.avif 1274w, https://www.rosa.gr/wp-content/uploads/2026/06/TRUMP-1-300x147.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/TRUMP-1-1024x501.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/TRUMP-1-768x376.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/TRUMP-1-150x73.avif 150w" sizes="(max-width: 1274px) 100vw, 1274px">			</a>				</div>
+	<div class="post-info">
+			<div class="top-row">
+							<div class="spotlight-title  green">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026				</div>
+					</div>
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/dysarestimenos-me-tis-epitheseis-netaniachou-ston-livano-o-trab-an-den-imoun-ego-den-tha-ypirche-israil/">						Δυσαρεστημένος με τις επιθέσεις Νετανιάχου στον Λίβανο ο Τραμπ: «Αν δεν ήμουν εγώ δεν θα υπήρχε Ισραήλ»						</a>		</h3>
+			</div>
+	</div>
+			</li>
+					<li class="related-post">
+				
+
+
+
+
+
+
+
+		<div class="post-image">
+			<a href="https://www.rosa.gr/kosmos/aragtsi-o-polemos-den-borei-na-lixei-choris-tin-apochorisi-tou-israil-apo-ton-livano/">			<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[2][self::SECTION]/*[3][self::DIV]/*[2][self::UL]/*[6][self::LI]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1274" height="623" src="https://www.rosa.gr/wp-content/uploads/2026/06/Abbas-Araghchi.avif" class="attachment-full size-full" alt="Αμπάς Αραγτσί" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2026/06/Abbas-Araghchi.avif 1274w, https://www.rosa.gr/wp-content/uploads/2026/06/Abbas-Araghchi-300x147.avif 300w, https://www.rosa.gr/wp-content/uploads/2026/06/Abbas-Araghchi-1024x501.avif 1024w, https://www.rosa.gr/wp-content/uploads/2026/06/Abbas-Araghchi-768x376.avif 768w, https://www.rosa.gr/wp-content/uploads/2026/06/Abbas-Araghchi-150x73.avif 150w" sizes="(max-width: 1274px) 100vw, 1274px">			</a>				</div>
+	<div class="post-info">
+			<div class="top-row">
+							<div class="spotlight-title  green">
+					<a href="https://www.rosa.gr/kosmos/">
+						ΚΟΣΜΟΣ						-					</a>
+				</div>
+										<div class="date">
+					16.06.2026				</div>
+					</div>
+		<div class="title">
+		<h3>
+			<a href="https://www.rosa.gr/kosmos/aragtsi-o-polemos-den-borei-na-lixei-choris-tin-apochorisi-tou-israil-apo-ton-livano/">						Αραγτσί: Ο πόλεμος δεν μπορεί να λήξει χωρίς την αποχώρηση του Ισραήλ από τον Λίβανο						</a>		</h3>
+			</div>
+	</div>
+			</li>
+			</ul>
+</div>
+
+<div class="ad-placement ">
+	<div class="ad-wraper">
+		<div id="ocm-outbrain-feed"></div>	</div>
+</div>
+
+</section>
+
+<div class="read-more-posts posts-container" style="cursor: pointer;">
+	<h3>ΔΕΙΤΕ ΕΠΙΣΗΣ	<svg width="11" height="6" viewBox="0 0 11 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M10 1L5.5 5L1 1" stroke="white"></path>
+	</svg>
+
+	</h3>
+	
+<article id="post-313395" class="post-item post-313395 post type-post status-publish format-standard has-post-thumbnail hentry category-kosmos tag-ipa tag-dimoskopisi">
+
+			<div class="post-thumbnail">
+			<a href="https://www.rosa.gr/kosmos/dyo-stous-pente-amerikanous-pistevoun-oti-oi-ipa-den-tha-antexoun-alla-250-chronia/">
+				<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[3][self::DIV]/*[2][self::ARTICLE]/*[1][self::DIV]/*[1][self::A]/*[1][self::IMG]" width="1024" height="501" src="https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-1024x501.jpg" class="attachment-large size-large wp-post-image" alt="Λευκός Οίκος" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-1024x501.jpg 1024w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-300x147.jpg 300w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-768x376.jpg 768w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos-150x73.jpg 150w, https://www.rosa.gr/wp-content/uploads/2025/11/leukos_oikos.jpg 1274w" sizes="(max-width: 1024px) 100vw, 1024px">			</a>
+		</div>
+	
+	<div class="post-content">
+
+		
+		<div class="post-meta">
+
+							<div class="post-category">
+					<a href="
+					https://www.rosa.gr/kosmos/					">
+						ΚΟΣΜΟΣ					</a>
+				</div>
+			
+			
+							<div class="post-date">
+					<span class="published-date">16.06.2026</span>
+				</div>
+			
+			<h2 class="post-title">
+				<a href="https://www.rosa.gr/kosmos/dyo-stous-pente-amerikanous-pistevoun-oti-oi-ipa-den-tha-antexoun-alla-250-chronia/">
+					Δύο στους πέντε Αμερικανούς πιστεύουν ότι οι ΗΠΑ δεν θα αντέξουν άλλα 250 χρόνια				</a>
+			</h2>
+		</div>
+	</div>
+
+</article>
+</div>
+
+	<section class="block posts-authors--block">
+		<div class="container">
+			
+<div class="title-row">
+			<a href="https://www.rosa.gr/opinions/">
+				<h2 class="section-title" data-text="Opinions">
+			Opinions		</h2>
+				</a>
+		
+	<!-- if cta -->
+		<!-- end if cta -->
+	 
+</div>
+				<div class="posts-authors--posts-container">
+				<div class="posts-container posts-authors--posts">
+					
+<article id="post-313370" class="post-item post-313370 post type-post status-publish format-standard has-post-thumbnail hentry category-opinions tag-souidia tag-mastropeia tag-sexoualiki-kakopoiisi-2">
+
+	
+	<div class="post-content">
+
+					<div class="post-author-avatar">
+				<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[4][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[1][self::ARTICLE]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::IMG]" width="683" height="1024" src="https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6-683x1024.png" class="attachment-large size-large" alt="Ειρήνη Δερμιτζάκη" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6-683x1024.png 683w, https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6-200x300.png 200w, https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6-768x1152.png 768w, https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6-1024x1536.png 1024w, https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6-150x225.png 150w, https://www.rosa.gr/wp-content/uploads/2025/11/SELECTED-6.png 1280w" sizes="(max-width: 683px) 100vw, 683px">			</div>
+		
+		<div class="post-meta">
+
+			
+							<span class="post-author-name"><a href="https://www.rosa.gr/author/idermitzaki/">Ειρηνη Δερμιτζακη</a></span>
+			
+							<div class="post-date">
+					<span class="published-date">16.06.2026</span>
+				</div>
+			
+			<h2 class="post-title">
+				<a href="https://www.rosa.gr/opinions/mono-4-chronia-fylaki-se-antra-pou-exedide-ti-syzygo-tou-mechri-pote-tha-perithalptontai-oi-kakopoiites/">
+					(Μόνο) 4 χρόνια φυλακή σε άντρα που εξέδιδε τη σύζυγό του – Μέχρι πότε θα περιθάλπτονται οι κακοποιητές;				</a>
+			</h2>
+		</div>
+	</div>
+
+</article>
+
+<article id="post-313197" class="post-item post-313197 post type-post status-publish format-standard has-post-thumbnail hentry category-opinions tag-gynaikoktonia">
+
+	
+	<div class="post-content">
+
+					<div class="post-author-avatar">
+				<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[4][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[2][self::ARTICLE]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::IMG]" width="683" height="1024" src="https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242-683x1024.png" class="attachment-large size-large" alt="Βαρβάρα Μανταίου" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242-683x1024.png 683w, https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242-200x300.png 200w, https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242-768x1152.png 768w, https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242-1024x1536.png 1024w, https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242-150x225.png 150w, https://www.rosa.gr/wp-content/uploads/2025/11/IMG_03242.png 1280w" sizes="(max-width: 683px) 100vw, 683px">			</div>
+		
+		<div class="post-meta">
+
+			
+							<span class="post-author-name"><a href="https://www.rosa.gr/author/vmantaiou/">Βαρβαρα Μανταιου</a></span>
+			
+							<div class="post-date">
+					<span class="published-date">15.06.2026</span>
+				</div>
+			
+			<h2 class="post-title">
+				<a href="https://www.rosa.gr/opinions/otan-viazeste-na-peite-oikogeneiaki-tragodia-emeis-idi-skeftomaste-gynaikoktonia/">
+					Όταν βιάζεστε να πείτε “οικογενειακή τραγωδία”, εμείς ήδη σκεφτόμαστε “γυναικοκτονία”				</a>
+			</h2>
+		</div>
+	</div>
+
+</article>
+
+<article id="post-312986" class="post-item post-312986 post type-post status-publish format-standard has-post-thumbnail hentry category-opinions tag-stratos">
+
+	
+	<div class="post-content">
+
+					<div class="post-author-avatar">
+				<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[3][self::SECTION]/*[4][self::SECTION]/*[1][self::DIV]/*[2][self::DIV]/*[1][self::DIV]/*[3][self::ARTICLE]/*[1][self::DIV]/*[1][self::DIV]/*[1][self::IMG]" width="683" height="1024" src="https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου-683x1024.png" class="attachment-large size-large" alt="Στεφανία Παπαδημητρίου" decoding="async" srcset="https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου-683x1024.png 683w, https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου-200x300.png 200w, https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου-768x1152.png 768w, https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου-1024x1536.png 1024w, https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου-150x225.png 150w, https://www.rosa.gr/wp-content/uploads/2025/11/Στεφανία_Παπαδημητρίου.png 1280w" sizes="(max-width: 683px) 100vw, 683px">			</div>
+		
+		<div class="post-meta">
+
+			
+							<span class="post-author-name"><a href="https://www.rosa.gr/author/spapadimitriou/">Στεφανια Παπαδημητριου</a></span>
+			
+							<div class="post-date">
+					<span class="published-date">15.06.2026</span>
+				</div>
+			
+			<h2 class="post-title">
+				<a href="https://www.rosa.gr/opinions/panta-tha-tous-ftaine-oi-gynaikes-eite-pane-strato-eite-ochi/">
+					Πάντα θα τους φταίνε οι γυναίκες, είτε πάνε στρατό είτε όχι				</a>
+			</h2>
+		</div>
+	</div>
+
+</article>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	
+</main>
+<footer>
+	<div class="footer-container">
+		<div class="footer-row footer-newsletter-container">
+			<div class="footer-newsletter">
+				
+				<form action="https://www.rosa.gr/wp-admin/admin-post.php" method="POST">
+					<div class="newsletter-form-fields">
+						<h3>Newsletter</h3>
+						<p>Σκέψου ριζοσπαστικά, εναλλακτικά και προοδευτικά, διαβάζοντας τα νέα από τη ROSA.</p>
+
+						<div class="subscribe-container">
+							<input type="email" id="email" name="user_email" placeholder="youremail@gmail.com" required="">
+							<!-- Hidden field to tell WordPress which handler to use -->
+							<input type="hidden" name="action" value="footer_subscribe_newsletter">
+
+							<button type="submit">ΕΓΓΡΑΦΗ</button>
+						</div>
+
+						<div class="terms-container">
+							<label>
+								<input type="checkbox" name="AGREE_TO_TERMS" value="1" required=""> Αποδέχομαι την <a href="/politiki-aporritou/" target="_blank">Πολιτική Προστασίας Προσωπικών Δεδομένων</a>
+							</label>
+						</div>
+					</div>
+				</form>
+
+			</div>
+
+		</div>
+		<div class="footer-row footer-logo-social">
+			<div class="footer-logo">
+				<div class="logo-container">
+										<a href="/">
+						<svg width="303" height="89" viewBox="0 0 303 89" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<g clip-path="url(#clip0_5053_46)">
+								<path d="M0 1.2964L46.8696 1.28906C58.9218 1.93234 74.2827 7.1942 75.0237 21.3858C75.8234 36.6933 59.074 44.654 46.0351 45.5285V46.0773C49.5511 46.2847 53.0635 46.793 56.5245 47.4207C57.5003 47.5978 62.5075 48.5026 62.922 48.911L79.0505 84.2528H86.0203V86.8223H45.6692V84.2528H53.7394L39.7999 46.9958H30.8126V84.2528H38.516V86.8223H0V84.2528H7.33656V3.86585H0V1.2964ZM30.8136 44.2429H42.6438C43.282 44.2429 47.3538 40.564 47.9646 39.8399C53.8109 32.9162 53.7339 16.2497 48.4928 9.02401C46.5652 6.36647 42.7116 3.86493 39.3423 3.86493H30.8136V44.242V44.2429Z" fill="white"></path>
+								<path d="M220.439 5.35928L219.546 31.7631L218.938 31.7291C213.212 24.3713 207.817 16.674 202.194 9.20794C201.443 8.21044 198.479 3.9314 197.769 3.54139C195.25 2.1594 190.053 3.30188 187.647 4.7059C179.5 9.46122 182.712 19.6931 188.174 25.2551C199.673 36.9644 222.259 42.3134 223.579 62.1385C225.532 91.4715 186.943 91.4899 167.196 86.0729C165.153 85.5122 163.151 84.8378 161.215 83.9825L161.77 56.3545L162.776 56.5417L185.208 85.7141C195.231 87.6908 204.943 82.2793 203.197 70.971C201.193 57.9953 180.089 51.1633 170.939 42.8677C155.547 28.9128 161.502 8.14896 180.889 2.34752C193.429 -1.40479 208.555 0.0928294 220.439 5.35744V5.35928Z" fill="white"></path>
+								<path d="M158.47 29.9275H133.709C132.642 18.71 131.147 1.81592 116.002 2.94098C101.539 4.01555 101.532 28.562 101.252 39.0197C101.034 47.1685 101.019 55.454 102.001 63.5817C103.248 73.9008 106.441 87.5005 119.838 85.5147C129.396 84.0988 131.948 73.2887 132.974 65.1647H156.085C150.138 78.078 137.909 86.348 123.872 88.0823C99.9727 91.0354 79.4129 77.3751 75.4356 53.2728C70.3201 22.2724 91.62 -3.33582 123.687 0.589014C140.451 2.6409 153.741 13.6932 158.47 29.9284V29.9275Z" fill="white"></path>
+								<path d="M223.949 84.2531L249.045 18.9579L243.941 4.78559L266.394 0L296.397 84.2531H303V87.0061H264.208C263.759 86.394 263.765 84.8431 264.208 84.2531H272.186L264.032 61.6658L235.496 61.7631L226.883 84.2531H239.447C240.018 84.9432 239.6 86.1361 239.722 87.0061H214.044V84.2531H223.949ZM263.199 59.1092L250.725 22.7699L236.604 59.1092H263.199Z" fill="white"></path>
+								<path d="M152.969 58.0083C152.727 60.1272 150.971 59.6133 149.615 59.8849C149.121 59.984 148.663 60.475 148.096 60.5658C147.325 60.6888 146.562 60.4172 145.932 60.4575C144.299 60.5603 143.056 61.2476 141.351 60.1804C139.995 59.3325 140.827 59.5325 139.014 59.0315C138.004 58.7525 137.15 57.7991 137.192 56.7236C136.267 57.2099 134.968 56.5226 134.47 55.6875C134.301 55.404 134.152 54.6423 134.038 54.5579C133.902 54.4579 133.099 54.4166 132.755 54.2826C131.17 53.6641 130.664 51.6186 131.851 50.3587L125.441 44.6986L131.59 35.7908C132.268 35.3742 133.125 36.0799 133.887 36.2662C136.545 36.9168 138.823 34.7585 142.062 35.0604C143.119 35.1586 145.187 36.3414 145.51 36.3121C145.77 36.2891 146.462 35.8285 146.915 35.7101C148.422 35.3155 149.568 35.1834 151.097 35.5633C153.293 36.1093 154.376 37.5427 156.891 37.2499C157.517 37.1774 158.765 36.5351 159.202 36.8067L164.625 46.2797L158.29 50.9432C159.604 52.1454 160.707 53.7696 159.211 55.3553C158.201 56.4263 156.913 55.9904 156.808 56.0675C156.634 56.195 156.559 56.797 156.354 57.0842C155.422 58.3891 154.432 58.3515 152.969 58.0092V58.0083ZM149.874 48.672C150.079 48.5408 150.652 48.6427 150.869 48.8225L156.822 54.7919C158.06 55.2333 158.942 54.4661 158.615 53.1823L148.068 42.6164C146.601 42.2356 144.372 47.9498 141.335 47.5396C140.904 47.4809 140.181 47.0827 139.965 46.7009C138.765 44.5848 142.315 38.4337 144.343 37.1784C143.322 36.3699 141.872 36.0845 140.589 36.1726C138.378 36.3249 136.731 37.8987 134.398 37.5885C133.922 37.5252 132.297 36.8361 132.059 36.9829L126.948 44.3673L132.723 49.3704C133.026 49.4245 133.396 48.75 133.755 48.6032C134.997 48.0957 136.768 48.7106 137.012 50.1164C139.026 48.973 140.995 49.1923 141.585 51.6911C142.668 51.38 144.242 52.2647 144.493 53.3659C144.593 53.8045 144.433 54.2753 144.624 54.702C144.722 54.9231 145.159 55.1746 145.343 55.4508C146.516 57.2054 144.978 57.7303 145.11 58.4405C145.979 59.6849 147.463 59.6445 148.748 59.1077C148.419 58.3965 146.389 57.1714 146.667 56.4061C147.16 55.047 149.481 58.4332 150.207 58.6635C151.622 59.1122 152.304 57.6935 151.582 56.5483C150.963 55.5646 148.49 53.8733 148.107 53.0511C147.944 52.7015 147.923 52.3381 148.312 52.15L149.034 52.3096C150.276 53.1823 152.561 56.4354 153.75 56.9539C154.938 57.4724 156.117 55.9674 155.252 54.8965C154.633 53.9669 149.811 49.831 149.703 49.263C149.682 49.1529 149.825 48.7032 149.874 48.672ZM158.627 38.0198C157.631 38.2025 156.494 38.62 155.469 38.5392C153.792 38.4071 151.881 36.7177 149.94 36.5378C145.763 36.1497 142.703 39.8258 141.409 43.4138C140.9 44.8261 140.134 47.0973 142.576 46.0503C144.345 45.2923 146.158 40.838 148.433 41.3427L157.46 50.0834L163.216 45.9906L158.628 38.0189L158.627 38.0198ZM134.578 49.5943C134.209 49.6613 132.558 51.2075 132.46 51.5324C132.12 52.6629 133.161 53.6458 134.255 53.141C134.483 53.0364 135.936 51.4893 136.017 51.224C136.288 50.3413 135.471 49.4309 134.577 49.5943H134.578ZM138.611 50.7028C138.177 50.7983 135.671 53.2301 135.499 53.6503C134.974 54.9277 135.816 56.1161 137.191 55.527C137.387 55.4425 140.127 52.6941 140.216 52.4996C140.732 51.38 139.791 50.4422 138.611 50.7028ZM138.708 57.5935C139.071 57.9376 139.984 57.8991 140.413 57.6504C140.597 57.544 143.122 54.9644 143.222 54.7736C143.945 53.3952 142.477 52.3078 141.137 53.2365C140.186 53.8954 137.491 56.4419 138.708 57.5935ZM144.346 59.6592C144.282 59.1324 143.94 58.8929 143.967 58.2873C144.004 57.466 145.296 56.3198 143.914 55.8206L141.232 58.4671C141.982 59.3628 143.184 59.772 144.346 59.6592Z" fill="white"></path>
+							</g>
+							<defs>
+								<clipPath id="clip0_5053_46">
+									<rect width="303" height="88.8377" fill="white"></rect>
+								</clipPath>
+							</defs>
+						</svg>
+					</a>
+				</div>
+				<div class="horizontal-line"></div>
+			</div>
+
+			<div class="socials-container">
+    <ul class="socials">
+        <li>
+            <a href="https://www.facebook.com/RosaProgressive/">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16.068" height="30" viewBox="0 0 16.068 30">
+                    <path id="Icon_awesome-facebook-f" data-name="Icon awesome-facebook-f" d="M16.624,16.875l.833-5.429h-5.21V7.922a2.715,2.715,0,0,1,3.061-2.933h2.368V.367A28.882,28.882,0,0,0,13.473,0C9.183,0,6.378,2.6,6.378,7.308v4.138H1.609v5.429H6.378V30h5.869V16.875Z" transform="translate(-1.609)" fill="#ffffff"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://www.instagram.com/rosa_progressive/">
+                <svg xmlns="http://www.w3.org/2000/svg" width="30" height="29.993" viewBox="0 0 30 29.993">
+                    <path id="Icon_awesome-instagram" data-name="Icon awesome-instagram" d="M15,9.544a7.69,7.69,0,1,0,7.69,7.69A7.678,7.678,0,0,0,15,9.544Zm0,12.689a5,5,0,1,1,5-5,5.009,5.009,0,0,1-5,5Zm9.8-13A1.794,1.794,0,1,1,23,7.436,1.789,1.789,0,0,1,24.8,9.23Zm5.093,1.82a8.876,8.876,0,0,0-2.423-6.284,8.935,8.935,0,0,0-6.284-2.423c-2.476-.141-9.9-.141-12.375,0A8.922,8.922,0,0,0,2.523,4.759,8.9,8.9,0,0,0,.1,11.044c-.141,2.476-.141,9.9,0,12.375A8.876,8.876,0,0,0,2.523,29.7a8.946,8.946,0,0,0,6.284,2.423c2.476.141,9.9.141,12.375,0A8.876,8.876,0,0,0,27.467,29.7a8.935,8.935,0,0,0,2.423-6.284c.141-2.476.141-9.892,0-12.368Zm-3.2,15.025a5.062,5.062,0,0,1-2.851,2.851c-1.974.783-6.659.6-8.841.6s-6.873.174-8.841-.6a5.062,5.062,0,0,1-2.851-2.851c-.783-1.974-.6-6.659-.6-8.841s-.174-6.873.6-8.841A5.062,5.062,0,0,1,6.157,5.542c1.974-.783,6.659-.6,8.841-.6s6.873-.174,8.841.6A5.062,5.062,0,0,1,26.69,8.393c.783,1.974.6,6.659.6,8.841S27.473,24.108,26.69,26.075Z" transform="translate(0.005 -2.238)" fill="#ffffff"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://twitter.com/rosa_progress">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32.052" height="30" viewBox="0 0 32.052 30">
+                    <path id="path1009" d="M6.368,21.9,18.743,38.45,6.29,51.9h2.8L20,40.122,28.807,51.9h9.535L25.271,34.423,36.862,21.9h-2.8L24.019,32.745,15.905,21.9Zm4.122,2.065h4.382l19.347,25.87h-4.38Z" transform="translate(-6.29 -21.9)" fill="#ffffff"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://www.tiktok.com/@rosa_progressive">
+                <svg xmlns="http://www.w3.org/2000/svg" width="26.063" height="30" viewBox="0 0 26.063 30">
+                    <path id="Icon_simple-tiktok" data-name="Icon simple-tiktok" d="M16.057.025C17.695,0,19.32.012,20.945,0a7.786,7.786,0,0,0,2.187,5.212,8.815,8.815,0,0,0,5.3,2.237v5.037a13.379,13.379,0,0,1-5.25-1.212,15.444,15.444,0,0,1-2.025-1.162c-.012,3.65.013,7.3-.025,10.937a9.547,9.547,0,0,1-1.687,4.925,9.313,9.313,0,0,1-7.387,4.012,9.114,9.114,0,0,1-5.1-1.287,9.426,9.426,0,0,1-4.562-7.137c-.025-.625-.037-1.25-.013-1.862a9.41,9.41,0,0,1,10.912-8.35c.025,1.85-.05,3.7-.05,5.55A4.289,4.289,0,0,0,7.77,19.55a4.959,4.959,0,0,0-.175,2.012A4.254,4.254,0,0,0,11.97,25.15a4.2,4.2,0,0,0,3.462-2.012,2.884,2.884,0,0,0,.512-1.325c.125-2.237.075-4.462.087-6.7.012-5.037-.013-10.062.025-15.087Z" transform="translate(-2.369)" fill="#ffffff"></path>
+                </svg>
+            </a>
+        </li>
+        <li>
+            <a href="https://www.youtube.com/@ROSAProgressive" target="_blank">
+                <svg height="30px" width="30px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 461.001 461.001" xml:space="preserve" fill="#000000">
+                    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+                    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+                    <g id="SVGRepo_iconCarrier">
+                        <g>
+                            <path style="fill:#ffffff;" d="M365.257,67.393H95.744C42.866,67.393,0,110.259,0,163.137v134.728 c0,52.878,42.866,95.744,95.744,95.744h269.513c52.878,0,95.744-42.866,95.744-95.744V163.137 C461.001,110.259,418.135,67.393,365.257,67.393z M300.506,237.056l-126.06,60.123c-3.359,1.602-7.239-0.847-7.239-4.568V168.607 c0-3.774,3.982-6.22,7.348-4.514l126.06,63.881C304.363,229.873,304.298,235.248,300.506,237.056z"></path>
+                        </g>
+                    </g>
+                </svg>
+            </a>
+        </li>
+    </ul>
+</div>		</div>
+
+
+		<div class="footer-row footer-menu-container">
+			<ul class="footer-main"><li id="menu-item-238196" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238196"><a href="https://www.rosa.gr/manifesto/">Manifesto</a></li>
+<li id="menu-item-238208" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238208"><a href="https://www.rosa.gr/rosa-team/">Rosa Team</a></li>
+<li id="menu-item-238197" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238197"><a href="https://www.rosa.gr/epikoinonia/">Επικοινωνια</a></li>
+<li id="menu-item-238198" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238198"><a href="https://www.rosa.gr/diafimisteite-sto-rosa-gr/">Διαφημιστειτε στο Rosa.gr</a></li>
+<li id="menu-item-238199" class="menu-item menu-item-type-custom menu-item-object-custom footer-main-item menu-item-238199"><a href="https://smb.rosa.gr">Στηριζουμε τις ΜμΕ</a></li>
+<li id="menu-item-283150" class="menu-item menu-item-type-custom menu-item-object-custom footer-main-item menu-item-283150"><a href="https://creators.rosa.gr/">Γινε Creator στη Rosa</a></li>
+<li id="menu-item-238200" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238200"><a href="https://www.rosa.gr/taftotita/">Ταυτοτητα</a></li>
+<li id="menu-item-238201" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238201"><a href="https://www.rosa.gr/oroi-chrisis/">Οροι χρησης</a></li>
+<li id="menu-item-238202" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy footer-main-item menu-item-238202"><a rel="privacy-policy" href="https://www.rosa.gr/politiki-aporritou/">Πολιτικη Απορρητου</a></li>
+<li id="menu-item-238203" class="menu-item menu-item-type-post_type menu-item-object-page footer-main-item menu-item-238203"><a href="https://www.rosa.gr/oroi-diagonismon/">Οροι Διαγωνισμων</a></li>
+</ul>		</div>
+
+		<div class="footer-row footer-bottom">
+			<div class="mht-container">
+				ΑΡΙΘΜΟΣ ΠΙΣΤΟΠΟΙΗΣΗΣ
+				Μ.Η.Τ. 242133
+				<img data-od-unknown-tag="" data-od-xpath="/HTML/BODY/MAIN/*[4][self::FOOTER]/*[1][self::DIV]/*[4][self::DIV]/*[1][self::DIV]/*[1][self::IMG]" src="https://rosa.gr/wp-content/themes/rosa-theme/assets/images/mht-icon.png">
+			</div>
+
+			<div class="footer-rights">
+				<div class="footer-rights-container">
+					<p>2025 © All rights reserved.</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</footer>
+
+
+    
+    
+    <style>
+    .ai-summary { 
+		max-width: 1594px;
+		padding: 15px 160px 45px;
+		margin: auto;
+		border-radius: 15px;
+		overflow: hidden; 
+	}
+    .ai-summary-title { 
+		display: flex;
+		padding: 10px 15px;
+		font-weight: 700;
+		color: #fff;
+		background: linear-gradient(to right, #9900fd 0%, #00fe9a 100%);
+		justify-content: center;
+		align-items: center;
+		gap: 15px;
+		text-align: center;
+	}
+    .ai-summary-title > img{ 
+		width: 5%; 
+	}
+    .ai-summary-content { 
+		overflow:hidden; 
+		transition:max-height 0.4s ease, opacity 0.4s ease;
+        background:#f5f5f5; 
+		opacity:0.85; 
+		padding:15px 20px; 
+	}
+    .ai-summary-content.collapsed { 
+		max-height:0; 
+		padding-top:0; 
+		padding-bottom:0; 
+		opacity:0; 
+	}
+    .ai-summary-content ul { 
+		margin: 0;
+		padding-left: 20px;
+		line-height: 1.9;
+		color: #000;
+		list-style: square; 
+	}
+    .ai-summary-disclaimer { 
+		margin-top:15px; 
+		font-size:.85em; 
+		opacity:.7; 
+		font-style:italic;
+        border-top:1px solid #ddd; 
+		padding-top:10px; 
+		color:black; 
+	}
+    .politisgroup-toggle-icon {
+		cursor: pointer; 
+		transition: transform 0.3s ease; 
+		margin-left: auto;
+	}
+    .ai-summary-text{
+		width:100%;
+	}
+	.ai-summary-text {
+		font-size: 22px;
+    	font-weight: 400;
+	}
+	.ai-summary-content ::marker {
+		  color: #9900fd;
+		}
+		
+	@media only screen and (max-width: 1500px){ 
+		.ai-summary {
+			padding: 5px 80px 30px;
+		}
+	}
+		
+	@media only screen and (max-width: 1279px){ 
+		.ai-summary {
+			padding: 5px 20px 30px;
+		}
+		
+		.ai-summary-title > img {
+				width: 10%;
+		}
+	}
+		
+	@media only screen and (max-width: 550px){ 
+		.ai-summary-title > img {
+				width: 15%;
+		}
+		
+		.ai-summary-text {
+			font-size: 18px;
+			font-weight: 400;
+		}
+	}
+    </style>
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<iframe name="googlefcPresent" style="display: none; width: 0px; height: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; z-index: -1000; left: -1000px; top: -1000px;"></iframe><iframe scrolling="no" frameborder="0" allowtransparency="true" src="https://platform.twitter.com/widgets/widget_iframe.1227a5674072e080ffb1ba14ac0c1079.html?origin=https%3A%2F%2Fwww.rosa.gr" title="Twitter settings iframe" style="display: none;"></iframe><iframe name="__tcfapiLocator" src="about:blank" style="display: none; width: 0px; height: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; z-index: -1000; left: -1000px; top: -1000px;"></iframe><iframe name="googlefcInactive" src="about:blank" style="display: none; width: 0px; height: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; z-index: -1000; left: -1000px; top: -1000px;"></iframe><iframe name="googlefcLoaded" src="about:blank" style="display: none; width: 0px; height: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; z-index: -1000; left: -1000px; top: -1000px;"></iframe><iframe id="rufous-sandbox" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="true" style="position: absolute; visibility: hidden; display: none; width: 0px; height: 0px; padding: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial;" title="Twitter analytics iframe"></iframe><iframe marginwidth="0" marginheight="0" scrolling="no" frameborder="0" id="1fabb9b00715178" width="0" height="0" src="about:blank" name="__pb_locator__" style="display: none; height: 0px; width: 0px; border: 0px;"></iframe><iframe allow="autoplay; attribution-reporting 'src' https://cm.teads.tv" scrolling="no" title="user-sync" frameborder="0" id="teadsusersync" src="https://sync.teads.tv/iframe?pid=230615&amp;gdprIab=%7B%22type%22%3A%22AddEventListenerDoesNotApply%22%2C%22reason%22%3A0%2C%22status%22%3A0%2C%22consent%22%3A%22%22%2C%22apiVersion%22%3A2%2C%22cmpId%22%3A300%7D&amp;fromFormat=true&amp;env=js-web&amp;auctid=68792016-3a56-462d-b156-00b1802fcd08&amp;vid=00000000-0000-0000-0000-000000000001&amp;1781650006794=" style="margin: 0px !important; padding: 0px !important; width: 0px !important; height: 0px !important; border: 0px !important; overflow: hidden !important; float: none !important; display: none;"></iframe><iframe id="AVLoaderaniplayer_AV66e1b44aa1ea2754bd0ad787-1781650007263" allow="autoplay" src="about:blank" style="display: none;"></iframe><iframe src="https://www.google.com/recaptcha/api2/aframe" width="0" height="0" style="display: none;"></iframe><iframe marginwidth="0" marginheight="0" scrolling="no" frameborder="0" id="4f36b5bccb4bd28" width="0" height="0" src="about:blank" srcdoc="
+            &lt;script&gt;(()=&gt;{&quot;use strict&quot;;const e=&quot;Prebid Event&quot;,n=&quot;browserIntervention&quot;;window.render=function(t,r,i){let{ad:o,adUrl:l,width:s,height:d,instl:c}=t,{mkFrame:a,sendMessage:h}=r;if(function(){const t=window;if(&quot;ReportingObserver&quot;in t)try{new t.ReportingObserver(t=&gt;{var r;r=t[0],h(e,{event:n,intervention:r})},{buffered:!0,types:[&quot;intervention&quot;]}).observe()}catch(e){}}(),!o&amp;&amp;!l){const e=new Error(&quot;Missing ad markup or URL&quot;);throw e.reason=&quot;noAd&quot;,e}{if(null==d){var v;const e=null===(v=i.document)||void 0===v?void 0:v.body;[e,null==e?void 0:e.parentElement].filter(e=&gt;null!=(null==e?void 0:e.style)).forEach(e=&gt;{e.style.height=&quot;100%&quot;})}const e=i.document,n={width:null!=s?s:&quot;100%&quot;,height:null!=d?d:&quot;100%&quot;};if(l&amp;&amp;!o?n.src=l:n.srcdoc=o,e.body.appendChild(a(e,n)),c&amp;&amp;i.frameElement){const e=i.frameElement.style;e.width=s?&quot;&quot;.concat(s,&quot;px&quot;):&quot;100vw&quot;,e.height=d?&quot;&quot;.concat(d,&quot;px&quot;):&quot;100vh&quot;}}}})();&lt;/script&gt;
+            &lt;script&gt;
+              window.parent.postMessage(
+                  { type: 'RENDERER_READY_2732cbaa75b3218' },
+                  '*'
+            );&lt;/script&gt;" style="display: none; height: 0px; width: 0px; border: 0px;"></iframe><div id="onesignal-slidedown-container" class="onesignal-slidedown-container onesignal-reset slide-down"><div id="onesignal-slidedown-dialog" class="onesignal-slidedown-dialog"><div id="normal-slidedown"><div class="slidedown-body" id="slidedown-body"><div class="slidedown-body-icon"><img alt="notification icon" src="https://www.rosa.gr/wp-content/uploads/2024/09/fav-icon-300x300.png"></div><div class="slidedown-body-message">Θέλετε να λαμβάνετε ενημερώσεις απο το Rosa.gr;</div><div class="clearfix"></div><div id="onesignal-loading-container"></div></div><div class="slidedown-footer" id="slidedown-footer"><button class="align-right primary slidedown-button" id="onesignal-slidedown-allow-button">ΝΑΙ ΘΕΛΩ</button><button class="align-right secondary slidedown-button" id="onesignal-slidedown-cancel-button">ΙΣΩΣ ΑΡΓΟΤΕΡΑ</button><div class="clearfix"></div></div></div></div></div></body><iframe id="goog_plcm_frame" src="https://cm.g.doubleclick.net/partnerpixels?gdpr=0&amp;url=https%3A%2F%2Fwww.rosa.gr%2Fkosmos%2Fi-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis%2F" style="display: none;"></iframe><iframe sandbox="allow-scripts allow-same-origin" id="5915ed69e674af8" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://onetag-sys.com/usync/?cb=1781650007747&amp;gdpr=0">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="6a7cda2173e36d" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ms-cookie-sync.presage.io/user-sync.html?gdpr_consent=&amp;source=prebid&amp;gpp=&amp;gpp_sid=&amp;us_privacy=">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="73493c44465f9d8" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://sync.connectad.io/iFrameSyncer?">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="8cca0b180e9b198" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://acdn.adnxs.com/dmp/async_usersync.html">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="992378145a52f98" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://gum.criteo.com/syncframe?origin=criteoPrebidAdapter&amp;topUrl=www.rosa.gr&amp;gpp=#{%22bundle%22:%22RDycu19Rd2NVb25jd2JJd1hHTHk1akpkRnIlMkZpSTdYRENzOUxTenJMRkxuMmZvWGd0amwxaFZYbEd4R0RwZXpFYjZOS1Qwa2RnaVllcEE0WFFWZzJ1QllRWkRDZmJTeVFzUVJCblJzJTJCYXlLayUyRmhQT1oxeEVrZjdoV1d0dnFwS3FMckVYbGFhb2ZPeVdFcFVFdzBiaTRQMkM0eGclM0QlM0Q%22,%22cw%22:true,%22lsw%22:true,%22origin%22:%22criteoPrebidAdapter%22,%22requestId%22:%220.48002687125489685%22,%22tld%22:%22www.rosa.gr%22,%22topUrl%22:%22www.rosa.gr%22,%22version%22:%2211_11_0%22}">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="106ab5acb1c073e8" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=3172&amp;gdpr=0&amp;">
+    </iframe></html>

--- a/src/extractors/custom/index.js
+++ b/src/extractors/custom/index.js
@@ -204,3 +204,4 @@ export * from './www.nexojornal.com.br';
 export * from './substack.com';
 export * from './www.dw.com';
 export * from './www.animenewsnetwork.com';
+export * from './www.rosa.gr';

--- a/src/extractors/custom/www.rosa.gr/index.js
+++ b/src/extractors/custom/www.rosa.gr/index.js
@@ -28,7 +28,9 @@ export const WwwRosaGrExtractor = {
 
     // The article body is .post-text; the social-follow icons live in a
     // sibling block (.follow-google-news) and are excluded by the selector.
-    // <picture> here is a subscription promo banner, not article imagery.
-    clean: ['picture'],
+    // Within .post-text, strip the inline "read also" related-article widget
+    // (.short-read-also, whose thumbnail links elsewhere), the subscription
+    // promo banner (.widget-article), and ad slots.
+    clean: ['.short-read-also', '.widget-article', '.ad-placement'],
   },
 };

--- a/src/extractors/custom/www.rosa.gr/index.js
+++ b/src/extractors/custom/www.rosa.gr/index.js
@@ -28,7 +28,11 @@ export const WwwRosaGrExtractor = {
     // block (.follow-google-news) and are excluded.
     selectors: [['.top-row .post-image', '.post-text']],
 
-    transforms: {},
+    transforms: {
+      // Preserve genuine section headings (the read-also widget's heading is
+      // already removed by the clean step below, which runs first).
+      h2: node => node.attr('class', 'mercury-parser-keep'),
+    },
 
     // Within .post-text, strip the inline "read also" related-article widget
     // (.short-read-also, whose thumbnail links elsewhere), the subscription

--- a/src/extractors/custom/www.rosa.gr/index.js
+++ b/src/extractors/custom/www.rosa.gr/index.js
@@ -1,0 +1,34 @@
+export const WwwRosaGrExtractor = {
+  domain: 'www.rosa.gr',
+
+  title: {
+    selectors: [['meta[name="og:title"]', 'value']],
+  },
+
+  author: {
+    selectors: [['meta[name="author"]', 'value']],
+  },
+
+  date_published: {
+    selectors: [['meta[name="article:published_time"]', 'value']],
+  },
+
+  dek: {
+    selectors: [['meta[name="og:description"]', 'value']],
+  },
+
+  lead_image_url: {
+    selectors: [['meta[name="og:image"]', 'value']],
+  },
+
+  content: {
+    selectors: ['.post-text'],
+
+    transforms: {},
+
+    // The article body is .post-text; the social-follow icons live in a
+    // sibling block (.follow-google-news) and are excluded by the selector.
+    // <picture> here is a subscription promo banner, not article imagery.
+    clean: ['picture'],
+  },
+};

--- a/src/extractors/custom/www.rosa.gr/index.js
+++ b/src/extractors/custom/www.rosa.gr/index.js
@@ -22,12 +22,14 @@ export const WwwRosaGrExtractor = {
   },
 
   content: {
-    selectors: ['.post-text'],
+    // Combine the article's hero image (.top-row .post-image, which lives in
+    // the header outside the body) with the body text (.post-text) so the
+    // photo renders inline. The social-follow icons sit in a separate sibling
+    // block (.follow-google-news) and are excluded.
+    selectors: [['.top-row .post-image', '.post-text']],
 
     transforms: {},
 
-    // The article body is .post-text; the social-follow icons live in a
-    // sibling block (.follow-google-news) and are excluded by the selector.
     // Within .post-text, strip the inline "read also" related-article widget
     // (.short-read-also, whose thumbnail links elsewhere), the subscription
     // promo banner (.widget-article), and ad slots.

--- a/src/extractors/custom/www.rosa.gr/index.test.js
+++ b/src/extractors/custom/www.rosa.gr/index.test.js
@@ -85,5 +85,23 @@ describe('WwwRosaGrExtractor', () => {
         'expected related-article, promo, ad, and social widgets to be removed'
       );
     });
+
+    it('retains genuine section headings', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+      const headings = $('h2')
+        .toArray()
+        .map(h => $(h).text().trim());
+
+      assert.ok(
+        headings.includes('Η σκληρή πραγματικότητα της εκεχειρίας'),
+        'expected the article section heading to be kept'
+      );
+      assert.ok(
+        !headings.includes('ΔΙΑΒΑΣΤΕ ΕΠΙΣΗΣ'),
+        'expected the read-also widget heading to be dropped'
+      );
+    });
   });
 });

--- a/src/extractors/custom/www.rosa.gr/index.test.js
+++ b/src/extractors/custom/www.rosa.gr/index.test.js
@@ -62,16 +62,21 @@ describe('WwwRosaGrExtractor', () => {
 
       assert.strictEqual(
         first13,
-        'Μια νέα, εξαιρετικά κρίσιμη σελίδα ανοίγει για τη Μέση Ανατολή μετά την επίσημη'
+        'ΑΠΕ-ΜΠΕ/EPA Μια νέα, εξαιρετικά κρίσιμη σελίδα ανοίγει για τη Μέση Ανατολή μετά την'
       );
     });
 
-    it('drops related-article, promo, ad, and social widgets', async () => {
+    it('includes the hero image and drops the related/promo/ad/social widgets', async () => {
       const { content } = await result;
 
       const $ = cheerio.load(content || '');
 
       assert.ok($('p').length > 0, 'expected article paragraphs');
+      assert.strictEqual(
+        $('img[src*="livanos_irsrail"]').length,
+        1,
+        'expected the hero article image to be included'
+      );
       assert.strictEqual(
         $(
           '.short-read-also, .post-list, .widget-article, .ad-placement, .follow-link'

--- a/src/extractors/custom/www.rosa.gr/index.test.js
+++ b/src/extractors/custom/www.rosa.gr/index.test.js
@@ -66,16 +66,18 @@ describe('WwwRosaGrExtractor', () => {
       );
     });
 
-    it('keeps article images and drops the social-follow icons', async () => {
+    it('drops related-article, promo, ad, and social widgets', async () => {
       const { content } = await result;
 
       const $ = cheerio.load(content || '');
 
-      assert.ok($('img').length > 0, 'expected the article image to remain');
+      assert.ok($('p').length > 0, 'expected article paragraphs');
       assert.strictEqual(
-        $('img[src*="/assets/images/facebook"], .follow-link').length,
+        $(
+          '.short-read-also, .post-list, .widget-article, .ad-placement, .follow-link'
+        ).length,
         0,
-        'expected social-follow icons to be excluded'
+        'expected related-article, promo, ad, and social widgets to be removed'
       );
     });
   });

--- a/src/extractors/custom/www.rosa.gr/index.test.js
+++ b/src/extractors/custom/www.rosa.gr/index.test.js
@@ -1,0 +1,82 @@
+import assert from 'assert';
+import * as cheerio from 'cheerio';
+
+import Parser from 'mercury';
+import getExtractor from 'extractors/get-extractor';
+import { excerptContent } from 'utils/text';
+
+const fs = require('fs');
+
+describe('WwwRosaGrExtractor', () => {
+  describe('initial test case', () => {
+    let result;
+    let url;
+    beforeAll(() => {
+      url =
+        'https://www.rosa.gr/kosmos/i-epomeni-mera-ston-livano-to-kyma-epistrofis-ton-ektopismenon-kai-i-varia-skia-tis-katastrofis/';
+      const html = fs.readFileSync('./fixtures/www.rosa.gr/1781600000000.html');
+      result = Parser.parse(url, { html, fallback: false });
+    });
+
+    it('is selected properly', () => {
+      const extractor = getExtractor(url);
+      assert.strictEqual(extractor.domain, new URL(url).hostname);
+    });
+
+    it('returns the title', async () => {
+      const { title } = await result;
+
+      assert.strictEqual(
+        title,
+        'Η επόμενη μέρα στον Λίβανο: Το κύμα επιστροφής των εκτοπισμένων και η βαριά σκιά της καταστροφής'
+      );
+    });
+
+    it('returns the author', async () => {
+      const { author } = await result;
+
+      assert.strictEqual(author, 'Χρήστος Τζίφας');
+    });
+
+    it('returns the date_published', async () => {
+      const { date_published } = await result;
+
+      assert.strictEqual(date_published, '2026-06-16T20:17:00.000Z');
+    });
+
+    it('returns the lead_image_url', async () => {
+      const { lead_image_url } = await result;
+
+      assert.strictEqual(
+        lead_image_url,
+        'https://www.rosa.gr/wp-content/uploads/2026/04/livanos_irsrail.jpg'
+      );
+    });
+
+    it('returns the content', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      const first13 = excerptContent($('*').first().text(), 13);
+
+      assert.strictEqual(
+        first13,
+        'Μια νέα, εξαιρετικά κρίσιμη σελίδα ανοίγει για τη Μέση Ανατολή μετά την επίσημη'
+      );
+    });
+
+    it('keeps article images and drops the social-follow icons', async () => {
+      const { content } = await result;
+
+      const $ = cheerio.load(content || '');
+
+      assert.ok($('img').length > 0, 'expected the article image to remain');
+      assert.strictEqual(
+        $('img[src*="/assets/images/facebook"], .follow-link').length,
+        0,
+        'expected social-follow icons to be excluded'
+      );
+    });
+  });
+});

--- a/src/extractors/custom/www.rosa.gr/index.test.js
+++ b/src/extractors/custom/www.rosa.gr/index.test.js
@@ -86,7 +86,7 @@ describe('WwwRosaGrExtractor', () => {
       );
     });
 
-    it('retains genuine section headings', async () => {
+    it('retains section headings', async () => {
       const { content } = await result;
 
       const $ = cheerio.load(content || '');


### PR DESCRIPTION
Adds a custom parser for Rosa.gr, requested in jocmp/capyreader#2147 ("images missing, social icons poorly displayed").

**Cloudflare note:** rosa.gr sits behind Cloudflare's JS challenge, so server-side fetches (curl, Mercury's `fetchResource`, CI) get a 403 — the generator can't run against it. The fixture was captured from a real browser session (which clears the challenge), and the parser is verified against that fixture. This parser only helps if capyreader's own fetch path can retrieve the page (the reporter sees the article with broken images, so it can).

**Root cause:** generic extraction pulled in Rosa's social-follow block and a subscription `<picture>` banner while the real article image got lost. This parser:
- Title/dek/lead image/author/date from meta tags (date carries an explicit `+00:00` offset → TZ-stable)
- Content from `.post-text` — the real article body; the `.follow-google-news` social icons live in a sibling block and are excluded, and the promo `<picture>` is cleaned

7/7 parser tests pass (including assertions that the article image stays and social-follow icons are gone).